### PR TITLE
CB-7091: Remove check_requirements() funcs from platform parsers

### DIFF
--- a/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
@@ -93,21 +93,6 @@ describe('blackberry10 project parser', function() {
         });
     });
 
-    describe('check_requirements', function() {
-        it('should fire a callback if the blackberry-deploy shell-out fails', function(done) {
-            sh.andCallFake(function(cmd, opts, cb) {
-                (cb || opts)(1, 'no bb-deploy dewd!');
-            });
-            errorWrapper(platforms.blackberry10.parser.check_requirements(proj), done, function(err) {
-                expect(err).toContain('no bb-deploy dewd');
-            });
-        });
-        it('should fire a callback with no error if shell out is successful', function(done) {
-            wrapper(platforms.blackberry10.parser.check_requirements(proj), done, function() {
-                expect(1).toBe(1);
-            });
-        });
-    });
     describe('instance', function() {
         var p, cp, rm, mkdir, is_cordova, write, read;
         var bb_proj = path.join(proj, 'platforms', 'blackberry10');

--- a/cordova-lib/src/cordova/metadata/blackberry10_parser.js
+++ b/cordova-lib/src/cordova/metadata/blackberry10_parser.js
@@ -29,8 +29,7 @@ var fs            = require('fs'),
     child_process = require('child_process'),
     ConfigParser  = require('../../configparser/ConfigParser'),
     CordovaError  = require('../../CordovaError'),
-    events        = require('../../events'),
-    lazy_load     = require('../lazy_load');
+    events        = require('../../events');
 
 module.exports = function blackberry_parser(project) {
     if (!fs.existsSync(path.join(project, 'www'))) {
@@ -39,24 +38,6 @@ module.exports = function blackberry_parser(project) {
     this.path = project;
     this.config_path = path.join(this.path, 'www', 'config.xml');
     this.xml = new ConfigParser(this.config_path);
-};
-
-// Returns a promise.
-module.exports.check_requirements = function(project_root, lib_path) {
-    if (lib_path === undefined) {
-        return lazy_load.based_on_config(project_root, 'blackberry10').then(function (lib_path) {
-            return module.exports.check_requirements(project_root, lib_path);
-        });
-    }
-    var d = Q.defer();
-    child_process.exec('"' + path.join(lib_path, 'bin', 'check_reqs') + '"', function(err, output, stderr) {
-        if (err) {
-            d.reject(new CordovaError('Requirements check failed: ' + output + stderr));
-        } else {
-            d.resolve();
-        }
-    });
-    return d.promise;
 };
 
 module.exports.prototype = {


### PR DESCRIPTION
No longer used, removing. They were either:
1) Empty
2) Duplicating the chqck_reqs call that is also done by platform create scripts
3) In Ubuntu duplicated the code from check_reqs
