### PR TITLE
Add support for plugin symbolic links

### DIFF
--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -115,7 +115,7 @@ module.exports = function plugin(command, targets, opts) {
 
                         // Fetch the plugin first.
                         events.emit('verbose', 'Calling plugman.fetch on plugin "' + target + '"');
-                        return plugman.raw.fetch(target, pluginsDir, { searchpath: searchPath, noregistry: opts.noregistry});
+                        return plugman.raw.fetch(target, pluginsDir, { searchpath: searchPath, noregistry: opts.noregistry, link: opts.link});
                     })
                     .then(function(dir) {
                         // Iterate (in serial!) over all platforms in the project and install the plugin.

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -104,7 +104,12 @@ module.exports.uninstallPlugin = function(id, plugins_dir, options) {
             return Q();
         }
 
-        shell.rm('-rf', plugin_dir);
+        if (fs.lstatSync(plugin_dir).isSymbolicLink()) {
+            fs.unlinkSync(plugin_dir);
+        } else {
+            shell.rm('-rf', plugin_dir);
+        }
+
         events.emit('verbose', 'Deleted "'+ id +'"');
     };
 


### PR DESCRIPTION
Useful in when developing a plugin, changes support both adding and uninstalling plugins.
