### PR TITLE
CB-6469 - Restore plugins from config.xml

### DIFF
--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -80,5 +80,20 @@ describe('config.xml parser', function () {
                 expect(cfg.getPreference('zimzooo!')).toEqual(undefined);
             });
         });
+        describe('feature',function(){
+            it('should allow adding a new feature', function(){
+                cfg.addFeature('myfeature');
+                var features = cfg.doc.findall('feature');
+                expect(features[0].attrib.name).toEqual('myfeature');
+            });
+            it('should allow adding features with params', function(){
+                cfg.addFeature('afeature', JSON.parse('[{"name":"paraname", "value":"paravalue"}]'));
+                var features = cfg.doc.findall('feature');
+                expect(features[0].attrib.name).toEqual('afeature');
+                var params = features[0].findall('param');
+                expect(params[0].attrib.name).toEqual('paraname');
+                expect(params[0].attrib.value).toEqual('paravalue');
+            });
+        });
     });
 });

--- a/cordova-lib/spec-cordova/restore.spec.js
+++ b/cordova-lib/spec-cordova/restore.spec.js
@@ -1,0 +1,69 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var project_dir = path.join(__dirname, 'fixtures', 'base');
+
+var cordova = require('../src/cordova/cordova'),
+    cordova_util = require('../src/cordova/util'),
+    ConfigParser = require('../src/cordova/ConfigParser');
+
+describe('restore command', function(){
+  var is_cordova, result, config_add_feature, cd_project;
+
+   function wrapper(f, post) {
+        runs(function() {
+            Q().then(f).then(function() { result = true; }, function(err) { result = err; });
+        });
+        waitsFor(function() { return result; }, 'promise never resolved', 500);
+        runs(post);
+    }
+
+  beforeEach(function(){
+    is_cordova = spyOn(cordova_util, 'isCordova').andReturn(project_dir);
+   
+  });
+
+  it('should not run outside of a Cordova-based project by calling util.isCordova', function() {
+     is_cordova.andReturn(false);
+     wrapper(cordova.raw.restore, function() {
+        expect(result).toEqual(new Error('Current working directory is not a Cordova-based project.'));
+     });
+  });
+
+  it('should not try to restore featrues from config.xml', function(){
+ 
+ 
+   cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
+ 
+    var call_count =0;
+    ConfigParser.prototype.write = function(){
+      call_count++;
+    }
+
+     expect(call_count).toEqual(0);
+     
+     cordova.restore('plugins');
+
+     expect(call_count).toEqual(0);
+  });
+
+
+
+
+});

--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -1,0 +1,63 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var project_dir = path.join(__dirname, 'fixtures', 'base');
+
+var cordova = require('../src/cordova/cordova'),
+    cordova_util = require('../src/cordova/util'),
+    ConfigParser = require('../src/cordova/ConfigParser');
+
+describe('save command', function(){
+  var is_cordova, result, config_add_feature, cd_project;
+
+   function wrapper(f, post) {
+        runs(function() {
+            Q().then(f).then(function() { result = true; }, function(err) { result = err; });
+        });
+        waitsFor(function() { return result; }, 'promise never resolved', 500);
+        runs(post);
+    }
+
+  beforeEach(function(){
+    is_cordova = spyOn(cordova_util, 'isCordova').andReturn(project_dir);
+   
+  });
+
+  it('should not run outside of a Cordova-based project by calling util.isCordova', function() {
+     is_cordova.andReturn(false);
+     wrapper(cordova.raw.save, function() {
+        expect(result).toEqual(new Error('Current working directory is not a Cordova-based project.'));
+     });
+  });
+
+  it('should not try to add features to config.xml', function(){
+   cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
+    var call_count =0;
+    ConfigParser.prototype.write = function(){
+      call_count++;
+    }
+    expect(call_count).toEqual(0);
+    cordova.save('plugins');
+    expect(call_count).toEqual(0);
+  });
+
+
+
+
+});

