### PR TITLE
[CB-7820] cordova platfrom restore stops if a platforms fails to restore

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -54,13 +54,13 @@ function add(hooksRunner, projectRoot, targets, opts) {
         return Q.reject(new CordovaError(msg));
     }
 
-    targets.forEach(function(platform) {
-        if ( !hostSupports(platform) ) {
-            msg = 'Applications for platform ' + platform +
+    for(var i= 0 ; i< targets.length; i++){
+        if ( !hostSupports(targets[i]) ) {
+            msg = 'Applications for platform ' + targets[i] +
                   ' can not be built on this OS - ' + process.platform + '.';
-            throw new CordovaError(msg);
+            return Q.reject( new CordovaError(msg));
         }
-    });
+    }
 
     var xml = cordova_util.projectConfig(projectRoot);
     var cfg = new ConfigParser(xml);

--- a/cordova-lib/src/cordova/restore.js
+++ b/cordova-lib/src/cordova/restore.js
@@ -54,7 +54,21 @@ function installPlatformsFromConfigXML(cfg){
     if(!targets || !targets.length  ){
         return Q.all('No platforms are listed in config.xml to restore');
     }
-    return platform('add', targets);
+    
+    // Run platform add for all the platforms seperately 
+    // so that failure on one does not affect the other.
+    var promises = targets.map(function(target){
+        return platform('add',target);
+    });
+    return Q.allSettled(promises).then(
+        function (results) {
+            for(var i =0; i<results.length; i++){
+                //log the rejections otherwise they are lost
+                if(results[i].state ==='rejected'){
+                    events.emit('log', results[i].reason.message);
+                }
+            }
+        });
 }
 
 //returns a Promise


### PR DESCRIPTION
handles restoration for each platform separately so that if one fails installation for
others continues. Also makes a change on how the host is checked to allow such errors
not to completely halt the execution.
