### PR TITLE
CB-8482: Update engine syntax within config.xml

### DIFF
--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -385,24 +385,24 @@ ConfigParser.prototype = {
 
     /**
      * Adds an engine. Does not check for duplicates.
-     * @param  {String} id the engine id
+     * @param  {String} name the engine name
      * @param  {String} version engine version (optional)
      */
-    addEngine: function(id, version){
-        if(!id) return;
-        var el = et.Element('{http://cordova.apache.org/ns/1.0}engine');
-        el.attrib.id = id;
+    addEngine: function(name, version){
+        if(!name) return;
+        var el = et.Element('engine');
+        el.attrib.name = name;
         if(version){
             el.attrib.version = version;
         }
         this.doc.getroot().append(el);
     },
     /**
-     * Removes all the engines with given id
-     * @param  {String} id the engine id.
+     * Removes all the engines with given name
+     * @param  {String} name the engine name.
      */
-    removeEngine: function(id){
-        var engines = this.doc.findall('./'+this.cdvNamespacePrefix+':engine/[@id="' +id+'"]');
+    removeEngine: function(name){
+        var engines = this.doc.findall('./engine/[@name="' +name+'"]');
         for(var i=0; i < engines.length; i++){
             var childs = this.doc.getroot().getchildren();
             var idx = childs.indexOf(engines[i]);
@@ -412,11 +412,11 @@ ConfigParser.prototype = {
         }
     },
     getEngines: function(){
-        var engines = this.doc.findall('./'+this.cdvNamespacePrefix+':engine');
+        var engines = this.doc.findall('./engine');
         return engines.map(function(engine){
 	    var version = engine.attrib.version;
             return {
-		'id': engine.attrib.id,
+		'name': engine.attrib.name,
 		'version': version ? version : null
 	    };
         });

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -244,7 +244,7 @@ function getVersionFromConfigFile(platform, cfg) {
 
     // Get appropriate version from config.xml
     var engine = _.find(cfg.getEngines(), function(eng){
-	return eng.id.toLowerCase() === platform.toLowerCase();
+	return eng.name.toLowerCase() === platform.toLowerCase();
     });
 
     return engine && engine.version;

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -266,11 +266,11 @@ function remove(hooksRunner, projectRoot, targets, opts) {
         var autosave =  config_json.auto_save_platforms || false;
 	if(opts.save || autosave){
 	    targets.forEach(function(target) {
-		var platformId = target.split('@')[0];
+		var platformName = target.split('@')[0];
 		var xml = cordova_util.projectConfig(projectRoot);
 		var cfg = new ConfigParser(xml);
 		events.emit('log', 'Removing ' + target + ' from config.xml file ...');
-		cfg.removeEngine(platformId);
+		cfg.removeEngine(platformName);
 		cfg.write();
 	    });
 	}

--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -37,12 +37,12 @@ function installPlatformsFromConfigXML(platforms){
 
     var engines = cfg.getEngines(projectHome);
     var targets = engines.map(function(engine){
-        var platformPath = path.join(projectHome, 'platforms', engine.id);
+        var platformPath = path.join(projectHome, 'platforms', engine.name);
         var platformAlreadyAdded = fs.existsSync(platformPath);
 
        //if no platforms are specified we skip.
-       if( (platforms && platforms.indexOf(engine.id)> -1 ) && !platformAlreadyAdded ){
-         var t = engine.id;
+       if( (platforms && platforms.indexOf(engine.name)> -1 ) && !platformAlreadyAdded ){
+         var t = engine.name;
          if(engine.version){
            t += '@'+engine.version;
          }


### PR DESCRIPTION
CB-8482: Update engine syntax within config.xml

- from : `<cdv:engine id="android" version="3.7.0-dev" />`
- to :      `<engine name="android" version="3.7.0-dev" />`
- updated and tested all modules that depended on old syntax