### PR TITLE
CB-8239 Add support for git urls to 'cordova platform add'

### DIFF
--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -20,7 +20,8 @@ var cordova = require('../src/cordova/cordova'),
     shell = require('shelljs'),
     path = require('path'),
     fs = require('fs'),
-    util = require('../src/cordova/util'),
+    rewire = require('rewire'),
+    util = rewire('../src/cordova/util'),
     temp = path.join(__dirname, '..', 'temp'),
     fixtures = path.join(__dirname, 'fixtures');
 
@@ -182,5 +183,139 @@ describe('util module', function() {
             expect(res.length).toEqual(2);
             expect(res.indexOf('CVS')).toEqual(-1);
         });
+    });
+    describe('getPlatformDetailsFromDir function', function(){
+
+	var dir = 'C:\\Projects\\cordova-projects\\cordova-android';
+	var getPackageJsonContentOriginal = util.__get__('getPackageJsonContent');
+	var resolvePathOriginal = util.__get__('resolvePath');
+	var getPlatformDetailsFromDir = util.__get__('getPlatformDetailsFromDir'); // function under test
+
+	beforeEach(function() {
+	    util.__set__('getPackageJsonContent', function (p) {
+		return p + '\\package';
+            });
+	    util.__set__('resolvePath', function(p){
+		return p;
+	    });
+	});
+
+	afterEach(function() {
+	    util.__set__('getPackageJsonContent', getPackageJsonContentOriginal);
+	    util.__set__('resolvePath', resolvePathOriginal);
+	});
+	
+	it('returns the appropriate platform details', function(done){
+
+            // Mock out package.json content
+            util.__set__('getPackageJsonContent', function (p) {
+		return {
+                    'name': 'cordova-android',
+                    'version': '3.7.0-dev',
+                    'description': 'cordova-android release',
+                    'main': 'bin/create'
+		};
+            });
+
+            getPlatformDetailsFromDir(dir).then(function (platformDetails) {
+		expect(platformDetails.platform).toBe('android');
+		expect(platformDetails.libDir).toBe(dir);
+		done();
+            });
+	});
+
+	it('throws if the directory supplied does not contain a package.json file', function (done) {
+
+            util.__set__('getPackageJsonContent', function (p) {
+		var pPath = path.join(p, 'package');
+		var msg = "Cannot find module '" + pPath + "'";
+		var err = new Error(msg);
+		err.code = 'MODULE_NOT_FOUND';
+		throw err;
+            });
+
+            getPlatformDetailsFromDir(dir).fail(function (error) {
+		var packagePath = path.join(dir, 'package');
+		expect(error.message).toBe('The provided path does not seem to contain a Cordova platform: ' + dir +
+					   '\n' + 'Cannot find module ' + "'" + packagePath + "'");
+		done();
+            });
+	});
+
+	it('replaces "amazon" by "amazon-fireos" if package.json returns "amazon"', function (done) {
+
+            var dir = 'C:\\Projects\\cordova-projects\\cordova-amazon-fireos';
+
+            util.__set__('getPackageJsonContent', function (p) {
+		return {
+                    'name': 'cordova-amazon', // use 'cordova-amazon' instead of 'cordova-amazon-fireos'
+                    'version': '3.7.0-dev',
+                    'description': 'cordova-amazon-fireos release',
+                    'main': 'bin/create'
+		};
+            });
+
+            getPlatformDetailsFromDir(dir).then(function (platformDetails) {
+		expect(platformDetails.libDir).toBe(dir);
+		expect(platformDetails.platform).toBe('amazon-fireos');
+		done();
+            });
+	});
+
+	it('throws if package.json file has no name property', function (done) {
+	    
+            util.__set__('getPackageJsonContent', function (p) {
+		return {
+		    //name: 'cordova-android' --> No name
+		};
+            });
+
+            getPlatformDetailsFromDir(dir).fail(function (error) {
+		var packagePath = path.join(dir, 'package');
+		expect(error.message).toBe('The provided path does not seem to contain a ' + 'Cordova platform: ' + dir);
+		done();
+            });
+	});
+
+	it('throws if package.json file returns null', function (done) {
+	    
+            util.__set__('getPackageJsonContent', function (p) {
+		return null;
+            });
+
+            getPlatformDetailsFromDir(dir).fail(function (error) {
+		var packagePath = path.join(dir, 'package');
+		expect(error.message).toBe('The provided path does not seem to contain a ' + 'Cordova platform: ' + dir);
+		done();
+            });
+	});
+
+	it('throws if the name in package.json file is not a recognized platform', function (done) {
+
+            // These are the only 'recognized' platforms
+            util.__set__('platforms', {
+		"ios": {
+                    "hostos": ["darwin"],
+                    "parser": "./metadata/ios_parser",
+                    "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-ios.git",
+                    "version": "3.7.0"
+		}
+            });
+
+            util.__set__('getPackageJsonContent', function () {
+		return {
+                    'name': 'cordova-android',
+                    'version': '3.7.0-dev',
+                    'description': 'cordova-android release',
+                    'main': 'bin/create'
+		};
+            });
+
+            getPlatformDetailsFromDir(dir).fail(function (error) {
+		var packagePath = path.join(dir, 'package');
+		expect(error.message).toBe('The provided path does not seem to contain a ' + 'Cordova platform: ' + dir);
+		done();
+            });
+	});
     });
 });

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -39,6 +39,7 @@ var config            = require('./config'),
     semver            = require('semver'),
     unorm             = require('unorm'),
     shell             = require('shelljs'),
