### PR TITLE
CB-8577 BugFix 'cordova plugin add <plugin> --save' should properly save variables into config.xml to enable restoring later on.

### DIFF
--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -368,7 +368,7 @@ ConfigParser.prototype = {
     /**
      *This does not check for duplicate feature entries
      */
-    addFeature: function (name, params){
+    addFeature: function (name, params, variables){
         if(!name) return;
         var el = new et.Element('feature');
         el.attrib.name = name;
@@ -378,6 +378,14 @@ ConfigParser.prototype = {
                 p.attrib.name = param.name;
                 p.attrib.value = param.value;
                 el.append(p);
+            });
+        }
+        if (variables) {
+            variables.forEach(function(variable){
+                var v = new et.Element('variable');
+                v.attrib.name = variable.name;
+                v.attrib.value = variable.value;
+                el.append(v);
             });
         }
         this.doc.getroot().append(el);

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -141,6 +141,7 @@ module.exports = function plugin(command, targets, opts) {
                             var pluginInfo =  pluginInfoProvider.get(dir);
                             var existingFeature = cfg.getFeature(pluginInfo.id);
                             if(!existingFeature){
+                                var variables = [];
                                 var params = [{name:'id', value:pluginInfo.id}];
                                 var pluginVersion = versionFromTargetString(target);
                                 if(!pluginVersion && opts.shrinkwrap){
@@ -163,11 +164,11 @@ module.exports = function plugin(command, targets, opts) {
                                 if(opts.cli_variables){
                                     for(var varname in opts.cli_variables){
                                         if(opts.cli_variables.hasOwnProperty(varname)){
-                                            params.push({name:varname, value:opts.cli_variables[varname]});
+                                            variables.push({name:varname, value:opts.cli_variables[varname]});
                                         }
                                     } 
                                 }
-                                cfg.addFeature(pluginInfo.name, params);
+                                cfg.addFeature(pluginInfo.name, params, variables);
                                 cfg.write();
                                 events.emit('results', 'Saved plugin info for "'+pluginInfo.id+'" to config.xml');
                             }else{


### PR DESCRIPTION
CB-8577 BugFix 'cordova plugin add <plugin> --save' should properly save variables into config.xml to enable restoring later on.