### PR TITLE
[CB-6140] Don't allow deletion of platform dependencies

### DIFF
--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -116,7 +116,7 @@ module.exports.uninstallPlugin = function(id, plugins_dir, options) {
     // Recursively remove plugins which were installed as dependents (that are not top-level)
     // optional?
     var recursive = true;
-    var toDelete = recursive ? plugin_et.findall('dependency') : [];
+    var toDelete = recursive ? plugin_et.findall('.//dependency') : [];
     toDelete = toDelete && toDelete.length ? toDelete.map(function(p) { return p.attrib.id; }) : [];
     toDelete.push(top_plugin_id);
 

--- a/cordova-lib/src/plugman/util/dependencies.js
+++ b/cordova-lib/src/plugman/util/dependencies.js
@@ -52,7 +52,7 @@ module.exports = package = {
             tlps.push(plugin_id);
 
             var xml = xml_helpers.parseElementtreeSync( package.resolveConfig(plugin_id, plugins_dir) );
-            var deps = xml.findall('dependency');
+            var deps = xml.findall('.//dependency');
 
             deps && deps.forEach(function(dep) {
                 graph.add(plugin_id, dep.attrib.id);
@@ -60,7 +60,7 @@ module.exports = package = {
         });
         Object.keys(json.dependent_plugins).forEach(function(plugin_id) {
             var xml = xml_helpers.parseElementtreeSync( package.resolveConfig(plugin_id, plugins_dir) );
-            var deps = xml.findall('dependency');
+            var deps = xml.findall('.//dependency');
             deps && deps.forEach(function(dep) {
                 graph.add(plugin_id, dep.attrib.id);
             });


### PR DESCRIPTION
plugman dependency check will ignore platform/dependency when removing an
installed plugin, which will result in platform level dependencies is
uninstalled improperly.
