### PR TITLE
Update hooks-README.md

### DIFF
--- a/cordova-lib/templates/hooks-README.md
+++ b/cordova-lib/templates/hooks-README.md
@@ -80,7 +80,7 @@ cross-platform. Some good examples are shown here:
 
 [http://devgirl.org/2013/11/12/three-hooks-your-cordovaphonegap-project-needs/](http://devgirl.org/2013/11/12/three-hooks-your-cordovaphonegap-project-needs/)
 
-Also, note that even if you are working on Windows, and in case your hook scripts aren't bat files (which is recomended for use the code in a non-windows operating system) Cordova CLI will expect a shebang line as the first line for it to know the interpreter it needs to use to launch the script, if the script is not a bat file. The shebang line should match the following example:
+Also, note that even if you are working on Windows, and in case your hook scripts aren't bat files (which is recommended, if you want your scripts to work in non-Windows operating systems) Cordova CLI will expect a shebang line as the first line for it to know the interpreter it needs to use to launch the script. The shebang line should match the following example:
 
     #!/usr/bin/env [name_of_interpreter_executable]
 


### PR DESCRIPTION
I think letting know to users of Windows that a shebang line is expected at the start of their non bat scripts is a good idea, since its not typical for Windows users to write shebangs. I found out myself not knowing how to make my python and node.js scripts to work as hooks until I read cordova-lib\src\cordova\hooker.js line 77, function extractSheBangInterpreter.
