### PR TITLE
CB-7607 Add xxhdpi and xxxhdpi support to Android Cordova

### DIFF
--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -95,74 +95,78 @@ module.exports.prototype = {
         return densities;
     },
 
+    copyImage: function(src, density, name) {
+        var destFolder = path.join(this.path, 'res', (density ? 'drawable-': 'drawable') + density);
+        var destFilePath = path.join(destFolder, name);
+
+        // default template does not have default asset for this density
+        if (!fs.existsSync(destFolder)) {
+            fs.mkdirSync(destFolder);
+        }
+        events.emit('verbose', 'copying image from ' + src + ' to ' + destFilePath);
+        shell.cp('-f', src, destFilePath);
+    },
+
     handleSplashes:function(config) {
         var resources = config.getSplashScreens('android');
-        var destfilepath;
+        var me = this;
         // if there are "splash" elements in config.xml
         if (resources.length > 0) {
-            var densities = this.deleteDefaultResource('screen.png');
+            this.deleteDefaultResource('screen.png');
             events.emit('verbose', 'splash screens: ' + JSON.stringify(resources));
-            var res = path.join(this.path, 'res');
+
+            var projectRoot = util.isCordova(this.path);
 
             if (resources.defaultResource) {
-                destfilepath = path.join(res, 'drawable', 'screen.png');
-                events.emit('verbose', 'copying splash icon from ' + resources.defaultResource.src + ' to ' + destfilepath);
-                shell.cp('-f', resources.defaultResource.src, destfilepath);
+                me.copyImage(path.join(projectRoot, resources.defaultResource.src), '', 'screen.png');
             }
-            for (var i=0; i<densities.length; i++) {
-                var density = densities[i];
-                var resource = resources.getByDensity(density);
-                if (resource) {
-                    // copy splash screens.
-                    destfilepath = path.join(res, 'drawable-' + density, 'screen.png');
-                    events.emit('verbose', 'copying splash icon from ' + resource.src + ' to ' + destfilepath);
-                    shell.cp('-f', resource.src, destfilepath);
+            resources.forEach(function (resource) {
+                if (!resource.density) {
+                    return;
                 }
-            }
+                me.copyImage(path.join(projectRoot, resource.src), resource.density, 'screen.png');
+            });
         }
     },
 
     handleIcons: function(config) {
         var icons = config.getIcons('android');
+
         // if there are icon elements in config.xml
         if (icons.length === 0) {
             events.emit('verbose', 'This app does not have launcher icons defined');
             return;
         }
 
-        var densities = this.deleteDefaultResource('icon.png');
+        this.deleteDefaultResource('icon.png');
 
         var android_icons = {};
         var default_icon;
         // http://developer.android.com/design/style/iconography.html
-        var densityToSizeMap = {
-            'ldpi' : 36,
-            'mdpi' : 48,
-            'hdpi' : 72,
-            'xhdpi' : 96
+        var sizeToDensityMap = {
+            36: 'ldpi',
+            48: 'mdpi',
+            72: 'hdpi',
+            96: 'xhdpi',
+            144: 'xxhdpi',
+            192: 'xxxhdpi'
         };
         // find the best matching icon for a given density or size
         // @output android_icons
-        var parseIcon = function(icon, icon_size, size, density) {
+        var parseIcon = function(icon, icon_size) {
             // do I have a platform icon for that density already
+            var density = icon.density || sizeToDensityMap[icon_size];
+            if (!density) {
+                // invalid icon defition ( or unsupported size)
+                return;
+            }
             var previous = android_icons[density];
             if (previous && previous.platform) {
                 return;
             }
-            // already have one but this one is a platform icon
-            if (previous && icon.platform && icon.density == density) {
-                android_icons[density] = icon;
-                return;
-            }
-            // if density is explicitly defined take this one
-            if (density === icon.density) {
-                android_icons[density] = icon;
-                return;
-            }
-            if (size === parseInt(icon_size)) {
-                android_icons[density] = icon;
-            }
+            android_icons[density] = icon;
         };
+
         // iterate over all icon elements to find the default icon and call parseIcon
         for (var i=0; i<icons.length; i++) {
             var icon = icons[i];
@@ -177,33 +181,18 @@ module.exports.prototype = {
                     default_icon = icon;
                 }
             } else {
-                for (var k=0; k<densities.length; k++) {
-                    parseIcon(icon, size, densityToSizeMap[densities[k]], densities[k]);
-                }
+                parseIcon(icon, size);
             }
         }
         var projectRoot = util.isCordova(this.path);
-        var srcfilepath;
-        var destfilepath;
         // copy the default icon to the drawable folder
         if (default_icon) {
-            srcfilepath = path.join(projectRoot, default_icon.src);
-            destfilepath = path.join(this.path, 'res', 'drawable', 'icon.png');
-            events.emit('verbose', 'Copying default icon from ' + srcfilepath + ' to ' + destfilepath);
-            shell.cp('-f', srcfilepath, destfilepath);
+            this.copyImage(path.join(projectRoot, default_icon.src), '', 'icon.png');
         }
-        // copyIcon does the actual copying into the drawable folders
-        var copyIcon = function(density) {
-            if (android_icons[density]) {
-                srcfilepath = path.join(projectRoot, android_icons[density].src);
-                destfilepath = path.join(this.path, 'res', 'drawable-'+density, 'icon.png');
-                events.emit('verbose', 'Copying icon from ' + srcfilepath + ' to ' + destfilepath);
-                shell.cp('-f', srcfilepath, destfilepath);
-            }
-        }.bind(this);
-        for (var j=0; j<densities.length; j++) {
-            copyIcon(densities[j]);
-        }
+
+         for (var density in android_icons) {
+            this.copyImage(path.join(projectRoot, android_icons[density].src), density, 'icon.png');
+         }
     },
 
     update_from_config:function(config) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7607

Current Cordova template for Android does not have res sub-folders for xx and xxxhdpi plus due to current splash/icons support implementation it is possible to replace already existing drawables only(see var densities = this.deleteDefaultResource(...)). I don't think we should always keep new hi res images as part of default template due to the their big size so this commit improves splash/icons support implementation to make it possible to add drawables for the densities which are not present in template by default.

Example configuration for xxhdpi and xxxhdpi assets:

```
<icon src="res/android/xxhdpi.png" density="xxhdpi" />
<icon src="res/android/xxxhdpi.png" density="xxxhdpi" />

<splash src="res/android/land-xxhdpi.png" density="land-xxhdpi" />
<splash src="res/android/port-xxhdpi.png" density="port-xxhdpi" />

<splash src="res/android/land-xxxhdpi.png" density="land-xxxhdpi" />
<splash src="res/android/port-xxxhdpi.png" density="port-xxxhdpi" />
```
