### PR TITLE
Fixed windows8 platform build error when www (or one of its sub folders) contains .svn folders.

### DIFF
--- a/cordova-lib/src/cordova/metadata/windows8_parser.js
+++ b/cordova-lib/src/cordova/metadata/windows8_parser.js
@@ -269,10 +269,12 @@ module.exports.prototype = {
             var stat = fs.statSync(path.join(dir, folder_dir[item]));
 
             if(stat.isDirectory()) {
-                var sub_dir = this.folder_contents(path.join(name, folder_dir[item]), path.join(dir, folder_dir[item]));
-                //Add all subfolder item paths
-                for(sub_item in sub_dir) {
-                    results.push(sub_dir[sub_item]);
+                if (folder_dir[item] !== '.svn') {
+                    var sub_dir = this.folder_contents(path.join(name, folder_dir[item]), path.join(dir, folder_dir[item]));
+                    //Add all subfolder item paths
+                    for(sub_item in sub_dir) {
+                        results.push(sub_dir[sub_item]);
+                    }
                 }
             }
             else if(stat.isFile()) {


### PR DESCRIPTION
.svn folders are now ignored when adding file references to the jsproj file (They are already correctly ignored when copying the www folder, so referencing them in the jsproj file breaks the build since the svn files cannot be found in www).
