### PR TITLE
CB-7441 Plugman. jsproj files should be treated as xml if used with <config-file>

### DIFF
--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -539,7 +539,7 @@ function ConfigFile_load() {
     var ext = path.extname(filepath);
     // Windows8 uses an appxmanifest, and wp8 will likely use
     // the same in a future release
-    if (ext == '.xml' || ext == '.appxmanifest') {
+    if (ext == '.xml' || ext == '.appxmanifest' || ext == '.jsproj') {
         self.type = 'xml';
         self.data = xml_helpers.parseElementtreeSync(filepath);
     } else if (ext == '.pbxproj') {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7441
