### PR TITLE
CB-8154 - Fix errors adding platforms or plugins

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -39,6 +39,7 @@ var path          = require('path'),
     URL           = require('url'),
     Q             = require('q'),
     npm           = require('npm'),
+    unpack        = require('../util/unpack'),
     util          = require('./util'),
     stubplatform  = {
         url    : undefined,
@@ -160,7 +161,9 @@ function npm_cache_add(pkg) {
         return Q.ninvoke(npm.commands, 'cache', ['add', pkg]);
     }).then(function(info) {
         var pkgDir = path.resolve(npm.cache, info.name, info.version, 'package');
-        return pkgDir;
+        // Unpack the package that was added to the cache (CB-8154)
+        var package_tgz = path.resolve(npm.cache, info.name, info.version, 'package.tgz');
+        return unpack.unpackTgz(package_tgz, pkgDir);
     });
 }
 

--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -32,6 +32,7 @@ var npm = require('npm'),
     request = require('request'),
     home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE,
     events = require('../../events'),
+    unpack = require('../../util/unpack'),
     plugmanConfigDir = path.resolve(home, '.plugman'),
     plugmanCacheDir = path.resolve(plugmanConfigDir, 'cache');
 
@@ -166,7 +167,9 @@ module.exports = {
             var cl = (client === 'plugman' ? 'plugman' : 'cordova-cli');
             bumpCounter(info, cl);
             var pluginDir = path.resolve(npm.cache, info.name, info.version, 'package');
-            return pluginDir;
+            // Unpack the plugin that was added to the cache (CB-8154)
+            var package_tgz = path.resolve(npm.cache, info.name, info.version, 'package.tgz');
+            return unpack.unpackTgz(package_tgz, pluginDir);
         });
     },
 

--- a/cordova-lib/src/util/unpack.js
+++ b/cordova-lib/src/util/unpack.js
@@ -1,0 +1,39 @@
+// commands for packing and unpacking tarballs
+// this file is used by lib/cache.js
+
+var events = require('../events'),
+    fs     = require("fs"),
+    path   = require("path"),
+    Q      = require('q'),
+    tar    = require("tar"),
+    zlib   = require("zlib");
+
+exports.unpackTgz = unpackTgz;
+
+// Returns a promise for the path to the unpacked tarball (unzip + untar).
+function unpackTgz(package_tgz, unpackTarget) {
+    return Q.promise(function(resolve, reject) {
+//        var inputStream = fs.createReadStream(package_tgz);
+        var extractOpts = { type: "Directory", path: unpackTarget, strip: 1 };
+
+        fs.createReadStream(package_tgz)
+        .on("error", function (err) {
+            events.emit('verbose', 'Unable to open tarball ' + package_tgz + ': ' + err);
+            reject(err);
+        })
+        .pipe(zlib.createUnzip())
+        .on("error", function (err) {
+            events.emit('verbose', 'Error during unzip for ' + package_tgz + ': ' + err);
+            reject(err);
+        })
+        .pipe(tar.Extract(extractOpts))
+        .on('error', function(err) {
+            events.emit('verbose', 'Error during untar for ' + package_tgz + ': ' + err);
+            reject(err);
+        })
+        .on("end", resolve);
+    })
+    .then(function() {
+        return unpackTarget;
+    });
+}


### PR DESCRIPTION
- Added utility function to unpack a package.tgz file (gzip + tar)
- Use the new utility function when fetching plugins from the registry
- Use the new utility function when downloading platforms from the registry
- This compensates for the change in npm behaviour that no longer unpacks
  files that are added to the npm cached (change in 1.4.10)