+    util              = require('./util'),
     _                 = require('underscore');
 
 // Expose the platform parsers on top of this command
@@ -76,97 +77,94 @@ function add(hooksRunner, projectRoot, targets, opts) {
     }
 
     return hooksRunner.fire('before_platform_add', opts)
-    .then(function() {
-        return promiseutil.Q_chainmap(targets, function(target) {
-            // For each platform, download it and call its "create" script.
-            var parts = target.split('@');
-            var platform = parts[0];
-            var version = parts[1];
+	.then(function () {
+	    return promiseutil.Q_chainmap(targets, function (target) {
 
-            return Q.when().then(function() {
-                if (!(platform in platforms)) {
-                    return getPlatformDetailsFromDir(target);
-                } else {
-                    if (!version) {
-                        events.emit('verbose', 'No version supplied. Retrieving version from config.xml...');
-                    }
-                    version = version || getVersionFromConfigFile(platform, cfg);
-                    var tgt = version ? (platform + '@' + version) : platform;
-                    return isDirectory(version) ? getPlatformDetailsFromDir(version) : downloadPlatform(projectRoot, tgt, opts);
-                }
-            }).then(function(platDetails) {
-                var template = config_json && config_json.lib && config_json.lib[platform] && config_json.lib[platform].template || null;
-                return call_into_create(platDetails.platform, projectRoot, cfg, platDetails.libDir, template, opts);
-            });
-        });
-    })
-    .then(function() {
-        return hooksRunner.fire('after_platform_add', opts);
-    });
+	        // For each platform, download it and call its "create" script.
+	        var parts = target.split('@');
+	        var platform = parts[0];
+	        var version = parts[1];
+
+	        return Q.when().then(function () {
+	            if (!(platform in platforms)) {
+	                // First, try handling 'platform' as a directory, if it fails, try handling it as a git repository
+		        return Q.fcall(function () {
+	                    return util.getPlatformDetailsFromDir(target);
+	                }).fail(function (err) {
+	                    // Maybe it's a git repo
+	                    events.emit('verbose', err);
+	                    events.emit('verbose', 'Could not find local folder ' + target + '. Try to handle it as git repository.');
+	                    return cloneGitRepo(target);
+	                });
+	            }
+	            else {
+	                if (!version) {
+	                    events.emit('verbose', 'No version supplied. Retrieving version from config.xml...');
+	                }
+	                version = version || getVersionFromConfigFile(platform, cfg);
+	                var tgt = version ? (platform + '@' + version) : platform;
+
+	                if (isDirectory(version)) {
+	                    return util.getPlatformDetailsFromDir(version);
+	                }
+
+	                return Q.fcall(function () {
+	                    return downloadPlatform(projectRoot, tgt, opts);
+	                }).fail(function (err) {
+	                    // Maybe it's a git repo
+	                    events.emit('verbose', err);
+	                    events.emit('verbose', 'Could not download platform ' + tgt + '. Try to handle ' + version + ' as git repository.');
+	                    return cloneGitRepo(version);
+	                });
+	            }
+	        }).then(function (platDetails) {
+	            var template = config_json && config_json.lib && config_json.lib[platform] && config_json.lib[platform].template || null;
+	            return call_into_create(platDetails.platform, projectRoot, cfg, platDetails.libDir, template, opts);
+	        }).fail(function (error) {
+	            throw new CordovaError('Unable to add platform ' + target + '. Make sure to provide a valid version, an existing folder or an accessible git repository: ' +
+                           error);
+	        });
+	    }).then(function () {
+	        return hooksRunner.fire('after_platform_add', opts);
+	    });
+	});
 }
 
