### PR TITLE
CB-6973 Improving JSHint for src folder

### DIFF
--- a/cordova-lib/src/.jshintrc
+++ b/cordova-lib/src/.jshintrc
@@ -1,0 +1,10 @@
+{
+    "node": true
+  , "bitwise": true
+  , "undef": true
+  , "trailing": true
+  , "quotmark": true
+  , "indent": 4
+  , "unused": "vars"
+  , "latedef": "nofunc"
+}

--- a/cordova-lib/src/CordovaError.js
+++ b/cordova-lib/src/CordovaError.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          proto:true
-*/
+/* jshint proto:true */
 
 // A derived exception class. See usage example in cli.js
 // Based on:

--- a/cordova-lib/src/PluginInfo.js
+++ b/cordova-lib/src/PluginInfo.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true, laxcomma:true, laxbreak:true
-*/
+/* jshint sub:true, laxcomma:true, laxbreak:true */
 
 /*
 A class for holidng the information currently stored in plugin.xml

--- a/cordova-lib/src/PluginInfoProvider.js
+++ b/cordova-lib/src/PluginInfoProvider.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true, laxcomma:true, laxbreak:true
-*/
+/* jshint sub:true, laxcomma:true, laxbreak:true */
 
 var fs = require('fs');
 var path = require('path');

--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var et = require('elementtree'),
     xml= require('../util/xml-helpers'),

--- a/cordova-lib/src/cordova/build.js
+++ b/cordova-lib/src/cordova/build.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordovaUtil      = require('./util'),
     HooksRunner           = require('../hooks/HooksRunner');
 

--- a/cordova-lib/src/cordova/compile.js
+++ b/cordova-lib/src/cordova/compile.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var path              = require('path'),
     cordova_util      = require('./util'),
     HooksRunner            = require('../hooks/HooksRunner'),

--- a/cordova-lib/src/cordova/config.js
+++ b/cordova-lib/src/cordova/config.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var path          = require('path'),
     fs            = require('fs'),
     url           = require('url'),

--- a/cordova-lib/src/cordova/cordova.js
+++ b/cordova-lib/src/cordova/cordova.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_events = require('../events');
 var cordova_util = require('./util');
 

--- a/cordova-lib/src/cordova/create.js
+++ b/cordova-lib/src/cordova/create.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var path          = require('path'),
     fs            = require('fs'),
     shell         = require('shelljs'),

--- a/cordova-lib/src/cordova/emulate.js
+++ b/cordova-lib/src/cordova/emulate.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util      = require('./util'),
     path              = require('path'),
     HooksRunner            = require('../hooks/HooksRunner'),

--- a/cordova-lib/src/cordova/info.js
+++ b/cordova-lib/src/cordova/info.js
@@ -17,10 +17,6 @@ specific language governing permissions and limitations
 under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 /*
 A utility funciton to help output the information needed
 when submitting a help request.

--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 // The URL:true below prevents jshint error "Redefinition or 'URL'."
 /* globals URL:true */
 

--- a/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
+++ b/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var fs            = require('fs'),
     path          = require('path'),
     et            = require('elementtree'),

--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var fs            = require('fs'),
     path          = require('path'),
     et            = require('elementtree'),

--- a/cordova-lib/src/cordova/metadata/blackberry10_parser.js
+++ b/cordova-lib/src/cordova/metadata/blackberry10_parser.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var fs            = require('fs'),
     path          = require('path'),
     shell         = require('shelljs'),

--- a/cordova-lib/src/cordova/metadata/browser_parser.js
+++ b/cordova-lib/src/cordova/metadata/browser_parser.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var fs = require('fs'),
     path = require('path'),

--- a/cordova-lib/src/cordova/metadata/firefoxos_parser.js
+++ b/cordova-lib/src/cordova/metadata/firefoxos_parser.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var fs = require('fs'),
     path = require('path'),

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var fs            = require('fs'),
     unorm         = require('unorm'),

