### PR TITLE
CB-7827: Allow user to specify android activity name

### DIFF
--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -108,6 +108,9 @@ ConfigParser.prototype = {
     android_packageName: function() {
         return this.doc.getroot().attrib['android-packageName'];
     },
+    android_activityName: function() {
+	return this.doc.getroot().attrib['android-activityName'];
+    },
     ios_CFBundleIdentifier: function() {
         return this.doc.getroot().attrib['ios-CFBundleIdentifier'];
     },

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -521,7 +521,7 @@ function getCreateArgs(platDetails, projectRoot, cfg, template_dir, opts) {
     if (/android|ios/.exec(platDetails.platform) && semver.gt(platDetails.version, '3.3.0')) {
         args.push('--cli');
     }
-    
+
     var pkg = cfg.packageName().replace(/[^\w.]/g,'_');
     // CB-6992 it is necessary to normalize characters
     // because node and shell scripts handles unicode symbols differently
@@ -530,9 +530,9 @@ function getCreateArgs(platDetails, projectRoot, cfg, template_dir, opts) {
     args.push(output, pkg, name);
 
     var activityName = cfg.android_activityName();
-    if (activityName && platDetails.platform === 'android') {
-        activityName = activityName.replace(/W/g, '');
-	args.push(activityName);
+    if (activityName && platDetails.platform === 'android' && semver.gte(platDetails.version, '4.0.0-dev')) {
+        activityName = activityName.replace(/\W/g, '');
+        args.push('--activity-name', activityName);
     }
 
     if (template_dir) {

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -521,19 +521,27 @@ function getCreateArgs(platDetails, projectRoot, cfg, template_dir, opts) {
     if (/android|ios/.exec(platDetails.platform) && semver.gt(platDetails.version, '3.3.0')) {
         args.push('--cli');
     }
-
+    
     var pkg = cfg.packageName().replace(/[^\w.]/g,'_');
     // CB-6992 it is necessary to normalize characters
     // because node and shell scripts handles unicode symbols differently
     // We need to normalize the name to NFD form since iOS uses NFD unicode form
     var name = platDetails.platform == 'ios' ? unorm.nfd(cfg.name()) : cfg.name();
     args.push(output, pkg, name);
+
+    var activityName = cfg.android_activityName();
+    if (activityName && platDetails.platform === 'android') {
+        activityName = activityName.replace(/W/g, '');
+	args.push(activityName);
+    }
+
     if (template_dir) {
         args.push(template_dir);
     }
     if (opts.link) {
         args.push('--link');
     }
+
     return args;
 }
 


### PR DESCRIPTION
This change adds an attribute to config.xml android-activityName that can be used to specify a custom activity name. If none is specified it will still default to MainActivity. See http://markmail.org/message/pj5ig4b54nk4l7dr for a discussion of this issue.