### PR TITLE
xxhdpi/xxxhdpi and 9-patch splash image support for Android

### DIFF
--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -125,7 +125,12 @@ module.exports.prototype = {
                 if (!resource.density) {
                     return;
                 }
-                me.copyImage(path.join(projectRoot, resource.src), resource.density, 'screen.png');
+                var screenname = 'screen.png';
+                if (resource.src.match(/\.9\.png$/)) {
+                    screenname = 'screen.9.png';
+                }
+
+                me.copyImage(path.join(projectRoot, resource.src), resource.density, screenname);
             });
         }
     },


### PR DESCRIPTION
This combines #89 and #87 so that they won't conflict with each other.
/cc @sgrebnov 

From #89:

> https://issues.apache.org/jira/browse/CB-7607
> 
> Current Cordova template for Android does not have res sub-folders for xx and xxxhdpi plus due to current
> splash/icons support implementation it is possible to replace already existing drawables only(see var 
> densities = this.deleteDefaultResource(...)). I don't think we should always keep new hi res images as part
> of default template due to the their big size so this commit improves splash/icons support implementation
> to make it possible to add drawables for the densities which are not present in template by default.
> 
> Example configuration for xxhdpi and xxxhdpi assets:
> 
> ```
> <icon src="res/android/xxhdpi.png" density="xxhdpi" />
> <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
> 
> <splash src="res/android/land-xxhdpi.png" density="land-xxhdpi" />
> <splash src="res/android/port-xxhdpi.png" density="port-xxhdpi" />
> 
> <splash src="res/android/land-xxxhdpi.png" density="land-xxxhdpi" />
> <splash src="res/android/port-xxxhdpi.png" density="port-xxxhdpi" />
> ```

From #87:

> https://issues.apache.org/jira/browse/CB-7598
> 
> If a splashscreen image for Android is specified in config.xml and ends with .9.png, it is a 9-patch image
> and should retain that extension when copied into the platforms/android directory.
> 
> Currently the file will be renamed to screen.png when it should be screen.9.png.
