### PR TITLE
CB-7372 Fix generated launch path for FirefoxOS on Windows

### DIFF
--- a/cordova-lib/src/cordova/metadata/firefoxos_parser.js
+++ b/cordova-lib/src/cordova/metadata/firefoxos_parser.js
@@ -49,8 +49,8 @@ module.exports.prototype = {
 
         // overwrite properties existing in config.xml
         var contentNode = config.doc.find('content');
-        var contentSrc = contentNode.attrib['src'];
-        manifest.launch_path = path.join('/', contentSrc) || '/index.html';
+        var contentSrc = contentNode && contentNode.attrib['src'] || 'index.html';
+        manifest.launch_path = '/' + contentSrc;
 
         manifest.installs_allowed_from = manifest.installs_allowed_from || ['*'];
         manifest.version = config.version();


### PR DESCRIPTION
I was having issues on Windows when creating a new FirefoxOS project. A brand new project, when added to the Firefox App Manager, gave an error: "Launch path has to be an absolute path starting with '/': '\index.html'". The issue is the use of path.join to generate manifest.launch_path. On Windows, this uses backslashes, which caused the issue. I have opted to simply use concatenation instead.

I have also fixed an issue where "cordova prepare firefoxos" would fail if there was no <content> tag in the config.xml. If it is not present, we default to index.html.
