### PR TITLE
Check for a CORDOVA_HOME environment variable to create the global config path

### DIFF
--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -27,7 +27,10 @@ var fs            = require('fs'),
     shell         = require('shelljs');
 
 // Global configuration paths
-var HOME = process.env[(process.platform.slice(0, 3) == 'win') ? 'USERPROFILE' : 'HOME'];
+var HOME = process.env['CORDOVA_HOME'];
+if (!HOME) {
+	HOME = process.env[(process.platform.slice(0, 3) == 'win') ? 'USERPROFILE' : 'HOME'];
+}
 var global_config_path = path.join(HOME, '.cordova');
 var lib_path = path.join(global_config_path, 'lib');
 shell.mkdir('-p', lib_path);


### PR DESCRIPTION
I would like the ".cordova" folder not to be created in my HOME folder, but in a custom path, that would be declared in a CORDOVA_HOME environment variable. 

This will be useful for a multi-user environment. Instead of having the same .cordova folder in each user's HOME folder with the same content, I will be able to create a single .cordova folder, that every user will be able to access.
