### PR TITLE
CB-8053: Including a project reference in a plugin fails on Windows plat...

### DIFF
--- a/cordova-lib/src/plugman/platforms/windows.js
+++ b/cordova-lib/src/plugman/platforms/windows.js
@@ -130,10 +130,12 @@ module.exports = {
             // technically it is not possible to get here without isCustom == true -jm
             // var isCustom = el.attrib.custom == 'true';
             var type = el.attrib['type'];
-            // unfortunately we have to generate the plugin_dir path because it is not passed to uninstall
-            var plugin_dir = path.join(project_dir, 'cordova/plugins', plugin_id,src);
 
             if(type == 'projectReference') {
+                // unfortunately we have to generate the plugin_dir path because it is not passed to uninstall. Note
+                // that project_dir is the windows project directory ([project]\platforms\windows) - we need to get to
+                // [project]\plugins\[plugin_id]
+                var plugin_dir = path.join(project_dir, '..', '..', 'plugins', plugin_id, src);
                 project_file.removeProjectReference(plugin_dir);
             }
             else {


### PR DESCRIPTION
When working with the Windows platform, the existing logic to add a project reference was expecting two things:
1. There would only be one solution file.
2. That solution file would only contain a single project.

This is no longer true - there are now two solution files (one for VS 2012 and one for VS 2013). The VS 2013 solution is for a universal project, and contains five projects.

The change here is to make the code (in cordova-lib/src/util/windows/jsproj.js) which modifies the solution file more versatile by:
1. Handling any number of solution files (iterate all solution files we find).
2. Handling any number of projects in the solution (add the build depedency to every jsproj in the solution).

Includes matching changes to removeProjectReference(), and fixes a call in cordova-lib/src/plugman/platforms/windows.js to pass the correct path for plugin_dir.
