### PR TITLE
CB-6973 enable JSHint for spec-cordova

### DIFF
--- a/cordova-lib/.jshintignore
+++ b/cordova-lib/.jshintignore
@@ -1,0 +1,4 @@
+spec-cordova/fixtures/platforms/android/*
+spec-cordova/fixtures/base/www/index.html
+spec-cordova/fixtures/base/www/js/index.js
+spec-cordova/fixtures/projWithHooks/www/js/index.js

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "test": "npm run jshint && npm run jasmine",
-    "jshint": "node node_modules/jshint/bin/jshint src",
+    "jshint": "node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint spec-cordova",
     "jasmine": "node node_modules/jasmine-node/bin/jasmine-node --captureExceptions --color spec-plugman spec-cordova",
     "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
   },

--- a/cordova-lib/spec-cordova/.jshintrc
+++ b/cordova-lib/spec-cordova/.jshintrc
@@ -1,0 +1,11 @@
+{
+    "node": true
+  , "bitwise": true
+  , "undef": true
+  , "trailing": true
+  , "quotmark": true
+  , "indent": 4
+  , "unused": "vars"
+  , "latedef": "nofunc"
+  , "jasmine": true
+}

--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -117,11 +117,11 @@ describe('config.xml parser', function () {
         describe('feature',function(){
             it('should read feature id list', function() {
                var expectedList = [
-                   "org.apache.cordova.featurewithvars",
-                   "org.apache.cordova.featurewithurl",
-                   "org.apache.cordova.featurewithversion",
-                   "org.apache.cordova.featurewithurlandversion",
-                   "org.apache.cordova.justafeature"
+                   'org.apache.cordova.featurewithvars',
+                   'org.apache.cordova.featurewithurl',
+                   'org.apache.cordova.featurewithversion',
+                   'org.apache.cordova.featurewithurlandversion',
+                   'org.apache.cordova.justafeature'
                ];
                var list = cfg.getFeatureIdList();
                expect(list.length).toEqual(expectedList.length);
@@ -130,37 +130,37 @@ describe('config.xml parser', function () {
                });
             });
             it('should read feature given id', function(){
-                var feature = cfg.getFeature("org.apache.cordova.justafeature");
+                var feature = cfg.getFeature('org.apache.cordova.justafeature');
                 expect(feature).toBeDefined();
-                expect(feature.name).toEqual("A simple feature");
-                expect(feature.id).toEqual("org.apache.cordova.justafeature");
+                expect(feature.name).toEqual('A simple feature');
+                expect(feature.id).toEqual('org.apache.cordova.justafeature');
                 expect(feature.params).toBeDefined();
                 expect(feature.params.id).toBeDefined();
-                expect(feature.params.id).toEqual("org.apache.cordova.justafeature");
+                expect(feature.params.id).toEqual('org.apache.cordova.justafeature');
             });
             it('should not read feature given undefined id', function(){
-                var feature = cfg.getFeature("org.apache.cordova.undefinedfeature");
+                var feature = cfg.getFeature('org.apache.cordova.undefinedfeature');
                 expect(feature).not.toBeDefined();
             });
             it('should read feature with url and set \'url\' param', function(){
-                var feature = cfg.getFeature("org.apache.cordova.featurewithurl");
-                expect(feature.url).toEqual("http://cordova.apache.org/featurewithurl");
+                var feature = cfg.getFeature('org.apache.cordova.featurewithurl');
+                expect(feature.url).toEqual('http://cordova.apache.org/featurewithurl');
                 expect(feature.params).toBeDefined();
                 expect(feature.params.url).toBeDefined();
-                expect(feature.params.url).toEqual("http://cordova.apache.org/featurewithurl");
+                expect(feature.params.url).toEqual('http://cordova.apache.org/featurewithurl');
             });
             it('should read feature with version and set \'version\' param', function(){
-                var feature = cfg.getFeature("org.apache.cordova.featurewithversion");
-                expect(feature.version).toEqual("1.1.1");
+                var feature = cfg.getFeature('org.apache.cordova.featurewithversion');
+                expect(feature.version).toEqual('1.1.1');
                 expect(feature.params).toBeDefined();
                 expect(feature.params.version).toBeDefined();
-                expect(feature.params.version).toEqual("1.1.1");
+                expect(feature.params.version).toEqual('1.1.1');
             });
             it('should read feature variables', function () {
-                var feature = cfg.getFeature("org.apache.cordova.featurewithvars");
+                var feature = cfg.getFeature('org.apache.cordova.featurewithvars');
                 expect(feature.variables).toBeDefined();
                 expect(feature.variables.var).toBeDefined();
-                expect(feature.variables.var).toEqual("varvalue");
+                expect(feature.variables.var).toEqual('varvalue');
             });
             it('should allow adding a new feature', function(){
                 cfg.addFeature('myfeature');

--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -17,6 +17,8 @@
  under the License.
  **/
 
