### PR TITLE
CB-6976 Add support for Windows Universal apps (Windows 8.1 and WP 8.1)

### DIFF
--- a/cordova-lib/spec-plugman/platforms/windows8.spec.js
+++ b/cordova-lib/spec-plugman/platforms/windows8.spec.js
@@ -16,7 +16,7 @@
     specific language governing permissions and limitations
     under the License.
 */
-var windows8 = require('../../src/plugman/platforms/windows8'),
+var windows8 = require('../../src/plugman/platforms/windows'),
     common  = require('../../src/plugman/platforms/common'),
     install = require('../../src/plugman/install'),
     path    = require('path'),

--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -75,6 +75,10 @@ function cordova_git(platform) {
     }
 
     var url = platforms[platform].url + ';a=snapshot;h=' + platforms[platform].version + ';sf=tgz';
+    var url = platforms[platform].url + ';a=snapshot;h=' + platforms[platform].version + ';sf=tgz';
+    if (platform == 'windows' || platform == 'windows8') {
+        url = platforms[platform].url; // TODO tmp hack for win81. Must be removed.
+    }
     return module.exports.custom(url, 'cordova', platform, platforms[platform].version);
 }
 

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -166,6 +166,13 @@ function update(hooks, projectRoot, targets, opts) {
               cordova_util.binname + ' platform list`.';
         return Q.reject(new CordovaError(msg));
     }
+    // CB-6976 Windows Universal Apps. Special case to upgrade from windows8 to windows platform 
+    if (plat == 'windows8' && !fs.existsSync(path.join(projectRoot, 'platforms', 'windows'))) {
+        var platformPathWindows = path.join(projectRoot, 'platforms', 'windows');
+        fs.renameSync(platformPath, platformPathWindows)
+        plat = 'windows';
+        platformPath = platformPathWindows;
+    }
 
     // First, lazy_load the latest version.
     return hooks.fire('before_platform_update', opts)
