### PR TITLE
Add a type named "gradleReference" in framework

### DIFF
--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -107,7 +107,13 @@ module.exports = {
             }
 
             var projectConfig = module.exports.parseProjectFile(project_dir);
-            projectConfig.addSubProject(parentDir, subDir);
+            var type = source_el.attrib.type;
+            if (type == 'gradleReference') {
+                //add reference to build.gradle
+                projectConfig.addGradleReference(parentDir, subDir);
+            } else {
+                projectConfig.addSubProject(parentDir, subDir);
+            }
         },
         uninstall:function(source_el, project_dir, plugin_id) {
             var src = source_el.attrib.src;
@@ -130,7 +136,12 @@ module.exports = {
             }
 
             var projectConfig = module.exports.parseProjectFile(project_dir);
-            projectConfig.removeSubProject(parentDir, subDir);
+            var type = source_el.attrib.type;
+            if (type == 'gradleReference') {
+                projectConfig.removeGradleReference(parentDir, subDir);
+            } else {
+                projectConfig.removeSubProject(parentDir, subDir);
+            }
         }
     },
     parseProjectFile: function(project_dir){


### PR DESCRIPTION
It's too complex to dependence AAR in plugin, it need build the plugin
to a android project which include AndroidManifest.xml. This patch
reference the *.gradle in plugin to build.gradle in root project. Below is
a demo.
plugin.xml:
<framework src="libs/xwalk_core_library/xwalk.gradle" custom="true" type="gradleReference"/>

xwalk.gradle:
repositories {
    maven {
        url 'https://download.01.org/crosswalk/releases/crosswalk/android/maven2'
    }
}
dependencies {
    compile 'org.xwalk:xwalk_core_library_beta:9.38.208.4'
}

The build.gradle will add blow section:
// PLUGIN GRADLE EXTENSIONS START
apply from: 'libs/xwalk_core_library/xwalk.gradle'
// PLUGIN GRADLE EXTENSIONS END
