### PR TITLE
disables CB-6976 Add support for Windows Universal apps (Windows 8.1 and WP 8.1)

### DIFF
--- a/cordova-lib/src/cordova/metadata/windows_parser.js
+++ b/cordova-lib/src/cordova/metadata/windows_parser.js
@@ -62,13 +62,17 @@ module.exports = function windows_parser(project) {
 // Returns a promise
 module.exports.check_requirements = function(project_root) {
     events.emit('log', 'Checking windows requirements...');
-    var lib_path = path.join(util.libDirectory, 'windows', 'cordova',
-                    require('../platforms').windows.version, 'windows');
-
+    var lib_path = path.join(util.libDirectory, 'windows8', 'cordova',
+                    require('../platforms').windows8.version, 'windows8');
+    // CB-6976 Windows Universal Apps.
+    // var lib_path = path.join(util.libDirectory, 'windows', 'cordova',
+    //                 require('../platforms').windows.version, 'windows');
     var custom_path = config.has_custom_path(project_root, 'windows8') ||
         config.has_custom_path(project_root, 'windows');
     if (custom_path) {
-        lib_path = path.join(custom_path, 'windows');
+        // CB-6976 Windows Universal Apps.
+        //lib_path = path.join(custom_path, 'windows');
+        lib_path = path.join(custom_path, 'windows8');
     }
     var command = '"' + path.join(lib_path, 'bin', 'check_reqs') + '"';
     events.emit('verbose', 'Running "' + command + '" (output to follow)');

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -170,12 +170,12 @@ function update(hooks, projectRoot, targets, opts) {
         return Q.reject(new CordovaError(msg));
     }
     // CB-6976 Windows Universal Apps. Special case to upgrade from windows8 to windows platform
-    if (plat == 'windows8' && !fs.existsSync(path.join(projectRoot, 'platforms', 'windows'))) {
-        var platformPathWindows = path.join(projectRoot, 'platforms', 'windows');
-        fs.renameSync(platformPath, platformPathWindows);
-        plat = 'windows';
-        platformPath = platformPathWindows;
-    }
+    // if (plat == 'windows8' && !fs.existsSync(path.join(projectRoot, 'platforms', 'windows'))) {
+    //     var platformPathWindows = path.join(projectRoot, 'platforms', 'windows');
+    //     fs.renameSync(platformPath, platformPathWindows);
+    //     plat = 'windows';
+    //     platformPath = platformPathWindows;
+    // }
 
     // First, lazy_load the latest version.
     return hooks.fire('before_platform_update', opts)
@@ -355,10 +355,10 @@ function platform(command, targets, opts) {
     switch(command) {
         case 'add':
             // CB-6976 Windows Universal Apps. windows8 is now alias for windows
-            var idxWindows8 = targets.indexOf('windows8');
-            if (idxWindows8 >=0) {
-                targets[idxWindows8] = 'windows';
-            }
+            // var idxWindows8 = targets.indexOf('windows8');
+            // if (idxWindows8 >=0) {
+            //     targets[idxWindows8] = 'windows';
+            // }
             return add(hooks, projectRoot, targets, opts);
         case 'rm':
         case 'remove':

--- a/cordova-lib/src/cordova/platforms.js
+++ b/cordova-lib/src/cordova/platforms.js
@@ -71,16 +71,16 @@ module.exports = {
         hostos : ['win32'],
         parser: './metadata/windows_parser',
         url    : 'https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git',
-        version: 'master',
-        subdirectory: 'windows'
-    },
-    'windows':{
-        hostos : ['win32'],
-        parser: './metadata/windows_parser',
-        url    : 'https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git',
-        version: 'master',
-        subdirectory: 'windows'
+        version: '3.5.0',
+        subdirectory: 'windows8'
     }
+    // 'windows':{
+    //     hostos : ['win32'],
+    //     parser: './metadata/windows_parser',
+    //     url    : 'https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git',
+    //     version: 'master',
+    //     subdirectory: 'windows'
+    // }
 };
 
 var addModuleProperty = require('./util').addModuleProperty;

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -114,9 +114,9 @@ exports = module.exports = function prepare(options) {
 
                 // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
                 // we allow using windows8 tag for new windows platform
-                if (platform == 'windows') {
-                    exports._mergeXml(cfg.doc.getroot(), platform_cfg.doc.getroot(), 'windows8', true);
-                }
+                // if (platform == 'windows') {
+                //     exports._mergeXml(cfg.doc.getroot(), platform_cfg.doc.getroot(), 'windows8', true);
+                // }
 
                 platform_cfg.write();
 

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -512,9 +512,9 @@ function handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, 
     var platformTag = pluginInfo._et.find('./platform[@name="'+platform+'"]');
     // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
     // we allow using windows8 tag for new windows platform
-    if (platform == 'windows' && !platformTag) {
-        platformTag = pluginInfo._et.find('platform[@name="' + 'windows8' + '"]');
-    }
+    // if (platform == 'windows' && !platformTag) {
+    //     platformTag = pluginInfo._et.find('platform[@name="' + 'windows8' + '"]');
+    // }
     if ( pluginInfo.hasPlatformSection(platform) ) {
         var sourceFiles = platformTag.findall('./source-file'),
             headerFiles = platformTag.findall('./header-file'),

--- a/cordova-lib/src/plugman/prepare.js
+++ b/cordova-lib/src/plugman/prepare.js
@@ -114,9 +114,9 @@ module.exports = function handlePrepare(project_dir, platform, plugins_dir, www_
         var platformTag = xml.find(util.format('./platform[@name="%s"]', platform));
         // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
         // we allow using windows8 tag for new windows platform
-        if (platform == 'windows' && !platformTag) {
-            platformTag = xml.find('platform[@name="' + 'windows8' + '"]');
-        }
+        // if (platform == 'windows' && !platformTag) {
+        //     platformTag = xml.find('platform[@name="' + 'windows8' + '"]');
+        // }
 
         if (platformTag) {
             assets = assets.concat(platformTag.findall('./asset'));

--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -193,15 +193,15 @@ function remove_plugin_changes(plugin_name, plugin_id, is_top_level) {
             continue;
         }
         // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
-        if (self.platform == 'windows' && file == 'package.appxmanifest' &&
-            !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
-            // New windows template separate manifest files for Windows8, Windows8.1 and WP8.1
-            var substs = ['package.phone.appxmanifest', 'package.store.appxmanifest', 'package.store80.appxmanifest'];
-            for (var subst in substs) {
-                events.emit('verbose', 'Applying munge to ' + substs[subst]);
-                self.apply_file_munge(substs[subst], munge.files[file], true);
-            }
-        }
+        // if (self.platform == 'windows' && file == 'package.appxmanifest' &&
+        //     !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
+        //     // New windows template separate manifest files for Windows8, Windows8.1 and WP8.1
+        //     var substs = ['package.phone.appxmanifest', 'package.store.appxmanifest', 'package.store80.appxmanifest'];
+        //     for (var subst in substs) {
+        //         events.emit('verbose', 'Applying munge to ' + substs[subst]);
+        //         self.apply_file_munge(substs[subst], munge.files[file], true);
+        //     }
+        // }
         self.apply_file_munge(file, munge.files[file], /* remove = */ true);
     }
 
@@ -253,14 +253,14 @@ function add_plugin_changes(plugin_id, plugin_vars, is_top_level, should_increme
             continue;
         }
         // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
-        if (self.platform == 'windows' && file == 'package.appxmanifest' &&
-            !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
-            var substs = ['package.phone.appxmanifest', 'package.store.appxmanifest', 'package.store80.appxmanifest'];
-            for (var subst in substs) {
-                events.emit('verbose', 'Applying munge to ' + substs[subst]);
-                self.apply_file_munge(substs[subst], munge.files[file]);
-            }
-        }
+        // if (self.platform == 'windows' && file == 'package.appxmanifest' &&
+        //     !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
+        //     var substs = ['package.phone.appxmanifest', 'package.store.appxmanifest', 'package.store80.appxmanifest'];
+        //     for (var subst in substs) {
+        //         events.emit('verbose', 'Applying munge to ' + substs[subst]);
+        //         self.apply_file_munge(substs[subst], munge.files[file]);
+        //     }
+        // }
         self.apply_file_munge(file, munge.files[file]);
     }
 
@@ -320,9 +320,9 @@ function generate_plugin_config_munge(plugin_dir, vars) {
     var platformTag = plugin_xml.find('platform[@name="' + self.platform + '"]');
     // CB-6976 Windows Universal Apps. For smooth transition and to prevent mass api failures
     // we allow using windows8 tag for new windows platform
-    if (self.platform == 'windows' && !platformTag) {
-        platformTag = plugin_xml.find('platform[@name="' + 'windows8' + '"]');
-    }
+    // if (self.platform == 'windows' && !platformTag) {
+    //     platformTag = plugin_xml.find('platform[@name="' + 'windows8' + '"]');
+    // }
 
     var changes = [];
     // add platform-agnostic config changes


### PR DESCRIPTION
We should not include this functionality until new Windows platform is released. It is better to enable this for 3.6.0 release. This also guaranties nothing is broken with Windows8 platform after this Tools Release.
