### PR TITLE
Make required subdirectories for icons

### DIFF
--- a/cordova-lib/src/cordova/metadata/blackberry10_parser.js
+++ b/cordova-lib/src/cordova/metadata/blackberry10_parser.js
@@ -65,7 +65,7 @@ blackberry_parser.prototype.update_from_config = function(config) {
                 destFolder = path.join(dest, '..');
 
             if (!fs.existsSync(destFolder)) {
-                shell.mkdir(destFolder); // make sure target dir exists
+                shell.mkdir('-p', destFolder); // make sure target dir exists
             }
             events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
             shell.cp('-f', src, dest);


### PR DESCRIPTION
I was getting a 'no such file or directory' error when adding the 'blackberry10' platform when I has icons indicated in paths with more than one level. I've added the '-p' directive when creating the icon paths to prevent this error'