### PR TITLE
CB-8223 Expose config.xml in the Browser platform

### DIFF
--- a/cordova-lib/src/cordova/metadata/browser_parser.js
+++ b/cordova-lib/src/cordova/metadata/browser_parser.js
@@ -90,5 +90,8 @@ browser_parser.prototype.update_project = function(cfg) {
         .then(function(){
             this.update_overrides();
             util.deleteSvnFolders(this.www_dir());
+
+            // Copy munged config.xml to platform www dir
+            shell.cp('-rf', path.join(this.www_dir(), '..', 'config.xml'), this.www_dir());
         }.bind(this));
 };


### PR DESCRIPTION
Added step for copying platform munged `config.xml` to platform `www` directory near the `index.html`

[Corresponding JIRA issue](https://issues.apache.org/jira/browse/CB-8223)