### PR TITLE
CB-8043 CB-6462 CB-6105 Refactor orientation preference support

### DIFF
--- a/cordova-lib/spec-cordova/metadata/android_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/android_parser.spec.js
@@ -27,6 +27,7 @@ var platforms = require('../../src/cordova/platforms'),
     config = require('../../src/cordova/config'),
     Parser = require('../../src/cordova/metadata/parser'),
     ConfigParser = require('../../src/configparser/ConfigParser'),
+    CordovaError = require('../../src/CordovaError'),
     cordova = require('../../src/cordova/cordova');
 
 // Create a real config object before mocking out everything.
@@ -46,6 +47,7 @@ var MANIFEST_XML = '<manifest android:versionCode="1" android:versionName="0.0.1
 
 describe('android project parser', function() {
     var proj = path.join('some', 'path');
+    var android_proj = path.join(proj, 'platforms', 'android');
     var exists;
     beforeEach(function() {
         exists = spyOn(fs, 'existsSync').andReturn(true);
@@ -68,26 +70,30 @@ describe('android project parser', function() {
         it('should throw if provided directory does not contain an AndroidManifest.xml', function() {
             exists.andReturn(false);
             expect(function() {
-                new platforms.android.parser(proj);
+                new platforms.android.parser(android_proj);
             }).toThrow();
         });
         it('should create an instance with path, strings, manifest and android_config properties', function() {
             expect(function() {
-                var p = new platforms.android.parser(proj);
-                expect(p.path).toEqual(proj);
-                expect(p.strings).toEqual(path.join(proj, 'res', 'values', 'strings.xml'));
-                expect(p.manifest).toEqual(path.join(proj, 'AndroidManifest.xml'));
-                expect(p.android_config).toEqual(path.join(proj, 'res', 'xml', 'config.xml'));
+                var p = new platforms.android.parser(android_proj);
+                expect(p.path).toEqual(android_proj);
+                expect(p.strings).toEqual(path.join(android_proj, 'res', 'values', 'strings.xml'));
+                expect(p.manifest).toEqual(path.join(android_proj, 'AndroidManifest.xml'));
+                expect(p.android_config).toEqual(path.join(android_proj, 'res', 'xml', 'config.xml'));
             }).not.toThrow();
         });
         it('should be an instance of Parser', function() {
-            expect(new platforms.android.parser(proj) instanceof Parser).toBeTruthy();
+            expect(new platforms.android.parser(android_proj) instanceof Parser).toBe(true);
+        });
+        it('should call super with the correct arguments', function() {
+            var call = spyOn(Parser, 'call');
+            var p = new platforms.android.parser(android_proj);
+            expect(call).toHaveBeenCalledWith(p, 'android', android_proj);
         });
     });
 
     describe('instance', function() {
-        var p, cp, rm, mkdir, is_cordova, write, read;
-        var android_proj = path.join(proj, 'platforms', 'android');
+        var p, cp, rm, mkdir, is_cordova, write, read, getOrientation;
         var stringsRoot;
         var manifestRoot;
         beforeEach(function() {
@@ -96,7 +102,7 @@ describe('android project parser', function() {
             p = new platforms.android.parser(android_proj);
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').andReturn(android_proj);
             write = spyOn(fs, 'writeFileSync');
             read = spyOn(fs, 'readFileSync');
             mkdir = spyOn(shell, 'mkdir');
@@ -105,38 +111,51 @@ describe('android project parser', function() {
                     return stringsRoot = new et.ElementTree(et.XML(STRINGS_XML));
                 } else if (/AndroidManifest/.exec(path)) {
                     return manifestRoot = new et.ElementTree(et.XML(MANIFEST_XML));
+                } else {
+                    throw new CordovaError('Unexpected parseElementtreeSync: ' + path);
                 }
             });
+            getOrientation = spyOn(p.helper, 'getOrientation');
         });
 
         describe('update_from_config method', function() {
             beforeEach(function() {
-                spyOn(fs, 'readdirSync').andReturn([path.join(proj, 'src', 'android_pkg', 'MyApp.java')]);
+                spyOn(fs, 'readdirSync').andReturn([ path.join(android_proj, 'src', 'android_pkg', 'MyApp.java') ]);
                 cfg.name = function() { return 'testname' };
                 cfg.packageName = function() { return 'testpkg' };
                 cfg.version = function() { return 'one point oh' };
                 read.andReturn('package org.cordova.somepackage; public class MyApp extends CordovaActivity { }');
             });
 
-            it('should handle no orientation', function() {
-                cfg.getPreference = function() { return null; };
+            it('should write out the orientation preference value', function() {
+                getOrientation.andCallThrough();
                 p.update_from_config(cfg);
-                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('VAL');
+                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('landscape');
+            });
+            it('should handle no orientation', function() {
+                getOrientation.andReturn('');
+                p.update_from_config(cfg);
+                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toBeUndefined();
             });
             it('should handle default orientation', function() {
-                cfg.getPreference = function() { return 'default'; };
+                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toBeUndefined();
             });
             it('should handle portrait orientation', function() {
-                cfg.getPreference = function() { return 'portrait'; };
+                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('portrait');
             });
-            it('should handle invalid orientation', function() {
-                cfg.getPreference = function() { return 'prtrait'; };
+            it('should handle landscape orientation', function() {
+                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
                 p.update_from_config(cfg);
-                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('VAL');
+                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('landscape');
+            });
+            it('should handle custom orientation', function() {
+                getOrientation.andReturn('some-custom-orientation');
+                p.update_from_config(cfg);
+                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('some-custom-orientation');
             });
             it('should write out the app name to strings.xml', function() {
                 p.update_from_config(cfg);

--- a/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
@@ -89,7 +89,12 @@ describe('blackberry10 project parser', function() {
             expect(project).toBeDefined();
         });
         it('should be an instance of Parser', function() {
-            expect(new platforms.blackberry10.parser(proj) instanceof Parser).toBeTruthy();
+            expect(new platforms.blackberry10.parser(proj) instanceof Parser).toBe(true);
+        });
+        it('should call super with the correct arguments', function() {
+            var call = spyOn(Parser, 'call');
+            var p = new platforms.blackberry10.parser(proj);
+            expect(call).toHaveBeenCalledWith(p, 'blackberry10', proj);
         });
     });
 

--- a/cordova-lib/spec-cordova/metadata/browser_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/browser_parser.spec.js
@@ -40,7 +40,12 @@ describe('browser project parser', function() {
             }).not.toThrow();
         });
         it('should be an instance of Parser', function() {
-            expect(new platforms.browser.parser(proj) instanceof Parser).toBeTruthy();
+            expect(new platforms.browser.parser(proj) instanceof Parser).toBe(true);
+        });
+        it('should call super with the correct arguments', function() {
+            var call = spyOn(Parser, 'call');
+            var p = new platforms.browser.parser(proj);
+            expect(call).toHaveBeenCalledWith(p, 'browser', proj);
         });
     });
 

--- a/cordova-lib/spec-cordova/metadata/parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/parser.spec.js
@@ -17,16 +17,37 @@
     under the License.
 */
 
-var Parser = require('../../src/cordova/metadata/parser');
+var fs = require('fs'),
+    platforms = require('../../src/cordova/platforms.js'),
+    Parser = require('../../src/cordova/metadata/parser'),
+    ParserHelper = require('../../src/cordova/metadata/parserhelper/ParserHelper');
 
 describe('base parser', function() {
 
-    describe('instance', function() {
+    var exists, parser;
 
-        var parser;
+    beforeEach(function() {
+        exists = spyOn(fs, 'existsSync');
+        parser = new Parser();
+    });
 
-        beforeEach(function() {
-            parser = new Parser();
+    describe('properties', function() {
+
+        it('should have properties named path and platform', function() {
+            expect(parser.path).not.toBeUndefined();
+            expect(parser.platform).not.toBeUndefined();
+        });
+
+        it('should have a property named helper that is an instace of ParserHelper', function() {
+            var descriptor = Object.getOwnPropertyDescriptor(parser, 'helper');
+            expect(descriptor).not.toBeUndefined();
+            expect(descriptor.value instanceof ParserHelper).toBe(true);
+        });
+
+        it('should have an immutable helper property', function() {
+            var value = 'foo';
+            parser.helpers = value;
+            expect(parser.helper instanceof ParserHelper).toBe(true);
         });
 
     });

--- a/cordova-lib/spec-cordova/metadata/parserhelper/ParserHelper.spec.js
+++ b/cordova-lib/spec-cordova/metadata/parserhelper/ParserHelper.spec.js
@@ -1,0 +1,63 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var path = require('path'),
+    ParserHelper = require('../../../src/cordova/metadata/parserhelper/ParserHelper'),
+    ConfigParser = require('../../../src/configparser/ConfigParser');
+
+// Create a real config object before mocking out everything.
+var xml = path.join(__dirname, '..', '..', 'test-config.xml');
+var cfg = new ConfigParser(xml);
+
+describe('ParserHelper', function() {
+
+    describe('constructions', function() {
+
+        it('should pass platform name as a constructor parameter', function() {
+            var ph = new ParserHelper();
+            expect(ph.platform).toEqual('');
+            ph = new ParserHelper('some-platform');
+            expect(ph.platform).toEqual('some-platform');
+        });
+
+    });
+
+    describe('instance', function() {
+
+        var parserHelper;
+
+        beforeEach(function() {
+            parserHelper = new ParserHelper();
+        });
+
+        describe('getOrientation method', function() {
+
+            it('should return the global orientation value', function() {
+                expect(parserHelper.getOrientation(cfg)).toEqual('portrait');
+            });
+            it('should return the platform-specific orientation value', function() {
+                var parserHelperAndroid = new ParserHelper('android');
+                expect(parserHelperAndroid.getOrientation(cfg)).toEqual('landscape');
+            });
+
+        });
+
+    });
+
+});

--- a/cordova-lib/spec-cordova/metadata/parserhelper/preferences.spec.js
+++ b/cordova-lib/spec-cordova/metadata/parserhelper/preferences.spec.js
@@ -1,0 +1,113 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var path = require('path'),
+    fs = require('fs'),
+    events = require('../../../src/events'),
+    preferences = require('../../../src/cordova/metadata/parserhelper/preferences'),
+    ConfigParser = require('../../../src/configparser/ConfigParser');
+
+// Create a real config object before mocking out everything.
+var xml = path.join(__dirname, '..', '..', 'test-config.xml');
+var cfg = new ConfigParser(xml);
+
+describe('preferences', function() {
+
+    describe('properties', function() {
+
+        it('should define global orientation constants', function() {
+            expect(preferences.ORIENTATION_DEFAULT).toEqual('default');
+            expect(preferences.ORIENTATION_PORTRAIT).toEqual('portrait');
+            expect(preferences.ORIENTATION_LANDSCAPE).toEqual('landscape');
+            expect(preferences.ORIENTATION_GLOBAL_ORIENTATIONS).toEqual([ 'default', 'portrait', 'landscape' ]);
+        });
+
+    });
+
+    describe('methods', function() {
+
+        var readFile, emit;
+
+        beforeEach(function() {
+            readFile = spyOn(fs, 'readFileSync');
+            emit = spyOn(events, 'emit');
+        });
+
+        describe('isDefaultOrientation', function() {
+
+            it('should return true if an orientation is the default orientation', function() {
+                expect(preferences.isDefaultOrientation('default')).toBe(true);
+            });
+            it('should return false if an orientation is not the default orientation', function() {
+                expect(preferences.isDefaultOrientation('some-orientation')).toBe(false);
+            });
+
+        });
+
+        describe('isGlobalOrientation', function() {
+
+            it('should return true if an orientation is a global orientation', function() {
+                expect(preferences.isGlobalOrientation('portrait')).toBe(true);
+            });
+            it('should return false if an orientation is a global orientation', function() {
+                expect(preferences.isGlobalOrientation('some-orientation')).toBe(false);
+            });
+
+        });
+
+        describe('getOrientation', function() {
+
+            it('should handle no platform', function() {
+                expect(preferences.getOrientation(cfg)).toEqual('portrait');
+                expect(emit).not.toHaveBeenCalled();
+            });
+            it('should handle undefined platform-specific orientation', function() {
+                expect(preferences.getOrientation(cfg, 'ios')).toEqual('portrait');
+                expect(emit).not.toHaveBeenCalled();
+            });
+            it('should handle platform-specific orientation', function() {
+                expect(preferences.getOrientation(cfg, 'android')).toEqual('landscape');
+            });
+            it('should handle no orientation', function() {
+                var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget></widget>';
+                readFile.andReturn(configXml);
+                var configParser = new ConfigParser(xml);
+                expect(preferences.getOrientation(configParser)).toEqual('');
+                expect(emit).not.toHaveBeenCalled();
+            });
+            it('should handle invalid global orientation', function() {
+                var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><preference name="orientation" value="foobar" /></widget>';
+                readFile.andReturn(configXml);
+                var configParser = new ConfigParser(xml);
+                expect(preferences.getOrientation(configParser)).toEqual('default');
+                expect(emit).toHaveBeenCalledWith('warn', 'Unsupported global orientation: foobar');
+                expect(emit).toHaveBeenCalledWith('warn', 'Defaulting to value: default');
+            });
+            it('should handle custom platform-specific orientation', function() {
+                var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><platform name="some-platform"><preference name="orientation" value="foobar" /></platform></widget>';
+                readFile.andReturn(configXml);
+                var configParser = new ConfigParser(xml);
+                expect(preferences.getOrientation(configParser, 'some-platform')).toEqual('foobar');
+            });
+
+        });
+
+    });
+
+});

--- a/cordova-lib/spec-cordova/metadata/windows8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/windows8_parser.spec.js
@@ -91,7 +91,12 @@ describe('windows8 project parser', function() {
             }).not.toThrow();
         });
         it('should be an instance of Parser', function() {
-            expect(new platforms.windows8.parser(proj) instanceof Parser).toBeTruthy();
+            expect(new platforms.windows8.parser(proj) instanceof Parser).toBe(true);
+        });
+        it('should call super with the correct arguments', function() {
+            var call = spyOn(Parser, 'call');
+            var p = new platforms.windows8.parser(proj);
+            expect(call).toHaveBeenCalledWith(p, 'windows8', proj);
         });
     });
 

--- a/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
@@ -36,10 +36,25 @@ var platforms = require('../../src/cordova/platforms'),
 // Create a real config object before mocking out everything.
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
 
+var MANIFEST_XML, PROJ_XML, MAINPAGEXAML_XML, XAML_XML;
+MANIFEST_XML = PROJ_XML = XAML_XML = '<foo><App Title="s"><PrimaryToken /><RootNamespace/><SilverlightAppEntry/><XapFilename/><AssemblyName/></App></foo>';
+MAINPAGEXAML_XML = '<phone:PhoneApplicationPage x:Class="io.cordova.hellocordova.MainPage"' +
+    'FontFamily="{StaticResource PhoneFontFamilyNormal}" FontSize="{StaticResource PhoneFontSizeNormal}"' +
+    'Foreground="{StaticResource PhoneForegroundBrush}" Background="Black"' +
+    'SupportedOrientations="PortraitOrLandscape" Orientation="VAL"' +
+    'shell:SystemTray.IsVisible="True" d:DesignHeight="768" d:DesignWidth="480" xmlns:my="clr-namespace:WPCordovaClassLib">' +
+    '<Grid x:Name="LayoutRoot" Background="Transparent" HorizontalAlignment="Stretch">' +
+        '<Grid.RowDefinitions>' +
+            '<RowDefinition Height="*"/>' +
+        '</Grid.RowDefinitions>' +
+        '<my:CordovaView HorizontalAlignment="Stretch" Margin="0,0,0,0"  x:Name="CordovaView" VerticalAlignment="Stretch" />' +
+    '</Grid>' +
+    '</phone:PhoneApplicationPage>';
+
 describe('wp8 project parser', function() {
     var proj = '/some/path';
     var exists, exec, custom, readdir, cfg_parser, config_read;
-    var manifestXml, projXml;
+    var manifestXml, projXml, mainPageXamlXml;
     beforeEach(function() {
         exists = spyOn(fs, 'existsSync').andReturn(true);
         exec = spyOn(child_process, 'exec').andCallFake(function(cmd, opts, cb) {
@@ -57,14 +72,16 @@ describe('wp8 project parser', function() {
             : ({})
         });
         readdir = spyOn(fs, 'readdirSync').andReturn(['test.csproj']);
-        projXml = manifestXml = null;
+        projXml = manifestXml = mainPageXamlXml = null;
         spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
             if (/WMAppManifest.xml$/.exec(path)) {
-                return manifestXml = new et.ElementTree(et.XML('<foo><App Title="s"><PrimaryToken /><RootNamespace/><SilverlightAppEntry/><XapFilename/><AssemblyName/></App></foo>'));
+                return manifestXml = new et.ElementTree(et.XML(MANIFEST_XML));
             } else if (/csproj$/.exec(path)) {
-                return projXml = new et.ElementTree(et.XML('<foo><App Title="s"><PrimaryToken /><RootNamespace/><SilverlightAppEntry/><XapFilename/><AssemblyName/></App></foo>'));
+                return projXml = new et.ElementTree(et.XML(PROJ_XML));
+            } else if (/MainPage.xaml$/.exec(path)) {
+                return mainPageXamlXml = new et.ElementTree(et.XML(MAINPAGEXAML_XML));
             } else if (/xaml$/.exec(path)) {
-                return new et.ElementTree(et.XML('<foo><App Title="s"><PrimaryToken /><RootNamespace/><SilverlightAppEntry/><XapFilename/><AssemblyName/></App></foo>'));
+                return new et.ElementTree(et.XML(XAML_XML));
             } else {
                 throw new CordovaError('Unexpected parseElementtreeSync: ' + path);
             }
@@ -98,12 +115,17 @@ describe('wp8 project parser', function() {
             }).not.toThrow();
         });
         it('should be an instance of Parser', function() {
-            expect(new platforms.wp8.parser(proj) instanceof Parser).toBeTruthy();
+            expect(new platforms.wp8.parser(proj) instanceof Parser).toBe(true);
+        });
+        it('should call super with the correct arguments', function() {
+            var call = spyOn(Parser, 'call');
+            var p = new platforms.wp8.parser(proj);
+            expect(call).toHaveBeenCalledWith(p, 'wp8', proj);
         });
     });
 
     describe('instance', function() {
-        var p, cp, rm, is_cordova, write, read, mv, mkdir;
+        var p, cp, rm, is_cordova, write, read, mv, mkdir, getOrientation;
         var wp8_proj = path.join(proj, 'platforms', 'wp8');
         beforeEach(function() {
             p = new platforms.wp8.parser(wp8_proj);
@@ -114,6 +136,7 @@ describe('wp8 project parser', function() {
             is_cordova = spyOn(util, 'isCordova').andReturn(proj);
             write = spyOn(fs, 'writeFileSync');
             read = spyOn(fs, 'readFileSync').andReturn('');
+            getOrientation = spyOn(p.helper, 'getOrientation');
         });
 
         describe('update_from_config method', function() {
@@ -139,6 +162,42 @@ describe('wp8 project parser', function() {
                 p.update_from_config(cfg);
                 var appEl = manifestXml.getroot().find('.//App');
                 expect(appEl.attrib.Version).toEqual('one point oh');
+            });
+            it('should write out the orientation preference value', function() {
+                getOrientation.andCallThrough();
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait')
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
+            });
+            it('should handle no orientation', function() {
+                getOrientation.andReturn('');
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toBeUndefined();
+            });
+            it('should handle default orientation', function() {
+                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toBeUndefined();
+            });
+            it('should handle portrait orientation', function() {
+                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait')
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
+            });
+            it('should handle landscape orientation', function() {
+                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('landscape')
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('landscape');
+            });
+            it('should handle custom orientation', function() {
+                getOrientation.andReturn('some-custom-orientation');
+                p.update_from_config(cfg);
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('some-custom-orientation');
             });
         });
         describe('www_dir method', function() {

--- a/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
+++ b/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
@@ -40,7 +40,7 @@ function amazon_fireos_parser(project) {
     }
 
     // Call the base class constructor
-    Parser.apply(this, arguments);
+    Parser.call(this, 'amazon_fireos', project);
 
     this.path = project;
     this.strings = path.join(this.path, 'res', 'values', 'strings.xml');
@@ -51,16 +51,6 @@ function amazon_fireos_parser(project) {
 require('util').inherits(amazon_fireos_parser, Parser);
 
 module.exports = amazon_fireos_parser;
-
-amazon_fireos_parser.prototype.findOrientationPreference = function(config) {
-    var ret = config.getPreference('orientation');
-    if (ret && ret != 'default' && ret != 'portrait' && ret != 'landscape') {
-        events.emit('warn', 'Unknown value for orientation preference: ' + ret);
-        ret = null;
-    }
-
-    return ret;
-};
 
 amazon_fireos_parser.prototype.findAndroidLaunchModePreference = function(config) {
     var launchMode = config.getPreference('AndroidLaunchMode');
@@ -241,19 +231,13 @@ amazon_fireos_parser.prototype.update_from_config = function(config) {
 
     var act = manifest.getroot().find('./application/activity');
 
-     // Set the orientation in the AndroidManifest
-    var orientationPref = this.findOrientationPreference(config);
-    if (orientationPref) {
-        switch (orientationPref) {
-            case 'default':
-                delete act.attrib['android:screenOrientation'];
-                break;
-            case 'portrait':
-                act.attrib['android:screenOrientation'] = 'portrait';
-                break;
-            case 'landscape':
-                act.attrib['android:screenOrientation'] = 'landscape';
-        }
+    // Set the android:screenOrientation in the AndroidManifest
+    var orientation = this.helper.getOrientation(config);
+
+    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
+        act.attrib['android:screenOrientation'] = orientation;
+    } else {
+        delete act.attrib['android:screenOrientation'];
     }
 
     // Set android:launchMode in AndroidManifest

--- a/cordova-lib/src/cordova/metadata/blackberry10_parser.js
+++ b/cordova-lib/src/cordova/metadata/blackberry10_parser.js
@@ -37,7 +37,7 @@ function blackberry_parser(project) {
     }
 
     // Call the base class constructor
-    Parser.apply(this, arguments);
+    Parser.call(this, 'blackberry10', project);
 
     this.path = project;
     this.config_path = path.join(this.path, 'www', 'config.xml');

--- a/cordova-lib/src/cordova/metadata/browser_parser.js
+++ b/cordova-lib/src/cordova/metadata/browser_parser.js
@@ -32,7 +32,7 @@ var fs = require('fs'),
 function browser_parser(project) {
 
     // Call the base class constructor
-    Parser.apply(this, arguments);
+    Parser.call(this, 'browser', project);
 
     this.path = project;
 }

--- a/cordova-lib/src/cordova/metadata/firefoxos_parser.js
+++ b/cordova-lib/src/cordova/metadata/firefoxos_parser.js
@@ -34,7 +34,7 @@ var fs = require('fs'),
 function firefoxos_parser(project) {
 
     // Call the base class constructor
-    Parser.apply(this, arguments);
+    Parser.call(this, 'firefoxos', project);
 
     this.path = project;
     this.config_path = path.join(project, 'config.xml');
@@ -85,16 +85,13 @@ firefoxos_parser.prototype.update_from_config = function(config) {
         manifest.fullscreen = fullScreen;
     }
 
-    var orientations = [];
-    var preferenceNodes = config.doc.findall('preference');
-    preferenceNodes.forEach(function (preference) {
-        if (preference.attrib.name.toLowerCase() === 'orientation') {
-            orientations.push(preference.attrib.value);
-        }
-    });
+    // Set orientation preference
+    var orientation = this.helper.getOrientation(config);
 
-    if (orientations && orientations.length) {
-        manifest.orientation = orientations;
+    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
+        manifest.orientation = [ orientation ];
+    } else {
+        delete manifest.orientation;
     }
 
     var permissionNodes = config.doc.findall('permission');

--- a/cordova-lib/src/cordova/metadata/parserhelper/ParserHelper.js
+++ b/cordova-lib/src/cordova/metadata/parserhelper/ParserHelper.js
@@ -23,27 +23,24 @@
 
 'use strict';
 
-var ParserHelper = require('./parserhelper/ParserHelper');
+var extend = require('underscore').extend;
+var preferences = require('./preferences');
 
 /**
- * Base module for platform parsers
+ * Helper module for platform parsers
  *
- * @param {String} [platform]    Platform name (e.g. android)
- * @param {String} [projectPath] path/to/platform/project
+ * @param {String} [platform] Platform name (e.g. android)
  */
-function Parser (platform, projectPath) {
-
+function ParserHelper(platform) {
     this.platform = platform || '';
-    this.path = projectPath || '';
-
-    // Extend with a ParserHelper instance
-    Object.defineProperty(this, 'helper', {
-        value: new ParserHelper(this.platform),
-        enumerable: true,
-        configurable: false,
-        writable: false
-    });
-
 }
 
-module.exports = Parser;
+// Extend with helpers
+extend(ParserHelper.prototype, preferences);
+
+// Override getOrientation()
+ParserHelper.prototype.getOrientation = function (config) {
+    return preferences.getOrientation(config, this.platform);
+};
+
+module.exports = ParserHelper;

--- a/cordova-lib/src/cordova/metadata/parserhelper/preferences.js
+++ b/cordova-lib/src/cordova/metadata/parserhelper/preferences.js
@@ -1,0 +1,86 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
+          indent:4, unused:vars, latedef:nofunc, sub:true
+*/
+
+'use strict';
+
+var events = require('../../../events');
+
+var _ORIENTATION_DEFAULT = 'default';
+var _ORIENTATION_PORTRAIT = 'portrait';
+var _ORIENTATION_LANDSCAPE = 'landscape';
+var _ORIENTATION_GLOBAL_ORIENTATIONS = [ _ORIENTATION_DEFAULT, _ORIENTATION_PORTRAIT, _ORIENTATION_LANDSCAPE ];
+
+module.exports = {
+
+    ORIENTATION_DEFAULT: _ORIENTATION_DEFAULT,
+    ORIENTATION_PORTRAIT: _ORIENTATION_PORTRAIT,
+    ORIENTATION_LANDSCAPE: _ORIENTATION_LANDSCAPE,
+    ORIENTATION_GLOBAL_ORIENTATIONS: _ORIENTATION_GLOBAL_ORIENTATIONS,
+
+    /**
+     * @param  {String}  orientation Orientation
+     * @return {Boolean}             True if the value equals ORIENTATION_DEFAULT
+     */
+    isDefaultOrientation: function (orientation) {
+        return orientation.toLowerCase() === this.ORIENTATION_DEFAULT.toLowerCase();
+    },
+
+    /**
+     * @param  {String}  orientation Orientation
+     * @return {Boolean}             True if the value equals one of _ORIENTATION_SUPPORTED_GLOBAL_ORIENTATIONS
+     */
+    isGlobalOrientation: function (orientation) {
+        return this.ORIENTATION_GLOBAL_ORIENTATIONS.some(function (supportedOrientation) {
+            return orientation.toLowerCase() === supportedOrientation.toLowerCase();
+        });
+    },
+
+    /**
+     * Queries ConfigParser object for the orientation <preference> value.
+     *
+     * @param  {Object} config    ConfigParser object
+     * @param  {String} [platform]  Platform name
+     * @return {String}           Global/platform-specific orientation in lower-case (or empty string if both are undefined)
+     */
+    getOrientation: function (config, platform) {
+
+        var platformOrientation = platform ? config.getPlatformPreference('orientation', platform) : '';
+        var globalOrientation = '';
+
+        if (platformOrientation) {
+            return platformOrientation;
+        }
+
+        globalOrientation = config.getGlobalPreference('orientation');
+
+        // Check if the given global orientation is supported
+        if (globalOrientation && !this.isGlobalOrientation(globalOrientation)) {
+            events.emit( 'warn', [ 'Unsupported global orientation:', globalOrientation ].join(' ') );
+            events.emit( 'warn', [ 'Defaulting to value:', this.ORIENTATION_DEFAULT ].join(' ') );
+            globalOrientation = this.ORIENTATION_DEFAULT;
+        }
+
+        return globalOrientation;
+    }
+
+};

--- a/cordova-lib/src/cordova/metadata/ubuntu_parser.js
+++ b/cordova-lib/src/cordova/metadata/ubuntu_parser.js
@@ -34,7 +34,7 @@ var fs            = require('fs'),
 function ubuntu_parser(project) {
 
     // Call the base class constructor
-    Parser.apply(this, arguments);
+    Parser.call(this, 'ubuntu', project);
 
     this.path = project;
     this.config = new ConfigParser(this.config_xml());

--- a/cordova-lib/src/cordova/metadata/windows_parser.js
+++ b/cordova-lib/src/cordova/metadata/windows_parser.js
@@ -35,9 +35,6 @@ var fs            = require('fs'),
 
 function windows_parser(project) {
 
-    // Call the base class constructor
-    Parser.apply(this, arguments);
-
     try {
         this.isOldProjectTemplate = false;
         // Check that it's a universal windows store project
@@ -49,6 +46,10 @@ function windows_parser(project) {
         if (!projFile) {
             throw new CordovaError('No project file in "'+project+'"');
         }
+
+        // Call the base class constructor
+        Parser.call(this, 'windows8', project);
+
         this.projDir = project;
         this.projFilePath = path.join(this.projDir, projFile);
 


### PR DESCRIPTION
Fixes [CB-8043](https://issues.apache.org/jira/browse/CB-8043), [CB-6462](https://issues.apache.org/jira/browse/CB-6462) and [CB-6105](https://issues.apache.org/jira/browse/CB-6105). Touches [CB-6182](https://issues.apache.org/jira/browse/CB-6182).

Adds support for the global & platform-specific orientation preference (iOS, WP8 and FirefoxOS). Android and Amazon Fire OS already had this functionality. Additionally, the change will allow specifying a custom value  for the platform-specific orientation preference.  If need be I'd be happy to update the [docs](http://cordova.apache.org/docs/en/4.0.0/config_ref_index.md.html) accordingly.

As a future improvement the orientation preference could offer a similar level of granularity to that of the native APIs. For example, iOS & WP8 APIs allow setting both an initial orientation as well as a set of supported orientations for an app. For now, developers will have to resort to a custom approach in their Cordova builds in case they've such needs.

Tested on OS X Mavericks & Windows 8 running VS 2013.