--- a/cordova-lib/src/cordova/metadata/parser.js
+++ b/cordova-lib/src/cordova/metadata/parser.js
@@ -17,9 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
+/* jshint sub:true */
 
 'use strict';
 

--- a/cordova-lib/src/cordova/metadata/parserhelper/ParserHelper.js
+++ b/cordova-lib/src/cordova/metadata/parserhelper/ParserHelper.js
@@ -17,9 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
+/* jshint sub:true */
 
 'use strict';
 

--- a/cordova-lib/src/cordova/metadata/parserhelper/preferences.js
+++ b/cordova-lib/src/cordova/metadata/parserhelper/preferences.js
@@ -17,9 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
+/* jshint sub:true */
 
 'use strict';
 

--- a/cordova-lib/src/cordova/metadata/ubuntu_parser.js
+++ b/cordova-lib/src/cordova/metadata/ubuntu_parser.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var fs            = require('fs'),
     path          = require('path'),

--- a/cordova-lib/src/cordova/metadata/windows_parser.js
+++ b/cordova-lib/src/cordova/metadata/windows_parser.js
@@ -17,9 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
+/* jshint sub:true */
 
 var fs            = require('fs'),
     path          = require('path'),

--- a/cordova-lib/src/cordova/metadata/wp8_parser.js
+++ b/cordova-lib/src/cordova/metadata/wp8_parser.js
@@ -17,9 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
+/* jshint sub:true */
 
 var fs            = require('fs'),
     path          = require('path'),

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var config            = require('./config'),
     cordova           = require('./cordova'),
     cordova_util      = require('./util'),

--- a/cordova-lib/src/cordova/platforms.js
+++ b/cordova-lib/src/cordova/platforms.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var platforms = require('./platformsConfig.json');
 
 var addModuleProperty = require('./util').addModuleProperty;

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util  = require('./util'),
     path          = require('path'),
     semver        = require('semver'),

--- a/cordova-lib/src/cordova/plugin_parser.js
+++ b/cordova-lib/src/cordova/plugin_parser.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var xml = require('../util/xml-helpers');
 
 /** Deprecated. Use PluginInfo instead. */

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util      = require('./util'),
     ConfigParser      = require('../configparser/ConfigParser'),
     path              = require('path'),

--- a/cordova-lib/src/cordova/restore.js
+++ b/cordova-lib/src/cordova/restore.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util    = require('./util'),
     ConfigParser     = require('../configparser/ConfigParser'),
     path             = require('path'),

--- a/cordova-lib/src/cordova/run.js
+++ b/cordova-lib/src/cordova/run.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util      = require('./util'),
     path              = require('path'),
     HooksRunner            = require('../hooks/HooksRunner'),

--- a/cordova-lib/src/cordova/save.js
+++ b/cordova-lib/src/cordova/save.js
@@ -17,11 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
-
 var path             = require('path'),
     Q                = require('q'),
     cordova_util     = require('./util'),

--- a/cordova-lib/src/cordova/serve.js
+++ b/cordova-lib/src/cordova/serve.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var cordova_util = require('./util'),
     crypto = require('crypto'),
     path = require('path'),

--- a/cordova-lib/src/cordova/superspawn.js
+++ b/cordova-lib/src/cordova/superspawn.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var child_process = require('child_process');
 var fs = require('fs');
 var path = require('path');

