### PR TITLE
CB-7598 Android: Support for 9-patch splash images

### DIFF
--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -113,8 +113,16 @@ module.exports.prototype = {
                 var density = densities[i];
                 var resource = resources.getByDensity(density);
                 if (resource) {
+                    var destname = 'screen.png';
+
+                    // If it's a nine-patch image (*.9.png) we need to preserve
+                    // that extension
+                    if (resource.src.match(/\.9\.png$/)) {
+                        destname = 'screen.9.png';
+                    }
+
                     // copy splash screens.
-                    destfilepath = path.join(res, 'drawable-' + density, 'screen.png');
+                    destfilepath = path.join(res, 'drawable-' + density, destname);
                     events.emit('verbose', 'copying splash icon from ' + resource.src + ' to ' + destfilepath);
                     shell.cp('-f', resource.src, destfilepath);
                 }


### PR DESCRIPTION
If a splashscreen image for Android is specified in config.xml and ends with `.9.png`, it is a 9-patch image and should retain that extension when copied into the platforms/android directory.

Currently the file will be renamed to `screen.png` when it should be `screen.9.png`.