--- a/cordova-lib/src/cordova/ConfigParser.js
+++ b/cordova-lib/src/cordova/ConfigParser.js
@@ -155,6 +155,22 @@ ConfigParser.prototype = {
 
         return ret;
     },
+    /**
+     *This does not check for duplicate feature entries
+     */
+    addFeature: function (name, params){ 
+      var el = new et.Element('feature');
+        el.attrib.name = name;
+        if(params){
+          params.forEach(function(param){
+            var p = new et.Element('param');
+            p.attrib.name = param.name;
+            p.attrib.value = param.value;
+            el.append(p);
+          });
+        }
+        this.doc.getroot().append(el);
+    },    
     write:function() {
         fs.writeFileSync(this.path, this.doc.write({indent: 4}), 'utf-8');
     }

--- a/cordova-lib/src/cordova/cordova.js
+++ b/cordova-lib/src/cordova/cordova.js
@@ -64,5 +64,7 @@ addModuleProperty(module, 'platforms', './platform', true);
 addModuleProperty(module, 'compile', './compile', true);
 addModuleProperty(module, 'run', './run', true);
 addModuleProperty(module, 'info', './info', true);
+addModuleProperty(module, 'save', './save', true);
+addModuleProperty(module, 'restore', './restore', true);
 
 

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -26,6 +26,8 @@ var cordova_util  = require('./util'),
     config        = require('./config'),
     Q             = require('q'),
     CordovaError  = require('../CordovaError'),
+    ConfigParser  = require('./ConfigParser'),
+    fs            = require('fs'),
     PluginInfo    = require('../PluginInfo'),
     events        = require('./events');
 
@@ -173,6 +175,15 @@ module.exports = function plugin(command, targets, opts) {
                             var platformRoot = path.join(projectRoot, 'platforms', platform);
                             var platforms = require('./platforms');
                             var parser = new platforms[platform].parser(platformRoot);
+                            //check if plugin is restorable and warn
+                            var configPath = cordova_util.projectConfig(projectRoot);
+                            if(fs.existsSync(configPath)){//should not happen with real life but needed for tests
+                                var configXml = new ConfigParser(configPath);
+                                var features = configXml.doc.findall('./feature/param[@name="id"][@value="'+target+'"]/..');
+                                if(features && features.length){
+                                    events.emit('results','"'+target + '" plugin is restorable, call "cordova save plugins" to remove it from restorable plugins list');
+                                }
+                            }                            
                             events.emit('verbose', 'Calling plugman.uninstall on plugin "' + target + '" for platform "' + platform + '"');
                             return plugman.raw.uninstall.uninstallPlatform(platform, platformRoot, target, path.join(projectRoot, 'plugins'));
                         });

--- a/cordova-lib/src/cordova/restore.js
+++ b/cordova-lib/src/cordova/restore.js
@@ -1,0 +1,76 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var cordova_util    = require('./util'),
+    ConfigParser     = require('./ConfigParser'),
+    path             = require('path'),
+    xml              = require('../util/xml-helpers')
+    Q                = require('q'),
+    fs               = require('fs'),
+    plugin           = require('./plugin'),
+    events           = require('./events');
+
+module.exports = function restore(target){
+    var projectHome = cordova_util.cdProjectRoot();
+    var configPath = cordova_util.projectConfig(projectHome);
+    var configXml = new ConfigParser(configPath);    
+    return installPluginsFromConfigXML(configXml);
+}
+
+
+//returns a Promise
+function installPluginsFromConfigXML(cfg){
+        //Install plugins that are listed on config.xml
+        var pluginsFromConfig = new Array();
+        var projectRoot = cordova_util.cdProjectRoot();
+        var plugins_dir = path.join(projectRoot, 'plugins');
+
+        var features = cfg.doc.findall('feature');
+        features.forEach(function(feature){
+          var params = feature.findall('param');
+          var pluginId = "";
+          var pluginVersion = "";
+          for( var i =0; i < params.length; i++){
+            if(params[i].attrib.name === 'id'){
+              pluginId = params[i].attrib.value;
+            }
+            if(params[i].attrib.name === 'version'){
+              pluginVersion = params[i].attrib.value;
+            }
+          } 
+          var pluginPath =  path.join(plugins_dir,pluginId);
+          // contents of the plugins folder takes precedence hence
+          // we ignore if the correct version is installed or not.
+          if(pluginId !== "" && !fs.existsSync(pluginPath)){
+            if( pluginVersion !== ""){
+              pluginId = pluginId +"@"+pluginVersion;
+            }
+            events.emit('log', "Discovered "+ pluginId + " in config.xml. Installing to the project")
+            pluginsFromConfig.push(pluginId);
+          }
+
+        })
+        
+        //Use cli instead of plugman directly ensuring all the hooks 
+        // to get fired.  
+        if(pluginsFromConfig.length >0){
+            return plugin("add",pluginsFromConfig);
+        }
+        return Q.all("No config.xml plugins to install");
+}

