### PR TITLE
CB-6481 adds plugin level hooks support

### DIFF
--- a/cordova-lib/spec-plugman/plugins/HooksTestPlugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/HooksTestPlugin/plugin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+xmlns:android="http://schemas.android.com/apk/res/android"
+           id="id.plugin"
+      version="0.0.2">
+    <name>The Plugin</name>
+
+    <script type="postinstall" src="scripts/hook.js" />
+    <script type="preinstall" src="scripts/hook.js" />
+    <script type="uninstall" src="scripts/hook.js" />
+    <platform name="ios">
+        <script type="install" src="scripts/hook.js" />
+    </platform>
+</plugin>

--- a/cordova-lib/spec-plugman/plugins/HooksTestPlugin/scripts/hook.js
+++ b/cordova-lib/spec-plugman/plugins/HooksTestPlugin/scripts/hook.js
@@ -1,0 +1,11 @@
+var Q = require('q');
+
+module.exports = function(context) {
+    var deferral = new Q.defer();
+
+    setTimeout(function(){
+        deferral.resolve();
+    }, 0);
+
+    return deferral.promise;
+}

--- a/cordova-lib/spec-plugman/util/hooks.spec.js
+++ b/cordova-lib/spec-plugman/util/hooks.spec.js
@@ -1,0 +1,66 @@
+var hooks  = require('../../src/plugman/util/hooks'),
+    path = require('path'),
+    et = require('elementtree'),
+    xml_helpers = require('../../src/util/xml-helpers');
+
+var pluginId = 'id.sample.plugin',
+    platform = 'ios',
+    project_dir = path.join(__dirname, '..'),
+    plugin_dir = path.join(project_dir, 'plugins', 'HooksTestPlugin'),
+    samplePluginPath = path.join(plugin_dir, 'plugin.xml'),
+    samplePluginXml = xml_helpers.parseElementtreeSync(samplePluginPath),
+    hookFile = path.join(samplePluginPath, 'scripts/hook');
+
+
+describe('plugin hooks', function() {
+
+    it('fire method should exist', function() {
+            expect(hooks.fire).toBeDefined();
+    });
+
+    it('should throw if passed in an invalid hook event', function() {
+        expect(function() {
+            hooks.fire('blahblah', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+        }).toThrow();
+    });
+    it('should support beforeinstall/afterinstall/uninstall hook types', function() {
+        expect(function() {
+            hooks.fire('beforeinstall', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+            hooks.fire('afterinstall', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+            hooks.fire('uninstall', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+        }).not.toThrow();
+    });
+    it('should return promise', function() {
+        var res = hooks.fire('beforeinstall', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+        expect(typeof res).toEqual('object');
+    });
+    it('should correctly execute runScriptFile method', function() {
+        var runScriptFile = spyOn(hooks, 'runScriptFile').andCallThrough();
+        var promise = hooks.fire('afterinstall', pluginId, samplePluginXml, platform, project_dir, plugin_dir);
+        var done = false;
+
+        promise.then(function(){
+            expect(runScriptFile.calls.length).toBeGreaterThan(0);
+            var args = runScriptFile.mostRecentCall.args;
+            
+            // check args num
+            expect(args.length).toEqual(2);
+
+            // first arg is hook file location
+            expect(args[0]).toEqual('scripts/hook.js');
+
+            // second arg should correctly represent content information
+            var ctx = args[1];
+            expect(ctx.platform).toEqual(platform);
+            expect(ctx.projectDir).toEqual(project_dir);
+            expect(ctx.pluginDir).toEqual(plugin_dir);
+            expect(ctx.pluginId).toEqual(pluginId);
+
+            done = true;
+        }).fail(function(ex){
+            expect("fail callback should not be called: " + ex).not.toBeDefined();
+            done = true;
+        });
+         waitsFor(function() { return done; }, 'promise never resolved', 3000);
+    });
+});

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -15,6 +15,7 @@ var path = require('path'),
     shell   = require('shelljs'),
     events = require('./events'),
     plugman = require('./plugman'),
+    pluginHooks = require('./util/hooks'),
     isWindows = (os.platform().substr(0,3) === 'win');
 
 /* INSTALL FLOW
@@ -304,7 +305,12 @@ var runInstall = module.exports.runInstall = function runInstall(actions, platfo
                 copyPlugin(plugin_dir, plugins_dir, options.link);
             }
 
-            return handleInstall(actions, plugin_id, plugin_et, platform, project_dir, plugins_dir, install_plugin_dir, filtered_variables, options.www_dir, options.is_top_level);
+            pluginHooks.fire('beforeinstall', plugin_id, plugin_et, platform, project_dir, plugin_dir).then(function() {
+                return handleInstall(actions, plugin_id, plugin_et, platform, project_dir, plugins_dir,
+                    install_plugin_dir, filtered_variables, options.www_dir, options.is_top_level);
+            }).then(function(){
+                return pluginHooks.fire('afterinstall', plugin_id, plugin_et, platform, project_dir, plugin_dir);
+            });
         }
     ).fail(
         function (error) {

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -14,7 +14,8 @@ var path = require('path'),
     underscore = require('underscore'),
     events = require('./events'),
     platform_modules = require('./platforms'),
-    plugman = require('./plugman');
+    plugman = require('./plugman'),
+    pluginHooks = require('./util/hooks');
 
 // possible options: cli_variables, www_dir
 // Returns a promise.
@@ -211,7 +212,9 @@ function runUninstallPlatform(actions, platform, project_dir, plugin_dir, plugin
     }
 
     return promise.then(function() {
-        return handleUninstall(actions, platform, plugin_id, plugin_et, project_dir, options.www_dir, plugins_dir, plugin_dir, options.is_top_level);
+        return handleUninstall(actions, platform, plugin_id, plugin_et, project_dir, options.www_dir, plugins_dir, plugin_dir, options.is_top_level)
+    }).then(function(){
+        return pluginHooks.fire('uninstall', plugin_id, plugin_et, platform, project_dir, plugin_dir);
     });
 }
 

--- a/cordova-lib/src/plugman/util/hooks.js
+++ b/cordova-lib/src/plugman/util/hooks.js
@@ -1,0 +1,140 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var path = require('path'),
+    fs   = require('fs'),
+    child_process = require('child_process'),
+    Q = require('q'),
+    events = require('../events'),
+    os = require('os'),
+    isWindows = (os.platform().substr(0,3) === 'win');
+
+/**
+ * Implements functionality to run plugin level hooks. 
+ * Hooks are defined in plugin config file as <script> elements.
+ */
+module.exports = {
+    /**
+     * Fires specific plugin hook: 'preinstall', 'afterinstall', 'uninstall', etc.
+     * Async. Returns promise.
+     */
+    fire: function(type, plugin_id, pluginElement, platform, project_dir, plugin_dir) {
+        // args check
+        if (!type) {
+            throw Error('hook type is not specified');
+        }
+
+        events.emit('debug', 'Executing "' + type + '"  hook for "' + plugin_id + '" on ' + platform + '.');
+        
+        var scriptTypes = this.getScriptTypesForHook(type);
+        if (!scriptTypes) {
+            throw Error('unknown plugin hook type: "' + type + '"' );
+        }
+
+        var scriptFilesToRun = this.getScriptFiles(pluginElement, scriptTypes, platform);
+        var context = {
+                platform: platform,
+                projectDir: project_dir,
+                pluginDir: plugin_dir,
+                cmdLine: process.argv.join(' '),
+                pluginId: plugin_id
+            };
+
+        return this.runScripts(scriptFilesToRun, context);
+    },
+
+    /**
+     * Returns all script types represented corresponding hook event.
+     * Allows to use multiple script types for the same hook event (usage simplicity),
+     * For example: 
+     * <script type='install' .. /> or <script type='postinstall' .. /> could be used 
+     * to define 'afterinstall' hook.
+     */
+    getScriptTypesForHook: function(hookType) {
+        var knownTypes = {
+            beforeinstall: ['beforeinstall', 'preinstall'],
+            afterinstall: ['install', 'afterinstall', 'postinstall'],
+            uninstall: ['uninstall']
+        }
+
+         return knownTypes[hookType.toLowerCase()];
+    },
+
+    /**
+     * Gets all scripts from the plugin xml with the specified types.
+     */
+    getScriptFiles: function(pluginElement, scriptTypes, platform) {
+        var scriptElements =  pluginElement.findall('./script').concat(
+                pluginElement.findall('./platform[@name="' + platform + '"]/script'));
+
+        return scriptElements.filter(function(el) {
+            return el.attrib.src && el.attrib.type && scriptTypes.indexOf(el.attrib.type.toLowerCase()) > -1;
+        }).map(function(el) {
+            return el.attrib.src;
+        });
+    },
+
+    /**
+     * Serially runs the script files.
+     */
+    runScripts: function(scripts, context) {
+        var pendingScripts = scripts.slice(),
+            me = this;
+
+        var deferral = new Q.defer();
+
+        function executePendingScript() {
+            try {
+                if (pendingScripts.length == 0) {
+                    deferral.resolve();
+                    return;
+                }
+                var nextScript = pendingScripts[0];
+                pendingScripts.shift();
+
+                me.runScriptFile(nextScript, context).then(executePendingScript, function(err){
+                    deferral.reject(err);
+                });
+            } catch (ex) {
+                deferral.reject(ex);
+            }
+        }
+
+        executePendingScript();
+
+        return deferral.promise;
+    },
+
+    /**
+     * Async runs single script file.
+     */
+    runScriptFile: function(scriptPath, context) {
+
+        scriptPath = path.join(context.pluginDir, scriptPath);
+
+        if(!fs.existsSync(scriptPath)) {
+            events.emit('warn', "Script file does't exist and will be skipped: " + scriptPath);
+            return Q();
+        }
+        var scriptFn = require(scriptPath);
+
+        // if hook is async it can return promise instance and we will handle it
+        return Q(scriptFn(context));
+    }
+};


### PR DESCRIPTION
1.Support of **js hook files** (nodejs is used to run script file)

2.Support of the following **hook types**
-  beforeinstall/preinstall – run before plugin is installed
-  install/postinstall/afterinstall – run after plugin is installed
-  uninstall – run after plugin is uninstalled
  
  ```
  <script type="postinstall" src="scripts/postinstall.js" />
  <script type="preinstall" src="scripts/preinstall.js" />
  <script type="install" src="scripts/install.js" />
  ```

3.Use **context** argument to retrieve execution parameters **inside hook function**

```
module.exports = function(context) {
    console.log('hook.js>> platform: ' + context.platform);
    console.log('hook.js>> projectDir: ' + context.projectDir);
    console.log('hook.js>> pluginDir: ' + context.pluginDir);
    console.log('hook.js>> cmdLine: ' + context.cmdLine);

    var deferral = new Q.defer();

    setTimeout(function(){
        deferral.resolve();
    }, 1000);

    return deferral.promise;
}
```
