### PR TITLE
enable platform-specific-id. (android and ios)

### DIFF
--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -53,6 +53,18 @@ describe('config.xml parser', function () {
             });
         });
 
+        describe('package name / android-packageName', function() {
+            it('should get the android packagename', function() {
+                expect(cfg.android_packageName()).toEqual('io.cordova.hellocordova.android');
+            });
+        });
+
+        describe('package name / ios-CFBundleIdentifier', function() {
+            it('should get the ios packagename', function() {
+                expect(cfg.ios_CFBundleIdentifier()).toEqual('io.cordova.hellocordova.ios');
+            });
+        });
+
         describe('version', function() {
             it('should get the version', function() {
                 expect(cfg.version()).toEqual('0.0.1');

--- a/cordova-lib/spec-cordova/metadata/android_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/android_parser.spec.js
@@ -139,8 +139,14 @@ describe('android project parser', function() {
                 expect(stringsRoot.getroot().find('string').text).toEqual('testname');
             });
             it('should write out the app id to androidmanifest.xml and update the cordova-android entry Java class', function() {
+                cfg.android_packageName = function () { return null };
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().attrib.package).toEqual('testpkg');
+            });
+            it('should write out the app id to androidmanifest.xml and update the cordova-android entry Java class with android_packageName', function() {
+                cfg.android_packageName = function () { return 'testpkg_android' };
+                p.update_from_config(cfg);
+                expect(manifestRoot.getroot().attrib.package).toEqual('testpkg_android');
             });
             it('should write out the app version to androidmanifest.xml', function() {
                 p.update_from_config(cfg);

--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -117,8 +117,15 @@ describe('ios project parser', function () {
                 });
             });
             it('should write out the app id to info plist as CFBundleIdentifier', function(done) {
+                cfg.ios_CFBundleIdentifier = function() { return null };
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg');
+                });
+            });
+            it('should write out the app id to info plist as CFBundleIdentifier with ios-CFBundleIdentifier', function(done) {
+                cfg.ios_CFBundleIdentifier = function() { return 'testpkg_ios' };
+                wrapper(p.update_from_config(cfg), done, function() {
+                    expect(plist_build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg_ios');
                 });
             });
             it('should write out the app version to info plist as CFBundleVersion', function(done) {

--- a/cordova-lib/spec-cordova/test-config.xml
+++ b/cordova-lib/spec-cordova/test-config.xml
@@ -2,7 +2,9 @@
 <widget xmlns     = "http://www.w3.org/ns/widgets"
         xmlns:cdv = "http://cordova.apache.org/ns/1.0"
         id        = "io.cordova.hellocordova"
-        version   = "0.0.1">
+        version   = "0.0.1"
+        android-packageName="io.cordova.hellocordova.android"
+        ios-CFBundleIdentifier="io.cordova.hellocordova.ios">
     <name>Hello Cordova</name>
 
     <description>

--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -89,6 +89,12 @@ ConfigParser.prototype = {
     setPackageName: function(id) {
         this.doc.getroot().attrib['id'] = id;
     },
+    android_packageName: function() {
+        return this.doc.getroot().attrib['android-packageName'];
+    },
+    ios_CFBundleIdentifier: function() {
+        return this.doc.getroot().attrib['ios-CFBundleIdentifier'];
+    },
     name: function() {
         return getNodeTextSafe(this.doc.find('name'));
     },

--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -226,7 +226,7 @@ module.exports.prototype = {
         manifest.getroot().attrib["android:versionCode"] = versionCode;
 
         // Update package name by changing the AndroidManifest id and moving the entry class around to the proper package directory
-        var pkg = config.packageName();
+        var pkg = config.android_packageName() || config.packageName();
         pkg = pkg.replace(/-/g, '_'); // Java packages cannot support dashes
         var orig_pkg = manifest.getroot().attrib.package;
         manifest.getroot().attrib.package = pkg;

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -60,7 +60,7 @@ module.exports.prototype = {
             return Q.reject(new Error('update_from_config requires a ConfigParser object'));
         }
         var name = config.name();
-        var pkg = config.packageName();
+        var pkg = config.ios_CFBundleIdentifier() || config.packageName();
         var version = config.version();
 
         // Update package id (bundle id)


### PR DESCRIPTION
I want to specify ID by platforms.

I lost my certification file for Android application.
I want to release my android application as new application. But I want to release my iOS application as new version.
