### PR TITLE
CB-8406 BugFix: 'cordova platform update' updates platform to the version in config.xml instead of pinned version

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -91,6 +91,13 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     platform = null;
                 }
                 if (platform) {
+
+                    // CB-8406 : Prevent 'cordova platform update' from updating to the version used in config.xml
+                    // instead, use the pinned version
+                    if(cmd == 'update'){
+                        version = platforms[platform].version;
+                    }
+
                     if (!version) {
                         events.emit('verbose', 'No version supplied. Retrieving version from config.xml...');
                     }


### PR DESCRIPTION
CB-8406:
-'cordova platform update' updates platform to the version in config.xml instead of to the pinned version
- details can be found in this jira: https://issues.apache.org/jira/browse/CB-8406
