### PR TITLE
Update properties-parser to version 0.2.3

### DIFF
--- a/cordova-lib/npm-shrinkwrap.json
+++ b/cordova-lib/npm-shrinkwrap.json
@@ -465,8 +465,8 @@
       }
     },
     "properties-parser": {
-      "version": "~0.2.2",
-      "from": "properties-parser@0.2.2"
+      "version": "~0.2.3",
+      "from": "properties-parser@0.2.3"
     },
     "q": {
       "version": "0.9.7",

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -26,7 +26,7 @@
     "npmconf": "0.1.x",
     "osenv": "0.0.x",
     "plist-with-patches": "0.5.x",
-    "properties-parser": "~0.2.2",
+    "properties-parser": "~0.2.3",
     "q": "~0.9",
     "rc": "0.3.0",
     "request": "2.22.0",


### PR DESCRIPTION
Version 0.2.2 had issues with duplicating the whole .properties file contents in some cases.
