### PR TITLE
CB-8472 Can't find config.xml error installing platform after plugin.

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -151,6 +151,8 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     return superspawn.spawn(bin, args, copts);
                 }).then(function() {
                     copy_cordova_js(projectRoot, platform);
+                }).then(function () {
+                    return require('./cordova').raw.prepare(platform);
                 }).then(function() {
                     if (cmd == 'add') {
                         return installPluginsForNewPlatform(platform, projectRoot, cfg, opts);
@@ -163,14 +165,12 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                         cfg.removeEngine(platform);
                         cfg.addEngine(platform, version);
                         cfg.write();
-                    }                    
+                    }
                 });
             });
         });
     }).then(function() {
         return hooksRunner.fire('after_platform_' + cmd, opts);
-    }).then(function() {
-        return require('./cordova').raw.prepare(platform);
     });
 }
 


### PR DESCRIPTION
Recent changes to the process of adding a platform meant we were trying to trying to install plugins for the platform before we had called prepare() for the platform. Also, we were calling prepare() outside the loop that processes each platform, which meant the plaform local variable was not in scope, and we were passing a reference to a function called platform() to prepare() rather than a platform name.

Fixed this by moving the prepare() call back where it used to be - just before we install plugins.