### PR TITLE
CB-6655 Export plugin ID to hooks when adding plugins from Git repos

### DIFF
--- a/cordova-lib/src/plugman/util/plugins.js
+++ b/cordova-lib/src/plugman/util/plugins.js
@@ -93,6 +93,7 @@ module.exports = {
             shell.cp('-R', path.join(tmp_dir, '*'), plugin_dir);
 
             events.emit('verbose', 'Plugin "' + plugin_id + '" fetched.');
+            process.env.CORDOVA_PLUGIN_ID = plugin_id;
             return plugin_dir;
         });
     }


### PR DESCRIPTION
Update plugins.js to set CORDOVA_PLUGIN_ID environment variable.
