### PR TITLE
CB-6711: Use parseProjectFile when working with XCode projects.

### DIFF
--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -37,7 +37,6 @@ var fs   = require('fs'),
     glob = require('glob'),
     plist = require('plist-with-patches'),
     bplist = require('bplist-parser'),
-    xcode = require('xcode'),
     et   = require('elementtree'),
     _ = require('underscore'),
     xml_helpers = require('../../util/xml-helpers'),
@@ -510,8 +509,7 @@ function ConfigFile_load() {
         self.data = xml_helpers.parseElementtreeSync(filepath);
     } else if (ext == '.pbxproj') {
         self.type = 'pbxproj';
-        self.data = xcode.project(filepath);
-        self.data.parseSync();
+        self.data = platforms.ios.parseProjectFile(self.project_dir).xcode;
     } else {
         // plist file
         self.type = 'plist';


### PR DESCRIPTION
Otherwise the changes get overwritten by the cached version of the project file.
Add a unit test to guard against similar bugs in the future.