+/* jshint boss:true */
+
 var cordova = require('../src/cordova/cordova'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     shell  = require('shelljs'),
@@ -407,7 +409,6 @@ describe('HooksRunner', function() {
             });
 
             it('should run before_plugin_uninstall, before_plugin_install, after_plugin_install hooks for a plugin being installed with correct opts.plugin context', function (done) {
-                var test_event = 'before_plugin_install';
                 var projectRoot = cordovaUtil.isCordova();
 
                 // remove plugin
@@ -447,12 +448,13 @@ describe('HooksRunner', function() {
                                 delete call.args[1].plugin.pluginInfo._et;
                             }
 
-                            if(call.args[0] == 'before_plugin_uninstall' || call.args[0] == 'before_plugin_install'
-                                || call.args[0] == 'after_plugin_install') {
+                            if(call.args[0] == 'before_plugin_uninstall' ||
+                                call.args[0] == 'before_plugin_install' ||
+                                call.args[0] == 'after_plugin_install') {
                                 if(call.args[1] && call.args[1].plugin) {
                                     if(call.args[1].plugin.platform == 'android') {
-                                        expect(JSON.stringify(androidPluginOpts)
-                                            === JSON.stringify(call.args[1])).toBe(true);
+                                        expect(JSON.stringify(androidPluginOpts) ===
+                                            JSON.stringify(call.args[1])).toBe(true);
                                     }
                                 }
                             }

--- a/cordova-lib/spec-cordova/PluginInfo.spec.js
+++ b/cordova-lib/spec-cordova/PluginInfo.spec.js
@@ -47,7 +47,7 @@ describe('PluginInfo', function () {
     });
     it('should throw when there is no plugin.xml file', function () {
         expect(function () {
-            var p = new PluginInfo('/non/existent/dir');
+            new PluginInfo('/non/existent/dir');
         }).toThrow();
     });
 });

--- a/cordova-lib/spec-cordova/build.spec.js
+++ b/cordova-lib/spec-cordova/build.spec.js
@@ -18,9 +18,6 @@
 */
 var cordova = require('../src/cordova/cordova'),
     platforms = require('../src/cordova/platforms'),
-    shell = require('shelljs'),
-    path = require('path'),
-    fs = require('fs'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     Q = require('q'),
     util = require('../src/cordova/util');
@@ -31,19 +28,6 @@ describe('build command', function() {
     var is_cordova, cd_project_root, list_platforms, fire;
     var project_dir = '/some/path';
     var prepare_spy, compile_spy;
-    var result;
-
-    function buildPromise(f) {
-        f.then(function() { result = true; }, function(err) { result = err; });
-    }
-
-    function wrapper(f, post) {
-        runs(function() {
-            buildPromise(f);
-        });
-        waitsFor(function() { return result; }, 'promise never resolved', 500);
-        runs(post);
-    }
 
     beforeEach(function() {
         is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
@@ -61,7 +45,7 @@ describe('build command', function() {
             }, function(err) {
                 expect(err.message).toEqual(
                     'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                )
+                );
             }).fin(done);
         });
 
@@ -73,7 +57,7 @@ describe('build command', function() {
             }, function(err) {
                 expect(err.message).toEqual(
                     'Current working directory is not a Cordova-based project.'
-                )
+                );
             }).fin(done);
         });
     });
@@ -89,7 +73,7 @@ describe('build command', function() {
         });
         it('should pass down options', function(done) {
             cordova.raw.build({platforms: ['android'], options: ['--release']}).then(function() {
-                var opts = {platforms: ['android'], options: ["--release"], verbose: false};
+                var opts = {platforms: ['android'], options: ['--release'], verbose: false};
                 expect(prepare_spy).toHaveBeenCalledWith(opts);
                 expect(compile_spy).toHaveBeenCalledWith(opts);
                 done();
@@ -121,7 +105,7 @@ describe('build command', function() {
                 }, function(err) {
                     expect(err.message).toEqual(
                         'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                    )
+                    );
                 }).fin(done);
             });
         });

--- a/cordova-lib/spec-cordova/compile.spec.js
+++ b/cordova-lib/spec-cordova/compile.spec.js
@@ -19,13 +19,10 @@
 var cordova = require('../src/cordova/cordova'),
     platforms = require('../src/cordova/platforms'),
     path = require('path'),
-    fs = require('fs'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     superspawn = require('../src/cordova/superspawn'),
     util = require('../src/cordova/util'),
-    Q = require('q'),
-    os = require('os');
-
+    Q = require('q');
 
 var supported_platforms = Object.keys(platforms).filter(function(p) { return p != 'www'; });
 
@@ -46,7 +43,7 @@ describe('compile command', function() {
         cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
         list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
         fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
-        spyOn(superspawn, 'spawn').andCallFake(function() { return Q() });
+        spyOn(superspawn, 'spawn').andCallFake(function() { return Q(); });
     });
     describe('failure', function() {
         it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function() {
@@ -73,7 +70,7 @@ describe('compile command', function() {
         });
 
         it('should pass down optional parameters', function (done) {
-            cordova.raw.compile({platforms:["blackberry10"], options:["--release"]}).then(function () {
+            cordova.raw.compile({platforms:['blackberry10'], options:['--release']}).then(function () {
                 expect(superspawn.spawn).toHaveBeenCalledWith(path.join(project_dir, 'platforms', 'blackberry10', 'cordova', 'build'), ['--release'], jasmine.any(Object));
                 done();
             });
@@ -105,7 +102,7 @@ describe('compile command', function() {
                     expect(fire).not.toHaveBeenCalled();
                     expect(err.message).toContain(
                         'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                    )
+                    );
                 }).fin(done);
             });
         });

--- a/cordova-lib/spec-cordova/create.spec.js
+++ b/cordova-lib/spec-cordova/create.spec.js
@@ -22,36 +22,19 @@ var helpers = require('./helpers'),
     fs = require('fs'),
     shell = require('shelljs'),
     Q = require('q'),
-    config = require('../src/cordova/config'),
     events = require('../src/events'),
-    util = require('../src/cordova/util'),
     ConfigParser = require('../src/configparser/ConfigParser'),
     cordova = require('../src/cordova/cordova');
-
-// A utility function to generate all combinations of elements from 2 arrays.
-// crossConcat(['x', 'y'], ['1', '2', '3'])
-// -> [ 'x1', 'x2', 'x3', 'y1', 'y2', 'y3']
-var crossConcat = function(a, b, delimiter){
-    var result = [];
-    delimiter = delimiter || '';
-    for (var i = 0; i < a.length; i++) {
-        for (var j = 0; j < b.length; j++) {
-            result.push(a[i] + delimiter + b[j]);
-        }
-    }
-    return result;
-};
 
 var tmpDir = helpers.tmpDir('create_test');
 var appName = 'TestBase';
 var appId = 'org.testing';
 var project = path.join(tmpDir, appName);
-var cordovaDir = path.join(project, '.cordova');
 var configNormal = {
       lib: {
         www: {
           url: path.join(__dirname, 'fixtures', 'base', 'www'),
-          version: "testCordovaCreate",
+          version: 'testCordovaCreate',
           id: appName
         }
       }
@@ -68,17 +51,17 @@ var configSymlink = {
 describe('cordova create checks for valid-identifier', function(done) {    
 
     it('should reject reserved words from start of id', function(done) {
-        cordova.raw.create("projectPath", "int.bob", "appName")
+        cordova.raw.create('projectPath', 'int.bob', 'appName')
         .fail(function(err) {
-            expect(err.message).toBe("App id contains a reserved word, or is not a valid identifier.");
+            expect(err.message).toBe('App id contains a reserved word, or is not a valid identifier.');
         })
         .fin(done);
     });
 
     it('should reject reserved words from end of id', function(done) {
-        cordova.raw.create("projectPath", "bob.class", "appName")
+        cordova.raw.create('projectPath', 'bob.class', 'appName')
         .fail(function(err) {
-            expect(err.message).toBe("App id contains a reserved word, or is not a valid identifier.");
+            expect(err.message).toBe('App id contains a reserved word, or is not a valid identifier.');
         })
         .fin(done);
     });
@@ -145,7 +128,7 @@ describe('create end-to-end', function() {
         .fail(function(err) {
             if(process.platform.slice(0, 3) == 'win') {
                 // Allow symlink error if not in admin mode
-                expect(err.message).toBe("Symlinks on Windows require Administrator privileges");
+                expect(err.message).toBe('Symlinks on Windows require Administrator privileges');
             } else {
                 if (err) {
                     console.log(err.stack);

--- a/cordova-lib/spec-cordova/emulate.spec.js
+++ b/cordova-lib/spec-cordova/emulate.spec.js
@@ -20,11 +20,9 @@ var cordova = require('../src/cordova/cordova'),
     platforms = require('../src/cordova/platforms'),
     superspawn = require('../src/cordova/superspawn'),
     path = require('path'),
-    fs = require('fs'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     Q = require('q'),
-    util = require('../src/cordova/util'),
-    os = require('os');
+    util = require('../src/cordova/util');
 
 var supported_platforms = Object.keys(platforms).filter(function(p) { return p != 'www'; });
 
@@ -75,7 +73,7 @@ describe('emulate command', function() {
             });
         });
         it('should pass down options', function(done) {
-            cordova.raw.emulate({platforms: ['ios'], options:["--optionTastic"]}).then(function(err) {
+            cordova.raw.emulate({platforms: ['ios'], options:['--optionTastic']}).then(function(err) {
                 expect(prepare_spy).toHaveBeenCalledWith(['ios']);
                 expect(superspawn.spawn).toHaveBeenCalledWith(path.join(project_dir, 'platforms', 'ios', 'cordova', 'run'), ['--emulator', '--optionTastic'], jasmine.any(Object));
 
@@ -107,7 +105,7 @@ describe('emulate command', function() {
                     expect('this call').toBe('fail');
                 }, function(err) {
                     expect(fire).not.toHaveBeenCalled();
-                    expect(''+err).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.')
+                    expect(''+err).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.');
                 }).fin(done);
             });
         });

--- a/cordova-lib/spec-cordova/fixtures/platforms/android-lib/framework/assets/www/cordova.js
+++ b/cordova-lib/spec-cordova/fixtures/platforms/android-lib/framework/assets/www/cordova.js
@@ -1,1 +1,1 @@
-This is a placeholder file.
+/* This is a placeholder file */

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/android/androidBeforeBuild.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/android/androidBeforeBuild.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('26', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/android/androidBeforeInstall.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/android/androidBeforeInstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('25', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeBuild.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeBuild.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('21', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeInstall01.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeInstall01.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('17', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeInstall2.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeInstall2.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('18', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeUninstall.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/beforeUninstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('20', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/windows/windowsBeforeBuild.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/windows/windowsBeforeBuild.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('24', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/windows/windowsBeforeInstall.js
+++ b/cordova-lib/spec-cordova/fixtures/plugins/com.plugin.withhooks/scripts/windows/windowsBeforeInstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('23', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/android/appAndroidBeforeBuild.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/android/appAndroidBeforeBuild.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('15', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/android/appAndroidBeforePluginInstall.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/android/appAndroidBeforePluginInstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('16', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/appBeforeBuild02.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/appBeforeBuild02.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('09', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/appBeforePluginInstall.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/appBeforePluginInstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('10', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/orderLogger.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/orderLogger.js
@@ -9,4 +9,4 @@ module.exports.logOrder = function logOrder(index, context) {
 
         fs.appendFileSync('hooks_order.txt', indexWithEOL);
     }
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/windows/appWindowsBeforeBuild.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/windows/appWindowsBeforeBuild.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('12', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/windows/appWindowsBeforePluginInstall.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/scripts/windows/appWindowsBeforePluginInstall.js
@@ -1,4 +1,4 @@
 module.exports = function(context) {
     var orderLogger = require(require('path').join(context.opts.projectRoot, 'scripts', 'orderLogger'));
     orderLogger.logOrder('13', context);
-}
+};

--- a/cordova-lib/spec-cordova/fixtures/projWithHooks/www/js/index.js
+++ b/cordova-lib/spec-cordova/fixtures/projWithHooks/www/js/index.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 var app = {
     // Application Constructor
     initialize: function() {

--- a/cordova-lib/spec-cordova/lazy_load.spec.js
+++ b/cordova-lib/spec-cordova/lazy_load.spec.js
@@ -16,11 +16,13 @@
     specific language governing permissions and limitations
     under the License.
 */
+
+/* jshint sub:true */
+
 var lazy_load = require('../src/cordova/lazy_load'),
     config = require('../src/cordova/config'),
-    util = require('../src/cordova/util'),
     shell = require('shelljs'),
-    npmconf = require('npmconf');
+    npmconf = require('npmconf'),
     path = require('path'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     request = require('request'),
@@ -29,8 +31,7 @@ var lazy_load = require('../src/cordova/lazy_load'),
     platforms = require('../src/cordova/platforms');
 
 describe('lazy_load module', function() {
-    var custom_path;
-    var npm_cache_add;
+    var custom_path, npm_cache_add, fakeLazyLoad;
     beforeEach(function() {
         custom_path = spyOn(config, 'has_custom_path').andReturn(false);
         npm_cache_add = spyOn(lazy_load, 'npm_cache_add').andReturn(Q(path.join('lib','dir')));
@@ -48,7 +49,7 @@ describe('lazy_load module', function() {
         beforeEach(function() {
             custom = spyOn(lazy_load, 'custom').andReturn(Q(path.join('lib','dir')));
             version = platforms.android.version;
-            platforms.android.version = "3.14.15.9265";
+            platforms.android.version = '3.14.15.9265';
         });
         afterEach(function () {
             platforms.android.version = version;
@@ -61,7 +62,6 @@ describe('lazy_load module', function() {
             }).fin(done);
         });
         it('should invoke lazy_load.custom with appropriate url, platform, and version as specified in platforms manifest', function(done) {
-            var url = platforms.android.url + ';a=snapshot;h=' + platforms.android.version + ';sf=tgz';
             lazy_load.cordova('android').then(function(dir) {
                 expect(npm_cache_add).toHaveBeenCalled();
                 expect(dir).toBeDefined();
@@ -71,7 +71,7 @@ describe('lazy_load module', function() {
     });
 
     describe('custom method (loads custom cordova libs)', function() {
-        var exists, fire, rm;
+        var exists, fire, rm, mv, readdir;
         beforeEach(function() {
             spyOn(shell, 'mkdir');
             rm = spyOn(shell, 'rm');
@@ -91,7 +91,7 @@ describe('lazy_load module', function() {
                 }
             };
             lazy_load.custom(mock_platforms, 'platform X').then(function() {
-                expect(fire).not.toHaveBeenCalled()
+                expect(fire).not.toHaveBeenCalled();
             }, function(err) {
                 expect(err).not.toBeDefined();
             }).fin(done);
@@ -106,7 +106,7 @@ describe('lazy_load module', function() {
                 }
             };
             lazy_load.custom(mock_platforms, 'platform X').then(function() {
-                expect(fire).not.toHaveBeenCalled()
+                expect(fire).not.toHaveBeenCalled();
             }, function(err) {
                 expect(err).not.toBeDefined();
             }).fin(done);
@@ -136,7 +136,7 @@ describe('lazy_load module', function() {
                     }, 10);
                     return fakeRequest;
                 });
-                load_spy = spyOn(npmconf, 'load').andCallFake(function(cb) { cb(null, { get: function() { return npmConfProxy }}); });
+                load_spy = spyOn(npmconf, 'load').andCallFake(function(cb) { cb(null, { get: function() { return npmConfProxy; }}); });
             });
 
             it('should call request with appropriate url params', function(done) {
@@ -231,13 +231,13 @@ describe('lazy_load module', function() {
     });
 
     describe('based_on_config method', function() {
-        var cordova, custom;
+        var cordova, custom, read;
         beforeEach(function() {
             cordova = spyOn(lazy_load, 'cordova').andReturn(Q());
             custom = spyOn(lazy_load, 'custom').andReturn(Q());
         });
         it('should invoke custom if a custom lib is specified', function(done) {
-            var read = spyOn(config, 'read').andReturn({
+            read = spyOn(config, 'read').andReturn({
                 lib:{
                     maybe:{
                         url:'you or eye?',

--- a/cordova-lib/spec-cordova/metadata/android_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/android_parser.spec.js
@@ -16,6 +16,9 @@
     specific language governing permissions and limitations
     under the License.
 */
+
+/* jshint boss:true */
+
 var platforms = require('../../src/cordova/platforms'),
     util = require('../../src/cordova/util'),
     path = require('path'),
@@ -23,12 +26,10 @@ var platforms = require('../../src/cordova/platforms'),
     fs = require('fs'),
     et = require('elementtree'),
     xmlHelpers = require('../../src/util/xml-helpers'),
-    Q = require('q'),
     config = require('../../src/cordova/config'),
     Parser = require('../../src/cordova/metadata/parser'),
     ConfigParser = require('../../src/configparser/ConfigParser'),
-    CordovaError = require('../../src/CordovaError'),
-    cordova = require('../../src/cordova/cordova');
+    CordovaError = require('../../src/CordovaError');
 
 // Create a real config object before mocking out everything.
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
@@ -53,12 +54,6 @@ describe('android project parser', function() {
         exists = spyOn(fs, 'existsSync').andReturn(true);
         spyOn(config, 'has_custom_path').andReturn(false);
     });
-
-    function wrapper(p, done, post) {
-        p.then(post, function(err) {
-            expect(err).toBeUndefined();
-        }).fin(done);
-    }
 
     function errorWrapper(p, done, post) {
         p.then(function() {
@@ -121,9 +116,9 @@ describe('android project parser', function() {
         describe('update_from_config method', function() {
             beforeEach(function() {
                 spyOn(fs, 'readdirSync').andReturn([ path.join(android_proj, 'src', 'android_pkg', 'MyApp.java') ]);
-                cfg.name = function() { return 'testname' };
-                cfg.packageName = function() { return 'testpkg' };
-                cfg.version = function() { return 'one point oh' };
+                cfg.name = function() { return 'testname'; };
+                cfg.packageName = function() { return 'testpkg'; };
+                cfg.version = function() { return 'one point oh'; };
                 read.andReturn('package org.cordova.somepackage; public class MyApp extends CordovaActivity { }');
             });
 
@@ -162,12 +157,12 @@ describe('android project parser', function() {
                 expect(stringsRoot.getroot().find('string').text).toEqual('testname');
             });
             it('should write out the app id to androidmanifest.xml and update the cordova-android entry Java class', function() {
-                cfg.android_packageName = function () { return null };
+                cfg.android_packageName = function () { return null; };
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().attrib.package).toEqual('testpkg');
             });
             it('should write out the app id to androidmanifest.xml and update the cordova-android entry Java class with android_packageName', function() {
-                cfg.android_packageName = function () { return 'testpkg_android' };
+                cfg.android_packageName = function () { return 'testpkg_android'; };
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().attrib.package).toEqual('testpkg_android');
             });

--- a/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
@@ -24,11 +24,9 @@ var platforms = require('../../src/cordova/platforms'),
     fs = require('fs'),
     et = require('elementtree'),
     xmlHelpers = require('../../src/util/xml-helpers'),
-    Q = require('q'),
     config = require('../../src/cordova/config'),
     Parser = require('../../src/cordova/metadata/parser'),
-    ConfigParser = require('../../src/configparser/ConfigParser'),
-    cordova = require('../../src/cordova/cordova');
+    ConfigParser = require('../../src/configparser/ConfigParser');
 
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
 
@@ -112,7 +110,9 @@ describe('blackberry10 project parser', function() {
         });
 
         describe('update_from_config method', function() {
-            var xml_name, xml_pkg, xml_version, xml_access_rm, xml_update, xml_append, xml_content;
+            var xml_name, xml_pkg, xml_version, xml_access_rm, xml_update,
+                xml_append, xml_content, xml_access_add, xml_preference_remove,
+                xml_preference_add;
             beforeEach(function() {
                 xml_content = jasmine.createSpy('xml content');
                 xml_name = jasmine.createSpy('xml name');
@@ -175,7 +175,7 @@ describe('blackberry10 project parser', function() {
             });
         });
         describe('update_project method', function() {
-            var config, www, overrides, svn, parse, get_env, write_env;
+            var config, www, overrides, svn, parse;
             beforeEach(function() {
                 config = spyOn(p, 'update_from_config');
                 www = spyOn(p, 'update_www');

--- a/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
@@ -16,6 +16,9 @@
     specific language governing permissions and limitations
     under the License.
 */
+
+/* jshint boss:true */
+
 var platforms = require('../../src/cordova/platforms'),
     util = require('../../src/cordova/util'),
     path = require('path'),
@@ -30,10 +33,10 @@ var platforms = require('../../src/cordova/platforms'),
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
 
 var MANIFEST_JSON = {
-    "launch_path": "/index.html", "installs_allowed_from": [ "*" ], "version": "0.0.1", "name": "HelloCordova",
-    "description": "A sample Apache Cordova application that responds to the deviceready event.",
-    "developer": { "name": "Apache Cordova Team", "url": "http://cordova.io" },
-    "orientation": [ "portrait" ], "icons": { "60": "/icon/icon-60.png", "128": "/icon/icon-128.png" }
+    'launch_path': '/index.html', 'installs_allowed_from': [ '*' ], 'version': '0.0.1', 'name': 'HelloCordova',
+    'description': 'A sample Apache Cordova application that responds to the deviceready event.',
+    'developer': { 'name': 'Apache Cordova Team', 'url': 'http://cordova.io' },
+    'orientation': [ 'portrait' ], 'icons': { '60': '/icon/icon-60.png', '128': '/icon/icon-128.png' }
 };
 
 describe('firefoxos project parser', function() {

--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -22,13 +22,11 @@ var platforms = require('../../src/cordova/platforms'),
     shell = require('shelljs'),
     plist = require('plist'),
     xcode = require('xcode'),
-    et = require('elementtree'),
     fs = require('fs'),
     Q = require('q'),
     config = require('../../src/cordova/config'),
     Parser = require('../../src/cordova/metadata/parser'),
-    ConfigParser = require('../../src/configparser/ConfigParser'),
-    cordova = require('../../src/cordova/cordova');
+    ConfigParser = require('../../src/configparser/ConfigParser');
 
 // Create a real config object before mocking out everything.
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
@@ -94,7 +92,6 @@ describe('ios project parser', function () {
 
         describe('update_from_config method', function() {
             var mv;
-            var cfg_access_add, cfg_access_rm, cfg_pref_add, cfg_pref_rm, cfg_content;
             var plist_parse, plist_build, xc;
             var update_name, xc_write;
             beforeEach(function() {
@@ -109,9 +106,9 @@ describe('ios project parser', function () {
                     updateProductName:update_name,
                     writeSync:xc_write
                 });
-                cfg.name = function() { return 'testname' };
-                cfg.packageName = function() { return 'testpkg' };
-                cfg.version = function() { return 'one point oh' };
+                cfg.name = function() { return 'testname'; };
+                cfg.packageName = function() { return 'testpkg'; };
+                cfg.version = function() { return 'one point oh'; };
             });
 
             it('should update the app name in pbxproj by calling xcode.updateProductName, and move the ios native files to match the new name', function(done) {
@@ -126,13 +123,13 @@ describe('ios project parser', function () {
                 });
             });
             it('should write out the app id to info plist as CFBundleIdentifier', function(done) {
-                cfg.ios_CFBundleIdentifier = function() { return null };
+                cfg.ios_CFBundleIdentifier = function() { return null; };
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg');
                 });
             });
             it('should write out the app id to info plist as CFBundleIdentifier with ios-CFBundleIdentifier', function(done) {
-                cfg.ios_CFBundleIdentifier = function() { return 'testpkg_ios' };
+                cfg.ios_CFBundleIdentifier = function() { return 'testpkg_ios'; };
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].CFBundleIdentifier).toEqual('testpkg_ios');
                 });

--- a/cordova-lib/spec-cordova/metadata/parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/parser.spec.js
@@ -18,7 +18,6 @@
 */
 
 var fs = require('fs'),
-    platforms = require('../../src/cordova/platforms.js'),
     Parser = require('../../src/cordova/metadata/parser'),
     ParserHelper = require('../../src/cordova/metadata/parserhelper/ParserHelper');
 

--- a/cordova-lib/spec-cordova/metadata/windows8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/windows8_parser.spec.js
@@ -17,6 +17,8 @@
     under the License.
 */
 
+/* jshint boss:true */
+
 var platforms = require('../../src/cordova/platforms'),
     util = require('../../src/cordova/util'),
     path = require('path'),
@@ -29,7 +31,6 @@ var platforms = require('../../src/cordova/platforms'),
     config = require('../../src/cordova/config'),
     Parser = require('../../src/cordova/metadata/parser'),
     ConfigParser = require('../../src/configparser/ConfigParser'),
-    cordova = require('../../src/cordova/cordova'),
     HooksRunner = require('../../src/hooks/HooksRunner');
 
 // Create a real config object before mocking out everything.
@@ -38,7 +39,7 @@ var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
 describe('windows8 project parser', function() {
 
     var proj = '/some/path';
-    var exists, exec, custom, readdir, cfg_parser, config_read;
+    var exists, exec, custom, readdir, config_read;
     var winXml;
     beforeEach(function() {
         exists = spyOn(fs, 'existsSync').andReturn(true);
@@ -55,7 +56,7 @@ describe('windows8 project parser', function() {
                     }
                 }
             }
-            : ({})
+            : ({});
         });
         readdir = spyOn(fs, 'readdirSync').andReturn(['test.jsproj']);
         winXml = null;
@@ -116,10 +117,10 @@ describe('windows8 project parser', function() {
 
         describe('update_from_config method', function() {
             beforeEach(function() {
-                cfg.name = function() { return 'testname' };
-                cfg.content = function() { return 'index.html' };
-                cfg.packageName = function() { return 'testpkg' };
-                cfg.version = function() { return 'one point oh' };
+                cfg.name = function() { return 'testname'; };
+                cfg.content = function() { return 'index.html'; };
+                cfg.packageName = function() { return 'testpkg'; };
+                cfg.version = function() { return 'one point oh'; };
                 readdir.andReturn(['test.sln']);
             });
 
@@ -153,7 +154,7 @@ describe('windows8 project parser', function() {
             });
         });
         describe('update_project method', function() {
-            var config, www, overrides, svn, fire;
+            var config, www, svn, fire, shellls;
             beforeEach(function() {
                 config = spyOn(parser, 'update_from_config');
                 www = spyOn(parser, 'update_www');

--- a/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
@@ -17,6 +17,8 @@
     under the License.
 */
 
+/* jshint boss:true, sub:true */
+
 var platforms = require('../../src/cordova/platforms'),
     util = require('../../src/cordova/util'),
     path = require('path'),
@@ -30,7 +32,6 @@ var platforms = require('../../src/cordova/platforms'),
     Parser = require('../../src/cordova/metadata/parser'),
     ConfigParser = require('../../src/configparser/ConfigParser'),
     CordovaError = require('../../src/CordovaError'),
-    cordova = require('../../src/cordova/cordova'),
     HooksRunner = require('../../src/hooks/HooksRunner');
 
 // Create a real config object before mocking out everything.
@@ -53,7 +54,7 @@ MAINPAGEXAML_XML = '<phone:PhoneApplicationPage x:Class="io.cordova.hellocordova
 
 describe('wp8 project parser', function() {
     var proj = '/some/path';
-    var exists, exec, custom, readdir, cfg_parser, config_read;
+    var exists, exec, custom, readdir, config_read;
     var manifestXml, projXml, mainPageXamlXml;
     beforeEach(function() {
         exists = spyOn(fs, 'existsSync').andReturn(true);
@@ -69,7 +70,7 @@ describe('wp8 project parser', function() {
                     }
                 }
             }
-            : ({})
+            : ({});
         });
         readdir = spyOn(fs, 'readdirSync').andReturn(['test.csproj']);
         projXml = manifestXml = mainPageXamlXml = null;
@@ -141,10 +142,10 @@ describe('wp8 project parser', function() {
 
         describe('update_from_config method', function() {
             beforeEach(function() {
-                cfg.name = function() { return 'testname' };
-                cfg.content = function() { return 'index.html' };
-                cfg.packageName = function() { return 'testpkg' };
-                cfg.version = function() { return 'one point oh' };
+                cfg.name = function() { return 'testname'; };
+                cfg.content = function() { return 'index.html'; };
+                cfg.packageName = function() { return 'testpkg'; };
+                cfg.version = function() { return 'one point oh'; };
                 readdir.andReturn(['test.sln']);
             });
 
@@ -166,7 +167,7 @@ describe('wp8 project parser', function() {
             it('should write out the orientation preference value', function() {
                 getOrientation.andCallThrough();
                 p.update_from_config(cfg);
-                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait')
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
             });
             it('should handle no orientation', function() {
@@ -184,13 +185,13 @@ describe('wp8 project parser', function() {
             it('should handle portrait orientation', function() {
                 getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
                 p.update_from_config(cfg);
-                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait')
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
             });
             it('should handle landscape orientation', function() {
                 getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
                 p.update_from_config(cfg);
-                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('landscape')
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('landscape');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('landscape');
             });
             it('should handle custom orientation', function() {
@@ -222,7 +223,7 @@ describe('wp8 project parser', function() {
             });
         });
         describe('update_project method', function() {
-            var config, www, overrides, svn, fire;
+            var config, www, svn, fire;
             beforeEach(function() {
                 config = spyOn(p, 'update_from_config');
                 www = spyOn(p, 'update_www');

--- a/cordova-lib/spec-cordova/platform.spec.js
+++ b/cordova-lib/spec-cordova/platform.spec.js
@@ -21,7 +21,6 @@ var helpers = require('./helpers'),
     path = require('path'),
     fs = require('fs'),
     shell = require('shelljs'),
-    platforms = require('../src/cordova/platforms'),
     superspawn = require('../src/cordova/superspawn'),
     config = require('../src/cordova/config'),
     Q = require('q'),
@@ -32,23 +31,10 @@ var helpers = require('./helpers'),
 
 var projectRoot = 'C:\\Projects\\cordova-projects\\move-tracker';
 
-// Directory containing the 'bin/create' script. 
-var libDir = "C:\\Projects\\cordova-projects\\cordova-android\\";
-
-var cfg;
-var hostSupportsOriginal = platform.__get__('hostSupports');
-var ConfigParserOriginal = platform.__get__('ConfigParser');
-var configOriginal = platform.__get__('config');
-var fsOriginal = platform.__get__('fs');
-var platformsOriginal = platform.__get__('platforms');
-var promiseUtilOriginal = platform.__get__('promiseutil');
-
 describe('platform end-to-end', function () {
 
-    var supported_platforms = Object.keys(platforms).filter(function (p) { return p != 'www'; });
     var tmpDir = helpers.tmpDir('platform_test');
     var project = path.join(tmpDir, 'project');
-    var platformParser = platforms[helpers.testPlatform].parser;
 
     var results;
 
@@ -154,7 +140,7 @@ describe('add function', function () {
     it('throws if the target list is empty', function (done) {
         var targets = [];
         platform.add(hooksRunnerMock, projectRoot, targets, opts).fail(function (error) {
-            expect(error.message).toBe("No platform specified. Please specify a platform to add. See `cordova platform list`.");
+            expect(error.message).toBe('No platform specified. Please specify a platform to add. See `cordova platform list`.');
             done();
         });
     });
@@ -164,15 +150,14 @@ describe('add function', function () {
         // case 1 : target list undefined
         var targets; // = undefined;
         platform.add(hooksRunnerMock, projectRoot, targets, opts).fail(function (error) {
-            expect(error.message).toBe("No platform specified. Please specify a platform to add. See `cordova platform list`.");
+            expect(error.message).toBe('No platform specified. Please specify a platform to add. See `cordova platform list`.');
         });
 
         // case 2 : target list null
         targets = null;
         platform.add(hooksRunnerMock, projectRoot, targets, opts).fail(function (error) {
-            expect(error.message).toBe("No platform specified. Please specify a platform to add. See `cordova platform list`.");
+            expect(error.message).toBe('No platform specified. Please specify a platform to add. See `cordova platform list`.');
             done();
         });
     });
 });
-

--- a/cordova-lib/spec-cordova/plugin.spec.js
+++ b/cordova-lib/spec-cordova/plugin.spec.js
@@ -19,9 +19,7 @@
 
 var helpers = require('./helpers'),
     path = require('path'),
-    fs = require('fs'),
     shell = require('shelljs'),
-    Q = require('q'),
     events = require('../src/events'),
     cordova = require('../src/cordova/cordova');
 

--- a/cordova-lib/spec-cordova/plugin_parser.spec.js
+++ b/cordova-lib/spec-cordova/plugin_parser.spec.js
@@ -16,8 +16,7 @@
     specific language governing permissions and limitations
     under the License.
 */
-var cordova = require('../src/cordova/cordova'),
-    path = require('path'),
+var path = require('path'),
     fs = require('fs'),
     plugin_parser = require('../src/cordova/plugin_parser'),
     xml = path.join(__dirname, 'fixtures', 'plugins', 'test', 'plugin.xml');

--- a/cordova-lib/spec-cordova/prepare.spec.js
+++ b/cordova-lib/spec-cordova/prepare.spec.js
@@ -16,12 +16,11 @@
     specific language governing permissions and limitations
     under the License.
 */
-var cordova = require('../src/cordova/cordova'),
-    shell = require('shelljs'),
+
+var shell = require('shelljs'),
     plugman = require('../src/plugman/plugman'),
     PlatformJson = require('../src/plugman/util/PlatformJson'),
     path = require('path'),
-    fs = require('fs'),
     util = require('../src/cordova/util'),
     prepare = require('../src/cordova/prepare'),
     lazy_load = require('../src/cordova/lazy_load'),
@@ -29,10 +28,8 @@ var cordova = require('../src/cordova/cordova'),
     platforms = require('../src/cordova/platforms'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     xmlHelpers = require('../src/util/xml-helpers'),
-    fixtures = path.join(__dirname, 'fixtures'),
     et = require('elementtree'),
-    Q = require('q'),
-    hooks = path.join(fixtures, 'hooks');
+    Q = require('q');
 
 var project_dir = '/some/path';
 var supported_platforms = Object.keys(platforms).filter(function(p) { return p != 'www'; });
@@ -79,7 +76,7 @@ describe('prepare command', function() {
                 update_www: jasmine.createSpy(p + ' update_www'),
                 cordovajs_path: function(libDir) { return 'path/to/cordova.js/in/.cordova/lib';},
                 www_dir:function() { return path.join(project_dir, 'platforms', p, 'www'); },
-                config_xml: function () { return path.join(project_dir, "platforms", p, "www", "config.xml");}
+                config_xml: function () { return path.join(project_dir, 'platforms', p, 'www', 'config.xml');}
             });
         });
         plugman_prepare = spyOn(plugman, 'prepare').andReturn(Q());
@@ -135,9 +132,7 @@ describe('prepare command', function() {
         describe('plugman integration', function() {
             it('should invoke plugman.prepare after update_project', function(done) {
                 prepare().then(function() {
-                    var plugins_dir = path.join(project_dir, 'plugins');
                     supported_platforms.forEach(function(p) {
-                        var platform_path = path.join(project_dir, 'platforms', p);
                         expect(plugman_prepare).toHaveBeenCalled();
                     });
                 }, function(err) {
@@ -187,91 +182,91 @@ describe('prepare._mergeXml', function () {
     beforeEach(function() {
         dstXml = et.XML(TEST_XML);
     });
-    it("should merge attributes and text of the root element without clobbering", function () {
-        var testXml = et.XML("<widget foo='bar' id='NOTANID'>TEXT</widget>");
+    it('should merge attributes and text of the root element without clobbering', function () {
+        var testXml = et.XML('<widget foo="bar" id="NOTANID">TEXT</widget>');
         prepare._mergeXml(testXml, dstXml);
-        expect(dstXml.attrib.foo).toEqual("bar");
-        expect(dstXml.attrib.id).not.toEqual("NOTANID");
-        expect(dstXml.text).not.toEqual("TEXT");
+        expect(dstXml.attrib.foo).toEqual('bar');
+        expect(dstXml.attrib.id).not.toEqual('NOTANID');
+        expect(dstXml.text).not.toEqual('TEXT');
     });
 
-    it("should merge attributes and text of the root element with clobbering", function () {
-        var testXml = et.XML("<widget foo='bar' id='NOTANID'>TEXT</widget>");
-        prepare._mergeXml(testXml, dstXml, "foo", true);
-        expect(dstXml.attrib.foo).toEqual("bar");
-        expect(dstXml.attrib.id).toEqual("NOTANID");
-        expect(dstXml.text).toEqual("TEXT");
+    it('should merge attributes and text of the root element with clobbering', function () {
+        var testXml = et.XML('<widget foo="bar" id="NOTANID">TEXT</widget>');
+        prepare._mergeXml(testXml, dstXml, 'foo', true);
+        expect(dstXml.attrib.foo).toEqual('bar');
+        expect(dstXml.attrib.id).toEqual('NOTANID');
+        expect(dstXml.text).toEqual('TEXT');
     });
 
-    it("should not merge platform tags with the wrong platform", function () {
-        var testXml = et.XML("<widget><platform name='bar'><testElement testAttrib='value'>testTEXT</testElement></platform></widget>"),
+    it('should not merge platform tags with the wrong platform', function () {
+        var testXml = et.XML('<widget><platform name="bar"><testElement testAttrib="value">testTEXT</testElement></platform></widget>'),
             origCfg = et.tostring(dstXml);
 
-        prepare._mergeXml(testXml, dstXml, "foo", true);
+        prepare._mergeXml(testXml, dstXml, 'foo', true);
         expect(et.tostring(dstXml)).toEqual(origCfg);
     });
 
-    it("should merge platform tags with the correct platform", function () {
-        var testXml = et.XML("<widget><platform name='bar'><testElement testAttrib='value'>testTEXT</testElement></platform></widget>"),
+    it('should merge platform tags with the correct platform', function () {
+        var testXml = et.XML('<widget><platform name="bar"><testElement testAttrib="value">testTEXT</testElement></platform></widget>'),
             origCfg = et.tostring(dstXml);
 
-        prepare._mergeXml(testXml, dstXml, "bar", true);
+        prepare._mergeXml(testXml, dstXml, 'bar', true);
         expect(et.tostring(dstXml)).not.toEqual(origCfg);
-        var testElement = dstXml.find("testElement");
+        var testElement = dstXml.find('testElement');
         expect(testElement).toBeDefined();
-        expect(testElement.attrib.testAttrib).toEqual("value");
-        expect(testElement.text).toEqual("testTEXT");
+        expect(testElement.attrib.testAttrib).toEqual('value');
+        expect(testElement.text).toEqual('testTEXT');
     });
 
-    it("should merge singelton children without clobber", function () {
-        var testXml = et.XML("<widget><author testAttrib='value' href='http://www.nowhere.com'>SUPER_AUTHOR</author></widget>");
+    it('should merge singelton children without clobber', function () {
+        var testXml = et.XML('<widget><author testAttrib="value" href="http://www.nowhere.com">SUPER_AUTHOR</author></widget>');
 
         prepare._mergeXml(testXml, dstXml);
-        var testElements = dstXml.findall("author");
+        var testElements = dstXml.findall('author');
         expect(testElements).toBeDefined();
         expect(testElements.length).toEqual(1);
-        expect(testElements[0].attrib.testAttrib).toEqual("value");
-        expect(testElements[0].attrib.href).toEqual("http://cordova.io");
-        expect(testElements[0].attrib.email).toEqual("dev@cordova.apache.org");
-        expect(testElements[0].text).toContain("Apache Cordova Team");
+        expect(testElements[0].attrib.testAttrib).toEqual('value');
+        expect(testElements[0].attrib.href).toEqual('http://cordova.io');
+        expect(testElements[0].attrib.email).toEqual('dev@cordova.apache.org');
+        expect(testElements[0].text).toContain('Apache Cordova Team');
     });
 
-    it("should clobber singelton children with clobber", function () {
-        var testXml = et.XML("<widget><author testAttrib='value' href='http://www.nowhere.com'>SUPER_AUTHOR</author></widget>");
+    it('should clobber singelton children with clobber', function () {
+        var testXml = et.XML('<widget><author testAttrib="value" href="http://www.nowhere.com">SUPER_AUTHOR</author></widget>');
 
         prepare._mergeXml(testXml, dstXml, '', true);
-        var testElements = dstXml.findall("author");
+        var testElements = dstXml.findall('author');
         expect(testElements).toBeDefined();
         expect(testElements.length).toEqual(1);
-        expect(testElements[0].attrib.testAttrib).toEqual("value");
-        expect(testElements[0].attrib.href).toEqual("http://www.nowhere.com");
-        expect(testElements[0].attrib.email).toEqual("dev@cordova.apache.org");
-        expect(testElements[0].text).toEqual("SUPER_AUTHOR");
+        expect(testElements[0].attrib.testAttrib).toEqual('value');
+        expect(testElements[0].attrib.href).toEqual('http://www.nowhere.com');
+        expect(testElements[0].attrib.email).toEqual('dev@cordova.apache.org');
+        expect(testElements[0].text).toEqual('SUPER_AUTHOR');
     });
 
-    it("should append non singelton children", function () {
-        var testXml = et.XML("<widget><preference num='1'/> <preference num='2'/></widget>");
+    it('should append non singelton children', function () {
+        var testXml = et.XML('<widget><preference num="1"/> <preference num="2"/></widget>');
 
         prepare._mergeXml(testXml, dstXml, '', true);
-        var testElements = dstXml.findall("preference");
+        var testElements = dstXml.findall('preference');
         expect(testElements.length).toEqual(4);
     });
 
-    it("should handle namespaced elements", function () {
-        var testXml = et.XML("<widget><foo:bar testAttrib='value'>testText</foo:bar></widget>");
+    it('should handle namespaced elements', function () {
+        var testXml = et.XML('<widget><foo:bar testAttrib="value">testText</foo:bar></widget>');
 
         prepare._mergeXml(testXml, dstXml, 'foo', true);
-        var testElement = dstXml.find("foo:bar");
+        var testElement = dstXml.find('foo:bar');
         expect(testElement).toBeDefined();
-        expect(testElement.attrib.testAttrib).toEqual("value");
-        expect(testElement.text).toEqual("testText");
+        expect(testElement.attrib.testAttrib).toEqual('value');
+        expect(testElement.text).toEqual('testText');
     });
 
-    it("should not append duplicate non singelton children", function () {
-        var testXml = et.XML("<widget><preference name='fullscreen' value='true'/></widget>");
+    it('should not append duplicate non singelton children', function () {
+        var testXml = et.XML('<widget><preference name="fullscreen" value="true"/></widget>');
 
         prepare._mergeXml(testXml, dstXml, '', true);
-        var testElements = dstXml.findall("preference");
+        var testElements = dstXml.findall('preference');
         expect(testElements.length).toEqual(2);
     });
 });

--- a/cordova-lib/spec-cordova/restore.spec.js
+++ b/cordova-lib/spec-cordova/restore.spec.js
@@ -21,11 +21,10 @@ var path = require('path'),
     Q = require('q'),
     cordova = require('../src/cordova/cordova'),
     cordova_util = require('../src/cordova/util'),
-    ConfigParser = require('../src/configparser/ConfigParser'),
     project_dir = path.join(__dirname, 'fixtures', 'base');
 
 describe('restore command', function(){
-  var is_cordova, result, config_add_feature, cd_project;
+  var is_cordova, result;
 
    function wrapper(f, post) {
         runs(function() {
@@ -48,7 +47,6 @@ describe('restore command', function(){
   });
 
   it('should not try to restore features from config.xml', function(){
-      cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
       var call_count =0;
       expect(installPluginsFromConfigXML).toBeDefined();
       function installPluginsFromConfigXML(cfg){
@@ -60,7 +58,6 @@ describe('restore command', function(){
   });
 
   it('should not try to restore platforms from config.xml', function(){
-      cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
       var call_count =0;
       expect(installPlatformsFromConfigXML).toBeDefined();
       function installPlatformsFromConfigXML(cfg){

--- a/cordova-lib/spec-cordova/run.spec.js
+++ b/cordova-lib/spec-cordova/run.spec.js
@@ -20,7 +20,6 @@ var cordova = require('../src/cordova/cordova'),
     platforms = require('../src/cordova/platforms'),
     superspawn = require('../src/cordova/superspawn'),
     path = require('path'),
-    fs = require('fs'),
     HooksRunner = require('../src/hooks/HooksRunner'),
     Q = require('q'),
     util = require('../src/cordova/util');

--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -25,7 +25,7 @@ var path = require('path'),
     project_dir = path.join(__dirname, 'fixtures', 'base');
 
 describe('save command', function(){
-  var is_cordova, result, config_add_feature, cd_project;
+  var is_cordova, result;
 
    function wrapper(f, post) {
         runs(function() {
@@ -48,7 +48,6 @@ describe('save command', function(){
   });
 
   it('should not try to add features to config.xml', function(){
-    cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
     var parserWriter = spyOn(ConfigParser.prototype, 'write');
     expect(ConfigParser.prototype.write).not.toHaveBeenCalled();
     cordova.save('plugins');
@@ -57,11 +56,10 @@ describe('save command', function(){
   });
 
   it('should not try to add platforms to config.xml', function(){
-    cd_project_root = spyOn(cordova_util, 'cdProjectRoot').andReturn(project_dir);
     var call_count =0;
     ConfigParser.prototype.write = function(){
       call_count++;
-    }
+    };
     expect(call_count).toEqual(0);
     cordova.save('platforms');
     expect(call_count).toEqual(0);

--- a/cordova-lib/spec-cordova/serve.spec.js
+++ b/cordova-lib/spec-cordova/serve.spec.js
@@ -16,6 +16,10 @@
     specific language governing permissions and limitations
     under the License.
 */
+
+/* jshint expr: true */
+/* global xdescribe */
+
 var cordova = require('../src/cordova/cordova'),
     console = require('console'),
     path = require('path'),
@@ -24,12 +28,7 @@ var cordova = require('../src/cordova/cordova'),
     Q = require('q'),
     util = require('../src/cordova/util'),
     tempDir,
-    http = require('http'),
-    firefoxos_parser = require('../src/cordova/metadata/firefoxos_parser'),
-    android_parser = require('../src/cordova/metadata/android_parser'),
-    ios_parser = require('../src/cordova/metadata/ios_parser'),
-    blackberry_parser = require('../src/cordova/metadata/blackberry10_parser'),
-    wp8_parser        = require('../src/cordova/metadata/wp8_parser');
+    http = require('http');
 
 var cwd = process.cwd();
 
@@ -47,7 +46,7 @@ xdescribe('serve command', function() {
         process.chdir(cwd);
         process.env.PWD = cwd;
         shell.rm('-rf', tempDir);
-    })
+    });
     it('should not run outside of a Cordova-based project', function() {
         process.chdir(tempDir);
 
@@ -56,7 +55,7 @@ xdescribe('serve command', function() {
                 expect(server).toBe(null);
                 server.close();
             });
-        }).toThrow("Current working directory is not a Cordova-based project.");
+        }).toThrow('Current working directory is not a Cordova-based project.');
     });
 
     describe('`serve`', function() {
@@ -140,7 +139,7 @@ xdescribe('serve command', function() {
                             response += data;
                         });
                         res.on('end', function() {
-                            expect(response).toEqual(expectedContents)
+                            expect(response).toEqual(expectedContents);
                             if (response === expectedContents) {
                                 expect(res.statusCode).toEqual(200);
                             }
@@ -162,11 +161,11 @@ xdescribe('serve command', function() {
                     server && server.close();
                 });
             };
-        };
+        }
 
         it('should serve from top-level www if the file exists there', function() {
             var payload = 'This is test file.';
-            payloads.firefoxos = 'This is the firefoxos test file.'
+            payloads.firefoxos = 'This is the firefoxos test file.';
             test_serve('firefoxos', '/basictest.html', payload, {
                 setup: function (){
                     fs.writeFileSync(path.join(util.projectWww(tempDir), 'basictest.html'), payload);
@@ -176,7 +175,7 @@ xdescribe('serve command', function() {
 
         it('should honour a custom port setting', function() {
             var payload = 'This is test file.';
-            payloads.firefoxos = 'This is the firefoxos test file.'
+            payloads.firefoxos = 'This is the firefoxos test file.';
             test_serve('firefoxos', '/basictest.html', payload, {
                 port: 9001,
                 setup: function (){

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -16,13 +16,14 @@
     specific language governing permissions and limitations
     under the License.
 */
-var cordova = require('../src/cordova/cordova'),
-    shell = require('shelljs'),
+
+/* jshint sub: true */
+
+var shell = require('shelljs'),
     path = require('path'),
     fs = require('fs'),
     util = require('../src/cordova/util'),
-    temp = path.join(__dirname, '..', 'temp'),
-    fixtures = path.join(__dirname, 'fixtures');
+    temp = path.join(__dirname, '..', 'temp');
 
 var cwd = process.cwd();
 var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];

--- a/cordova-lib/spec-cordova/wrappers.spec.js
+++ b/cordova-lib/spec-cordova/wrappers.spec.js
@@ -16,6 +16,9 @@
     specific language governing permissions and limitations
     under the License.
 */
+
+/* jshint loopfunc: true */
+
 var Q = require('q'),
     cordova = require('../src/cordova/cordova');
 

--- a/cordova-lib/spec-cordova/xml-helpers.spec.js
+++ b/cordova-lib/spec-cordova/xml-helpers.spec.js
@@ -17,6 +17,8 @@
     under the License.
 */
 
+/* jshint laxcomma: true, multistr: true */
+
 var path = require('path')
   , xml_helpers = require('../src/util/xml-helpers')
   , et = require('elementtree')
@@ -24,13 +26,13 @@ var path = require('path')
   , title = et.XML('<title>HELLO</title>')
   , usesNetworkOne = et.XML('<uses-permission ' +
             'android:name="PACKAGE_NAME.permission.C2D_MESSAGE"/>')
-  , usesNetworkTwo = et.XML("<uses-permission android:name=\
-            \"PACKAGE_NAME.permission.C2D_MESSAGE\" />")
-  , usesReceive = et.XML("<uses-permission android:name=\
-            \"com.google.android.c2dm.permission.RECEIVE\"/>")
-  , helloTagOne = et.XML("<h1>HELLO</h1>")
-  , goodbyeTag = et.XML("<h1>GOODBYE</h1>")
-  , helloTagTwo = et.XML("<h1>  HELLO  </h1>");
+  , usesNetworkTwo = et.XML('<uses-permission android:name=\
+            "PACKAGE_NAME.permission.C2D_MESSAGE" />')
+  , usesReceive = et.XML('<uses-permission android:name=\
+            "com.google.android.c2dm.permission.RECEIVE"/>')
+  , helloTagOne = et.XML('<h1>HELLO</h1>')
+  , goodbyeTag = et.XML('<h1>GOODBYE</h1>')
+  , helloTagTwo = et.XML('<h1>  HELLO  </h1>');
 
 
 describe('xml-helpers', function(){
@@ -40,7 +42,7 @@ describe('xml-helpers', function(){
             expect(function() {
                 xml_helpers.parseElementtreeSync(xml_path);
             }).not.toThrow();
-        })
+        });
     });
     describe('equalNodes', function() {
         it('should return false for different tags', function(){


### PR DESCRIPTION
This change enables jshint for spec-cordova meaning that `npm run jshint` will not only check `src` folder but `spec-cordova` too. I've also fixed all the JSHint issues for the spec-cordova.