### PR TITLE
CB-7572 Serve - respond with 304 when resource not modified

### DIFF
--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -36,6 +36,7 @@
     "underscore": "1.4.4",
     "xcode": "0.6.7",
     "cordova-js": "3.6.4",
+    "d8": "0.4.4",
     "unorm": ">=1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This will prevent a lot of unnecessary network traffic, especially in situations such as a list control which has the same icon on each row.

I've tested it on OSX with Chrome, but plan on testing Windows and with mobile devices before merging.