-function isDirectory(dir) {
-    try {
+function isDirectory(dir){
+    try{
 	return fs.lstatSync(dir).isDirectory();
-    } catch(e) {
-	return false;
     }
+    catch(e){
+	return false;
+    }   
+}
+
+function cloneGitRepo(gitRepo)
+{
+    // Check all exit points and make sure their return types match to expected one.
+    return lazy_load.git_clone(gitRepo)
+        .then(function(clone) {
+	    // After cloning, retrieve the platform details from dir
+	    return util.getPlatformDetailsFromDir(clone.libDir);
+        })
+        .then(function(platDetails){
+	    return platDetails;
+	});
 }
 
 // Returns a Promise
 function downloadPlatform(projectRoot, target, opts) {
+
     // Using lazy_load for a platform specified by name
     return lazy_load.based_on_config(projectRoot, target, opts)
-    .then(function (libDir) {
-        return {
-            platform: target.split('@')[0],
-            libDir: libDir
-        };
-    }).fail(function (err) {
-        throw new CordovaError('Unable to fetch platform ' + target + ': ' + err);
-    });
-}
-
-function getPackageJsonContent(pPath) {
-    return require(path.join(pPath, 'package'));
-}
-
-function resolvePath(pPath){
-    return path.resolve(pPath);
-}
-
-// Returns a Promise
-// Gets platform details from a directory
-function getPlatformDetailsFromDir(dir){
-    var pkg;
-    var pPath = resolvePath(dir);
-
-    // Prep the message in advance, we might need it in several places.
-    var msg = 'The provided path does not seem to contain a ' +
-        'Cordova platform: ' + dir;
-    try {
-        pkg = getPackageJsonContent(pPath);
-    } catch(e) {
-	return Q.reject(new CordovaError(msg + '\n' + e.message));
-    }
-    if ( !pkg || !pkg.name ) {
-	return Q.reject(new CordovaError(msg));
-    }
-    // Package names for Cordova platforms look like "cordova-ios".
-    var nameParts = pkg.name.split('-');
-    var name = nameParts[1];
-    if (name == 'amazon') {
-        name = 'amazon-fireos';
-    }
-    if (!platforms[name]) {
-	return Q.reject(new CordovaError(msg));
-    }
-
-    // Use a fulfilled promise with the platform name and path as value to skip downloading.
-    return Q({
-	platform: name,
-	libDir: pPath
-    });
+	.then(function (libDir) {
+	    return {
+	        platform: target.split('@')[0],
+	        libDir: libDir
+	    };
+	}).fail(function (err) {
+	    throw new CordovaError('Unable to fetch platform ' + target + ': ' + err);
+	});
 }
 
 function getVersionFromConfigFile(platform, cfg) {
@@ -423,7 +421,7 @@ function platform(command, targets, opts) {
             // Neither path, nor platform name - throw.
             var msg;
             if (/[~:/\\.]/.test(t)) {
-                msg = 'Platform path "' + t + '" not found.';
+                return;
             } else {
                 msg = 'Platform "' + t +
                 '" not recognized as a core cordova platform. See `' +


### PR DESCRIPTION
CB-8239 Add support for git urls to 'cordova platform add'

These changes allow the following scenarios:
     *users can issue 'cordova platform add https://github.com/apache/cordova-android.git' and the git repo will be cloned and used.
     *users can issue 'cordova platform add android@https://github.com/apache/cordova-android.git' and the git repo will be cloned and used.
     *users can issue 'cordova platform add android' and if their config.xml file contains: '<engine id='android'      version='https://github.com/apache/cordova-android.git' />, then the git repo pointed to by config.xml will be cloned and used.