--- a/cordova-lib/src/cordova/save.js
+++ b/cordova-lib/src/cordova/save.js
@@ -1,0 +1,83 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var cordova_util    = require('./util'),
+    ConfigParser     = require('./ConfigParser'),
+    path             = require('path'),
+    xml              = require('../util/xml-helpers')
+    Q                = require('q'),
+    events           = require('./events');
+
+module.exports = function save(target, opts){
+  opts = opts || {};
+  var projectHome = cordova_util.cdProjectRoot();
+  var configPath = cordova_util.projectConfig(projectHome);
+  var configXml = new ConfigParser(configPath);
+  var pluginsPath = path.join(projectHome, 'plugins');
+  var plugins = cordova_util.findPlugins(pluginsPath);
+  var features = configXml.doc.findall('./feature/param[@name="id"]/..');
+  //clear obsolete features with id params.
+  for(var i=0; i<features.length; i++){
+     //somehow elementtree remove fails on me  
+     var childs = configXml.doc.getroot().getchildren();
+     var idx = childs.indexOf(features[i]);
+     if(idx > -1){
+        childs.splice(idx,1);
+      }
+  }
+  // persist the removed features here if there are no plugins 
+  // to be added to config.xml otherwise we can delay the 
+  // persist to add feature    
+  if((!plugins || plugins.length<1) &&
+        (features && features.length)){
+      configXml.write();
+  }
+
+  return Q.all(plugins.map(function(plugin){
+    var currentPluginPath = path.join(pluginsPath,plugin);
+    var name = readPluginName(currentPluginPath);
+    var id = plugin;
+    var version = readPluginVersion(currentPluginPath);
+    var params = [{name:"id", value:id}];
+    if(opts.shrinkwrap){
+        params.push({name:"version", value: version});
+    }
+    configXml.addFeature(name,params);
+    configXml.write();
+    events.emit('results', 'Saved plugin info for "'+plugin+'" to config.xml');
+    return Q();
+  }));
+}
+
+function readPluginName(pluginPath){
+    var xml_path = path.join(pluginPath, 'plugin.xml');
+    var et = xml.parseElementtreeSync(xml_path);
+    var el = et.getroot().find('name');
+    if(el && el.text){
+       return el.text.trim();
+    }
+    return "";
+}
+
+function readPluginVersion(pluginPath){
+    var xml_path = path.join(pluginPath, 'plugin.xml');
+    var et = xml.parseElementtreeSync(xml_path);
+    var version = et.getroot().attrib.version;
+    return version;
+}


### PR DESCRIPTION
Adds a new save command to CLI which persists the currently added plugins to config.xml. There
is also an accompanying restore command which scans the config.xml and
restores the missing plugins that are listed.  Adds a new function to ConfigParser for adding
features. Updates plugin rm command to print a warning to also remove a
plugin that has been added to config.xml as a restore target.

Adds two new test for the new commands namely restore.spec and save.spec and
enhances the existing ConfigParser.spec for the new addFeature function.
