### PR TITLE
CB-7199 control git/npm using platform.js

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -63,6 +63,7 @@ function Platform(platformString) {
         this.name = platformString;
         if (platforms[this.name]) this.version = platforms[this.name].version;
     }
+    this.source = 'source' in platforms[this.name] ? platforms[this.name].source : 'npm';
 }
 
 // Returns a promise for the path to the lazy-loaded directory.
@@ -84,7 +85,7 @@ function based_on_config(project_root, platform, opts) {
 // Returns a promise for the path to the lazy-loaded directory.
 function cordova(platform, opts) {
     platform = new Platform(platform);
-    var use_git = opts && opts.usegit || platform.name === 'www';
+    var use_git = opts && opts.usegit || platform.source === 'git';
     if ( use_git ) {
         return module.exports.cordova_git(platform);
     } else {

--- a/cordova-lib/src/cordova/platforms.js
+++ b/cordova-lib/src/cordova/platforms.js
@@ -60,6 +60,7 @@ module.exports = {
     'www':{
         hostos : [],
         url    : 'https://git-wip-us.apache.org/repos/asf?p=cordova-app-hello-world.git',
+        source : 'git',
         version: '3.5.0'
     },
     'firefoxos':{


### PR DESCRIPTION
www will default to git
if you want a platform to use git, just add source:git to its platforms.js section
