### PR TITLE
CB-7670 Fixes failure when trying to fetch dependent plugin while adding platform

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -136,7 +136,19 @@ function npm_cache_add(pkg) {
     var npm_cache_dir = path.join(util.libDirectory, 'npm_cache');
     // 'cache-min' is the time in seconds npm considers the files fresh and
     // does not ask the registry if it got a fresher version.
-    return Q.nfcall( npm.load, { 'cache-min': 3600*24, cache: npm_cache_dir })
+    var platformNpmConfig = {
+        'cache-min': 3600*24,
+        cache: npm_cache_dir,
+        registry: 'https://registry.npmjs.org'
+    };
+
+    return Q.nfcall(npm.load)
+    .then(function () {
+        // configure npm here instead of passing parameters to npm.load due to CB-7670
+        for (var prop in platformNpmConfig) {
+            npm.config.set(prop, platformNpmConfig[prop]);
+        }
+    })
     .then(function() {
         return Q.ninvoke(npm.commands, 'cache', ['add', pkg]);
     }).then(function(info) {

--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -150,7 +150,15 @@ module.exports = {
     fetch: function(plugin, client) {
         plugin = plugin.shift();
         return initSettings()
-        .then(Q.nbind(npm.load, npm))
+        .then(function (settings) {
+            return Q.nfcall(npm.load)
+            // configure npm here instead of passing parameters to npm.load due to CB-7670
+            .then(function () {
+                for (var prop in settings){
+                    npm.config.set(prop, settings[prop]);
+                }
+            });
+        })
         .then(function() {
             return Q.ninvoke(npm.commands, 'cache', ['add', plugin]);
         })


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CB-7670

Problem here is that cordova fetches platform and plugin using NPM and uses different registries for them.
Once npm is initialized using `npm.load()` in lazy_load module, further `npm.load()` (in plugman/fetch.js module) calls ignores provided configuration (https://github.com/npm/npm/blob/master/lib/npm.js#L263)
It seems that the proper way here is to load npm using `npm.load()` and configure it using `npm.config.set()` as described here: https://github.com/npm/npm#using-npm-programmatically
