### PR TITLE
Add JSCS config file

### DIFF
--- a/cordova-lib/.jscs.json
+++ b/cordova-lib/.jscs.json
@@ -1,0 +1,22 @@
+{
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "validateLineBreaks": "LF",
+    "validateIndentation": 4,
+    "requireLineFeedAtFileEnd": true,
+    "requireCapitalizedConstructors": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "requireSpaceAfterLineComment": true,
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+
+    "requireSpaceAfterKeywords": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do"
+    ]
+}


### PR DESCRIPTION
Don't merge yet - feedback wanted.

JSHint people want to focus on syntax linting and are dropping style oriented
options. They recommend using JSCS (in addition to JSHint) for style:
https://github.com/jshint/jshint/issues/1339

JSCS has recently added the options dropped from JSHint.
https://github.com/mdevils/node-jscs/issues/102

This commit contains a JSCS config file with some basic settings that generate
very few errors with the existing cordova-cli and lib code.

Would be glad to get some feedback about this. My goal is to eventually run
JSCS together with JSHint as part of `npm test`. The nice thing about JSCS
is that style flame wars can be way more structured with it, as we can argue
about very specific well named JSCS config options, or even vote on them :)

I'm using it with SublimeLinter-jscs
https://sublime.wbond.net/packages/SublimeLinter-jscs