--- a/cordova-lib/src/cordova/targets.js
+++ b/cordova-lib/src/cordova/targets.js
@@ -54,9 +54,9 @@ module.exports = function targets(options) {
 
     var result = Q();
     options.platforms.forEach(function(platform) {
-        if (~options.options.indexOf('--device')) {
+        if (options.options.indexOf('--device') >= 0) {
             result = result.then(displayDevices.bind(null, projectRoot, platform, options.options));
-        } else if(~options.options.indexOf('--emulator')) {
+        } else if(options.options.indexOf('--emulator') >= 0) {
             result = result.then(displayVirtualDevices.bind(null, projectRoot, platform, options.options));
         } else {
             result = result.then(displayDevices.bind(null, projectRoot, platform, options.options))

--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc, sub:true
-*/
-
+/* jshint sub:true */
 var fs            = require('fs'),
     path          = require('path'),
     CordovaError  = require('../CordovaError'),

--- a/cordova-lib/src/hooks/Context.js
+++ b/cordova-lib/src/hooks/Context.js
@@ -17,12 +17,6 @@
  under the License.
  */
 
-var Q = require('q'),
-    fs = require('fs'),
-    path = require('path'),
-    os = require('os'),
-    events = require('../events');
-
 /**
  * Creates hook script context
  * @constructor

--- a/cordova-lib/src/hooks/HooksRunner.js
+++ b/cordova-lib/src/hooks/HooksRunner.js
@@ -137,7 +137,7 @@ function runScript(script, context) {
  * Returns a promise. */
 function runScriptViaModuleLoader(script, context) {
     if(!fs.existsSync(script.fullPath)) {
-        events.emit('warn', "Script file does't exist and will be skipped: " + script.fullPath);
+        events.emit('warn', 'Script file does\'t exist and will be skipped: ' + script.fullPath);
         return Q();
     }
     var scriptFn = require(script.fullPath);
@@ -202,7 +202,7 @@ function extractSheBangInterpreter(fullpath) {
     var fileChunk;
     var octetsRead;
     var fileData;
-    var hookFd = fs.openSync(fullpath, "r");
+    var hookFd = fs.openSync(fullpath, 'r');
     try {
         // this is a modern cluster size. no need to read less
         fileData = new Buffer(4096);

--- a/cordova-lib/src/hooks/scriptsFinder.js
+++ b/cordova-lib/src/hooks/scriptsFinder.js
@@ -21,8 +21,6 @@ var path = require('path'),
     fs = require('fs'),
     cordovaUtil = require('../cordova/util'),
     events = require('../events'),
-    Q = require('q'),
-    plugin  = require('../cordova/plugin'),
     PluginInfoProvider = require('../PluginInfoProvider'),
     ConfigParser = require('../configparser/ConfigParser');
 
@@ -137,8 +135,6 @@ function getPluginScriptFiles(plugin, hook, platforms) {
  */
 function getAllPluginsHookScriptFiles(hook, opts) {
     var scripts = [];
-    var pluginDir;
-    var pluginInfo;
     var currentPluginOptions;
 
     var plugins = (new PluginInfoProvider()).getAllWithinSearchPath(path.join(opts.projectRoot, 'plugins'));

--- a/cordova-lib/src/plugman/adduser.js
+++ b/cordova-lib/src/plugman/adduser.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 module.exports = function() {

--- a/cordova-lib/src/plugman/config.js
+++ b/cordova-lib/src/plugman/config.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 module.exports = function(params) {

--- a/cordova-lib/src/plugman/create.js
+++ b/cordova-lib/src/plugman/create.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var Q = require('q'),
     fs = require('fs'),
     path = require('path'),

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var shell   = require('shelljs'),
     fs      = require('fs'),
     url     = require('url'),

--- a/cordova-lib/src/plugman/info.js
+++ b/cordova-lib/src/plugman/info.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 // Returns a promise.

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true, expr:true
-*/
+/* jshint laxcomma:true, sub:true, expr:true */
 
 var path = require('path'),
     fs   = require('fs'),

--- a/cordova-lib/src/plugman/owner.js
+++ b/cordova-lib/src/plugman/owner.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 // Returns a promise.

--- a/cordova-lib/src/plugman/platform.js
+++ b/cordova-lib/src/plugman/platform.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          quotmark:false
-*/
+/* jshint quotmark:false */
 
 var Q = require('q'),
     et = require('elementtree'),

--- a/cordova-lib/src/plugman/platform_operation.js
+++ b/cordova-lib/src/plugman/platform_operation.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var platform = require('./platform');
 
 module.exports = function( args ) {

--- a/cordova-lib/src/plugman/platforms.js
+++ b/cordova-lib/src/plugman/platforms.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 module.exports = {
     'android': require('./platforms/android'),
     'amazon-fireos': require('./platforms/amazon-fireos'),

--- a/cordova-lib/src/plugman/platforms/amazon-fireos.js
+++ b/cordova-lib/src/plugman/platforms/amazon-fireos.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
    , common = require('./common')

--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
    , common = require('./common')

--- a/cordova-lib/src/plugman/platforms/blackberry10.js
+++ b/cordova-lib/src/plugman/platforms/blackberry10.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
    , common = require('./common')

--- a/cordova-lib/src/plugman/platforms/browser.js
+++ b/cordova-lib/src/plugman/platforms/browser.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
     , fs = require('fs')

--- a/cordova-lib/src/plugman/platforms/common.js
+++ b/cordova-lib/src/plugman/platforms/common.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var shell = require('shelljs'),
     path  = require('path'),
     fs    = require('fs'),

--- a/cordova-lib/src/plugman/platforms/firefoxos.js
+++ b/cordova-lib/src/plugman/platforms/firefoxos.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
     , fs = require('fs')

--- a/cordova-lib/src/plugman/platforms/ios.js
+++ b/cordova-lib/src/plugman/platforms/ios.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
   , common = require('./common')

--- a/cordova-lib/src/plugman/platforms/tizen.js
+++ b/cordova-lib/src/plugman/platforms/tizen.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var path = require('path')
     , fs = require('fs')

--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 function replaceAt(str, index, char) {
     return str.substr(0, index) + char + str.substr(index + char.length);

--- a/cordova-lib/src/plugman/platforms/windows.js
+++ b/cordova-lib/src/plugman/platforms/windows.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var common = require('./common'),
     path = require('path'),

--- a/cordova-lib/src/plugman/platforms/wp8.js
+++ b/cordova-lib/src/plugman/platforms/wp8.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true
-*/
+/* jshint laxcomma:true, sub:true */
 
 var common = require('./common'),
     path = require('path'),

--- a/cordova-lib/src/plugman/plugman.js
+++ b/cordova-lib/src/plugman/plugman.js
@@ -19,10 +19,6 @@
 
 // copyright (c) 2013 Andrew Lunny, Adobe Systems
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var events = require('../events');
 var Q = require('q');
 

--- a/cordova-lib/src/plugman/prepare-browserify.js
+++ b/cordova-lib/src/plugman/prepare-browserify.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          unused:false, expr:true
-*/
+/* jshint unused:false, expr:true */
 
 var platform_modules   = require('./platforms'),
     path               = require('path'),

--- a/cordova-lib/src/plugman/prepare.js
+++ b/cordova-lib/src/plugman/prepare.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          expr:true, quotmark:false
-*/
+/* jshint expr:true, quotmark:false */
 
 var platform_modules = require('./platforms'),
     path            = require('path'),

--- a/cordova-lib/src/plugman/publish.js
+++ b/cordova-lib/src/plugman/publish.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 module.exports = function(plugin_path) {

--- a/cordova-lib/src/plugman/registry/manifest.js
+++ b/cordova-lib/src/plugman/registry/manifest.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var path = require('path'),
     Q = require('q'),
     fs = require('fs'),

--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true
-*/
+/* jshint laxcomma:true */
 
 var npm = require('npm'),
     path = require('path'),

--- a/cordova-lib/src/plugman/registry/whitelist.js
+++ b/cordova-lib/src/plugman/registry/whitelist.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 module.exports = [
     'org.apache.cordova.splashscreen',
     'org.apache.cordova.network-information',

--- a/cordova-lib/src/plugman/search.js
+++ b/cordova-lib/src/plugman/search.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 module.exports = function(search_opts) {

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          laxcomma:true, sub:true, expr:true
-*/
+/* jshint laxcomma:true, sub:true, expr:true */
 
 var path = require('path'),
     fs   = require('fs'),

--- a/cordova-lib/src/plugman/unpublish.js
+++ b/cordova-lib/src/plugman/unpublish.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var registry = require('./registry/registry');
 
 module.exports = function(plugin) {

--- a/cordova-lib/src/plugman/util/ConfigKeeper.js
+++ b/cordova-lib/src/plugman/util/ConfigKeeper.js
@@ -13,7 +13,7 @@
  * under the License.
  *
 */
-/* jshint node:true, sub:true, indent:4  */
+/* jshint sub:true */
 
 var path = require('path');
 var ConfigFile = require('./ConfigFile');

--- a/cordova-lib/src/plugman/util/ConfigKeeper.js
+++ b/cordova-lib/src/plugman/util/ConfigKeeper.js
@@ -14,7 +14,6 @@
  *
 */
 /* jshint node:true, sub:true, indent:4  */
-/* global jasmine, describe, beforeEach, afterEach, it, spyOn, expect */
 
 var path = require('path');
 var ConfigFile = require('./ConfigFile');

--- a/cordova-lib/src/plugman/util/PlatformJson.js
+++ b/cordova-lib/src/plugman/util/PlatformJson.js
@@ -14,8 +14,6 @@
  *
 */
 /* jshint node:true, sub:true, indent:4  */
-/* global jasmine, describe, beforeEach, afterEach, it, spyOn, expect */
-
 
 var fs = require('fs');
 var path = require('path');

--- a/cordova-lib/src/plugman/util/PlatformJson.js
+++ b/cordova-lib/src/plugman/util/PlatformJson.js
@@ -13,7 +13,7 @@
  * under the License.
  *
 */
-/* jshint node:true, sub:true, indent:4  */
+/* jshint sub:true */
 
 var fs = require('fs');
 var path = require('path');

--- a/cordova-lib/src/plugman/util/action-stack.js
+++ b/cordova-lib/src/plugman/util/action-stack.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          quotmark:false
-*/
+/* jshint quotmark:false */
 
 var platforms = require("../platforms"),
     events = require('../../events'),

--- a/cordova-lib/src/plugman/util/android-project.js
+++ b/cordova-lib/src/plugman/util/android-project.js
@@ -20,10 +20,7 @@
     Helper for Android projects configuration
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          boss:true
-*/
+/* jshint boss:true */
 
 var fs = require('fs'),
     path = require('path'),

--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -16,7 +16,6 @@
  * under the License.
  *
 */
-/* jshint node:true, sub:true, indent:4  */
 
 /*
  * This module deals with shared configuration / dependency "stuff". That is:
@@ -31,10 +30,7 @@
  * reference counts.
  */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true
-*/
+/* jshint sub:true */
 
 var fs   = require('fs'),
     path = require('path'),

--- a/cordova-lib/src/plugman/util/default-engines.js
+++ b/cordova-lib/src/plugman/util/default-engines.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var path = require('path');
 
 module.exports = function(project_dir){

--- a/cordova-lib/src/plugman/util/dependencies.js
+++ b/cordova-lib/src/plugman/util/dependencies.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          expr:true
-*/
+/* jshint expr:true */
 
 var dep_graph = require('dep-graph'),
     path = require('path'),

--- a/cordova-lib/src/plugman/util/metadata.js
+++ b/cordova-lib/src/plugman/util/metadata.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var fs = require('fs');
 var path = require('path');
 

--- a/cordova-lib/src/plugman/util/munge-util.js
+++ b/cordova-lib/src/plugman/util/munge-util.js
@@ -14,7 +14,6 @@
  *
 */
 /* jshint node:true, sub:true, indent:4  */
-/* global jasmine, describe, beforeEach, afterEach, it, spyOn, expect */
 
 var _ = require('underscore');
 

--- a/cordova-lib/src/plugman/util/munge-util.js
+++ b/cordova-lib/src/plugman/util/munge-util.js
@@ -13,7 +13,7 @@
  * under the License.
  *
 */
-/* jshint node:true, sub:true, indent:4  */
+/* jshint sub:true  */
 
 var _ = require('underscore');
 

--- a/cordova-lib/src/plugman/util/plist-helpers.js
+++ b/cordova-lib/src/plugman/util/plist-helpers.js
@@ -17,10 +17,6 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 // contains PLIST utility functions
 var __     = require('underscore');
 var plist = require('plist');

--- a/cordova-lib/src/plugman/util/plugins.js
+++ b/cordova-lib/src/plugman/util/plugins.js
@@ -17,10 +17,6 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var os = require('os'),
     path = require('path'),
     util = require('util'),

--- a/cordova-lib/src/plugman/util/prepare-namespace.js
+++ b/cordova-lib/src/plugman/util/prepare-namespace.js
@@ -16,10 +16,7 @@
     specific language governing permissions and limitations
     under the License.
 */
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          quotmark:false
-*/
+/* jshint quotmark:false */
 
 var util = require('util');
 

--- a/cordova-lib/src/plugman/util/search-and-replace.js
+++ b/cordova-lib/src/plugman/util/search-and-replace.js
@@ -18,10 +18,6 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var glob = require('glob'),
     fs = require('fs');
 

--- a/cordova-lib/src/util/promise-util.js
+++ b/cordova-lib/src/util/promise-util.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var Q = require('q');
 
 // Given a function and an array of values, creates a chain of promises that

--- a/cordova-lib/src/util/unpack.js
+++ b/cordova-lib/src/util/unpack.js
@@ -2,26 +2,25 @@
 // this file is used by lib/cache.js
 
 var events = require('../events'),
-    fs     = require("fs"),
-    path   = require("path"),
+    fs     = require('fs'),
     Q      = require('q'),
-    tar    = require("tar"),
-    zlib   = require("zlib");
+    tar    = require('tar'),
+    zlib   = require('zlib');
 
 exports.unpackTgz = unpackTgz;
 
 // Returns a promise for the path to the unpacked tarball (unzip + untar).
 function unpackTgz(package_tgz, unpackTarget) {
     return Q.promise(function(resolve, reject) {
-        var extractOpts = { type: "Directory", path: unpackTarget, strip: 1 };
+        var extractOpts = { type: 'Directory', path: unpackTarget, strip: 1 };
 
         fs.createReadStream(package_tgz)
-        .on("error", function (err) {
+        .on('error', function (err) {
             events.emit('verbose', 'Unable to open tarball ' + package_tgz + ': ' + err);
             reject(err);
         })
         .pipe(zlib.createUnzip())
-        .on("error", function (err) {
+        .on('error', function (err) {
             events.emit('verbose', 'Error during unzip for ' + package_tgz + ': ' + err);
             reject(err);
         })
@@ -30,7 +29,7 @@ function unpackTgz(package_tgz, unpackTarget) {
             events.emit('verbose', 'Error during untar for ' + package_tgz + ': ' + err);
             reject(err);
         })
-        .on("end", resolve);
+        .on('end', resolve);
     })
     .then(function() {
         return unpackTarget;

--- a/cordova-lib/src/util/windows/csproj.js
+++ b/cordova-lib/src/util/windows/csproj.js
@@ -17,10 +17,6 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc
-*/
-
 var xml_helpers = require('../../util/xml-helpers'),
     et = require('elementtree'),
     fs = require('fs'),

--- a/cordova-lib/src/util/windows/jsproj.js
+++ b/cordova-lib/src/util/windows/jsproj.js
@@ -17,10 +17,7 @@
     under the License.
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          quotmark:false, unused:false
-*/
+/* jshint quotmark:false, unused:false */
 
 /*
   Helper for dealing with Windows Store JS app .jsproj files

--- a/cordova-lib/src/util/xml-helpers.js
+++ b/cordova-lib/src/util/xml-helpers.js
@@ -17,10 +17,7 @@
  *
 */
 
-/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
-          indent:4, unused:vars, latedef:nofunc,
-          sub:true, laxcomma:true
-*/
+/* jshint sub:true, laxcomma:true */
 
 /**
  * contains XML utility functions, some of which are specific to elementtree


### PR DESCRIPTION
Enforcing better JSHint coverage for src\* :
- Move base rules to src\.jshintrc
- Fix previously un-jshinted files
- Remove base rules from individual files to contain exceptions only