### PR TITLE
CB-8457: Ignore version specifier when running hooks

### DIFF
--- a/cordova-lib/src/hooks/HooksRunner.js
+++ b/cordova-lib/src/hooks/HooksRunner.js
@@ -67,6 +67,7 @@ HooksRunner.prototype.prepareOptions = function(opts) {
     opts.projectRoot = this.projectRoot;
     opts.cordova = opts.cordova || {};
     opts.cordova.platforms = opts.cordova.platforms || opts.platforms || cordovaUtil.listPlatforms(opts.projectRoot);
+    opts.cordova.platforms = opts.cordova.platforms.map(function(platform) { return platform.split("@")[0]; } );
     opts.cordova.plugins = opts.cordova.plugins || opts.plugins || cordovaUtil.findPlugins(path.join(opts.projectRoot, 'plugins'));
 
     try {

--- a/cordova-lib/src/hooks/HooksRunner.js
+++ b/cordova-lib/src/hooks/HooksRunner.js
@@ -67,7 +67,7 @@ HooksRunner.prototype.prepareOptions = function(opts) {
     opts.projectRoot = this.projectRoot;
     opts.cordova = opts.cordova || {};
     opts.cordova.platforms = opts.cordova.platforms || opts.platforms || cordovaUtil.listPlatforms(opts.projectRoot);
-    opts.cordova.platforms = opts.cordova.platforms.map(function(platform) { return platform.split("@")[0]; } );
+    opts.cordova.platforms = opts.cordova.platforms.map(function(platform) { return platform.split('@')[0]; } );
     opts.cordova.plugins = opts.cordova.plugins || opts.plugins || cordovaUtil.findPlugins(path.join(opts.projectRoot, 'plugins'));
 
     try {


### PR DESCRIPTION
Trims the version specifier when running hooks. This allows platform add hooks to run when a version specific platform add command is used.