@@ -344,6 +351,11 @@ function platform(command, targets, opts) {
 
     switch(command) {
         case 'add':
+            // CB-6976 Windows Universal Apps. windows8 is now alias for windows
+            var idxWindows8 = targets.indexOf('windows8');
+            if (idxWindows8 >=0) {
+                targets[idxWindows8] = 'windows';
+            }
             return add(hooks, projectRoot, targets, opts);
         case 'rm':
         case 'remove':

--- a/cordova-lib/src/cordova/platforms.js
+++ b/cordova-lib/src/cordova/platforms.js
@@ -69,10 +69,17 @@ module.exports = {
     },
     'windows8':{
         hostos : ['win32'],
-        parser: './metadata/windows8_parser',
-        url    : 'https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git',
-        version: '3.5.0',
-        subdirectory: 'windows8'
+        parser: './metadata/windows_parser',
+        url    : 'http://github.com/MSOpenTech/cordova-windows/archive/win81.tar.gz',
+        version: '3.6.0',
+        subdirectory: 'windows'
+    },
+    'windows':{
+        hostos : ['win32'],
+        parser: './metadata/windows_parser',
+        url    : 'http://github.com/MSOpenTech/cordova-windows/archive/win81.tar.gz',
+        version: '3.6.0',
+        subdirectory: 'windows'
     }
 };
 

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -111,6 +111,13 @@ exports = module.exports = function prepare(options) {
                 // Update platform config.xml based on top level config.xml
                 var platform_cfg = new ConfigParser(parser.config_xml());
                 exports._mergeXml(cfg.doc.getroot(), platform_cfg.doc.getroot(), platform, true);
+
+                // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
+                // we allow using windows8 tag for new windows platform
+                if (platform == 'windows') {
+                    exports._mergeXml(cfg.doc.getroot(), platform_cfg.doc.getroot(), 'windows8', true);
+                }
+
                 platform_cfg.write();
 
                 return parser.update_project(cfg);

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -510,6 +510,11 @@ function handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, 
     var handler = platform_modules[platform];
 
     var platformTag = pluginInfo._et.find('./platform[@name="'+platform+'"]');
+    // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
+    // we allow using windows8 tag for new windows platform
+    if (platform == 'windows' && !platformTag) {
+        platformTag = pluginInfo._et.find('platform[@name="' + 'windows8' + '"]');
+    }
     if ( pluginInfo.hasPlatformSection(platform) ) {
         var sourceFiles = platformTag.findall('./source-file'),
             headerFiles = platformTag.findall('./header-file'),

--- a/cordova-lib/src/plugman/platforms.js
+++ b/cordova-lib/src/plugman/platforms.js
@@ -27,7 +27,8 @@ module.exports = {
     'ios': require('./platforms/ios'),
     'blackberry10': require('./platforms/blackberry10'),
     'wp8': require('./platforms/wp8'),
-    'windows8' : require('./platforms/windows8'),
+    'windows8' : require('./platforms/windows'),
+    'windows' : require('./platforms/windows'),
     'firefoxos': require('./platforms/firefoxos'),
     'ubuntu': require('./platforms/ubuntu'),
     'tizen': require('./platforms/tizen')

--- a/cordova-lib/src/plugman/prepare.js
+++ b/cordova-lib/src/plugman/prepare.js
@@ -27,7 +27,7 @@ var platform_modules = require('./platforms'),
     config_changes  = require('./util/config-changes'),
     xml_helpers     = require('../util/xml-helpers'),
     wp8             = require('./platforms/wp8'),
-    windows8        = require('./platforms/windows8'),
+    windows        = require('./platforms/windows'),
     common          = require('./platforms/common'),
     fs              = require('fs'),
     shell           = require('shelljs'),
@@ -76,11 +76,11 @@ module.exports = function handlePrepare(project_dir, platform, plugins_dir, www_
     // for windows phone and windows8 platforms we need to add all www resources to the .csproj(.jsproj) file
     // first we need to remove them all to prevent duplicates
     var projFile;
-    if (platform == 'wp8' || platform == 'windows8') {
+    if (platform == 'wp8' || platform == 'windows8' || platform == 'windows') {
         projFile = (platform == 'wp8') ? wp8.parseProjectFile(project_dir) :
-            windows8.parseProjectFile(project_dir);
+            windows.parseProjectFile(project_dir);
         // remove reference to cordova_plugins.js and all files inside plugins folder
-        projFile.removeSourceFile(new RegExp("^www\\\\(cordova_plugins.js|plugins\\\\)", "i"));
+        projFile.removeSourceFile(/^(\$\(MSBuildThisFileDirectory\))?www\\(cordova_plugins.js|plugins\\)/i);
     }
 
     platform_json = config_changes.get_platform_json(plugins_dir, platform);
@@ -112,6 +112,11 @@ module.exports = function handlePrepare(project_dir, platform, plugins_dir, www_
         var jsModules = xml.findall('./js-module');
         var assets = xml.findall('asset');
         var platformTag = xml.find(util.format('./platform[@name="%s"]', platform));
+        // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
+        // we allow using windows8 tag for new windows platform
+        if (platform == 'windows' && !platformTag) {
+            platformTag = xml.find('platform[@name="' + 'windows8' + '"]');
+        }
 
         if (platformTag) {
             assets = assets.concat(platformTag.findall('./asset'));
@@ -191,7 +196,7 @@ module.exports = function handlePrepare(project_dir, platform, plugins_dir, www_
     events.emit('verbose', 'Writing out cordova_plugins.js...');
     fs.writeFileSync(path.join(wwwDir, 'cordova_plugins.js'), final_contents, 'utf-8');
 
-    if(platform == 'wp8' || platform == 'windows8') {
+    if(platform == 'wp8' || platform == 'windows8' || platform == 'windows') {
         projFile.addSourceFile(path.join('www', 'cordova_plugins.js'));
         projFile.write();
     }

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -242,6 +242,11 @@ function handleUninstall(actions, platform, plugin_id, plugin_et, project_dir, w
     var platform_modules = require('./platforms');
     var handler = platform_modules[platform];
     var platformTag = plugin_et.find('./platform[@name="'+platform+'"]');
+    // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
+    // we allow using windows8 tag for new windows platform
+    if (platform == 'windows' && !platformTag) {
+         platformTag = plugin_et.find('platform[@name="' + 'windows8' + '"]');
+    }
     www_dir = www_dir || handler.www_dir(project_dir);
     events.emit('log', 'Uninstalling ' + plugin_id + ' from ' + platform);
 

--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -192,6 +192,16 @@ function remove_plugin_changes(plugin_name, plugin_id, is_top_level) {
             );
             continue;
         }
+        // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
+        if (self.platform == 'windows' && file == 'package.appxmanifest' &&
+        	!fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
+        	// New windows template separate manifest files for Windows8, Windows8.1 and WP8.1
+            var substs = ["package.phone.appxmanifest", "package.store.appxmanifest", "package.store80.appxmanifest"];
+            for (var subst in substs) {
+                events.emit('verbose', 'Applying munge to ' + substs[subst]);
+                self.apply_file_munge(substs[subst], munge.files[file], true);
+            }
+        }
         self.apply_file_munge(file, munge.files[file], /* remove = */ true);
     }
 
@@ -241,6 +251,15 @@ function add_plugin_changes(plugin_id, plugin_vars, is_top_level, should_increme
                 'which are no longer supported. Support has been removed as of Cordova 3.4.'
             );
             continue;
+        }
+        // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
+        if (self.platform == 'windows' && file == 'package.appxmanifest' &&
+        	!fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
+            var substs = ["package.phone.appxmanifest", "package.store.appxmanifest", "package.store80.appxmanifest"];
+            for (var subst in substs) {
+                events.emit('verbose', 'Applying munge to ' + substs[subst]);
+                self.apply_file_munge(substs[subst], munge.files[file]);
+            }
         }
         self.apply_file_munge(file, munge.files[file]);
     }
@@ -299,6 +318,12 @@ function generate_plugin_config_munge(plugin_dir, vars) {
     var plugin_xml = plugin_config.data;
 
     var platformTag = plugin_xml.find('platform[@name="' + self.platform + '"]');
+    // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
+    // we allow using windows8 tag for new windows platform
+    if (self.platform == 'windows' && !platformTag) {
+         platformTag = plugin_xml.find('platform[@name="' + 'windows8' + '"]');
+     }
+
     var changes = [];
     // add platform-agnostic config changes
     changes = changes.concat(plugin_xml.findall('config-file'));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6976
- Added new windows platform
- New platform can detect and correctly build both old Windows8 and new Windows project templates
- To have existing plugins working and for smooth transition added logic to re-use windows8 configuration settings (plugin.xml, config.xml).
- windows8 is now alias for windows. Both 'cordova some cmd windows8 and 'cordova some cmd windows' are equal
