### PR TITLE
CB-8190 Make plugman config/cache directory to be customizable via PLUGMAN_HOME

### DIFF
--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -33,7 +33,8 @@ var npm = require('npm'),
     home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE,
     events = require('../../events'),
     unpack = require('../../util/unpack'),
-    plugmanConfigDir = path.resolve(home, '.plugman'),
+    // if PLUGMAN_HOME env var is specified use it as config directory (see CB-8190)
+    plugmanConfigDir = process.env.PLUGMAN_HOME || path.resolve(home, '.plugman'),
     plugmanCacheDir = path.resolve(plugmanConfigDir, 'cache');
 
 


### PR DESCRIPTION
Implementation for [CB-8190](https://issues.apache.org/jira/browse/CB-8190)

Introduces `PLUGMAN_HOME` environment variable which specifies alternate location for plugman config/cache similar to https://github.com/apache/cordova-lib/pull/104
