### PR TITLE
Windows helper. Removes unnecessary $(MSBuildThisFileDirectory)

### DIFF
--- a/cordova-lib/src/util/windows/jsproj.js
+++ b/cordova-lib/src/util/windows/jsproj.js
@@ -82,8 +82,6 @@ jsproj.prototype = {
 
         events.emit('verbose','addReference::' + relPath);
 
-        relPath = this.isUniversalWindowsApp ? '$(MSBuildThisFileDirectory)' + relPath : relPath;
-
         var item = new et.Element('ItemGroup');
         var extName = path.extname(relPath);
 
@@ -110,8 +108,6 @@ jsproj.prototype = {
     removeReference:function(relPath) {
         events.emit('verbose','removeReference::' + relPath);
 
-        relPath = this.isUniversalWindowsApp ? '$(MSBuildThisFileDirectory)' + relPath : relPath;
-
         var extName = path.extname(relPath);
         var includeText = path.basename(relPath,extName);
         // <ItemGroup>
@@ -131,10 +127,9 @@ jsproj.prototype = {
         }
         // make ItemGroup to hold file.
         var item = new et.Element('ItemGroup');
-        var me = this;
+
         relative_path.forEach(function(filePath) {
             filePath = filePath.split('/').join('\\');
-            filePath = me.isUniversalWindowsApp ? '$(MSBuildThisFileDirectory)' + filePath : filePath;
 
             var content = new et.Element('Content');
             content.attrib.Include = filePath;
@@ -148,7 +143,6 @@ jsproj.prototype = {
         if (!isRegexp) {
             // path.normalize(relative_path);// ??
             relative_path = relative_path.split('/').join('\\');
-            relative_path = this.isUniversalWindowsApp ? '$(MSBuildThisFileDirectory)' + relative_path : relative_path;
         }
 
         var root = this.xml.getroot();


### PR DESCRIPTION
This property is not required since all main .jsproj and other shared project files are in the same folder
