### PR TITLE
Deprecate the old feature syntax from config.xml

### DIFF
--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -114,78 +114,94 @@ describe('config.xml parser', function () {
                 expect(cfg.getPlatformPreference('orientation', 'foobar')).toEqual('');
             });
         });
-        describe('feature',function(){
-            it('should read feature id list', function() {
+        describe('plugin',function(){
+            it('should read plugin id list', function() {
                var expectedList = [
                    'org.apache.cordova.featurewithvars',
                    'org.apache.cordova.featurewithurl',
                    'org.apache.cordova.featurewithversion',
                    'org.apache.cordova.featurewithurlandversion',
-                   'org.apache.cordova.justafeature'
+                   'org.apache.cordova.justafeature',
+                   'org.apache.cordova.legacyfeature'
                ];
-               var list = cfg.getFeatureIdList();
+               var list = cfg.getPluginIdList();
                expect(list.length).toEqual(expectedList.length);
-               expectedList.forEach(function(feature){
-                   expect(list).toContain(feature);
+               expectedList.forEach(function(plugin){
+               expect(list).toContain(plugin);
                });
             });
-            it('should read feature given id', function(){
-                var feature = cfg.getFeature('org.apache.cordova.justafeature');
-                expect(feature).toBeDefined();
-                expect(feature.name).toEqual('A simple feature');
-                expect(feature.id).toEqual('org.apache.cordova.justafeature');
-                expect(feature.params).toBeDefined();
-                expect(feature.params.id).toBeDefined();
-                expect(feature.params.id).toEqual('org.apache.cordova.justafeature');
+            it('should read plugin given id', function(){
+                var plugin = cfg.getPlugin('org.apache.cordova.justafeature');
+                expect(plugin).toBeDefined();
+                expect(plugin.name).toEqual('org.apache.cordova.justafeature');
+                expect(plugin.variables).toBeDefined();
             });
-            it('should not read feature given undefined id', function(){
-                var feature = cfg.getFeature('org.apache.cordova.undefinedfeature');
-                expect(feature).not.toBeDefined();
+            it('should not read plugin given undefined id', function(){
+                var plugin = cfg.getPlugin('org.apache.cordova.undefinedfeature');
+                expect(plugin).not.toBeDefined();
             });
-            it('should read feature with url and set \'url\' param', function(){
-                var feature = cfg.getFeature('org.apache.cordova.featurewithurl');
-                expect(feature.url).toEqual('http://cordova.apache.org/featurewithurl');
-                expect(feature.params).toBeDefined();
-                expect(feature.params.url).toBeDefined();
-                expect(feature.params.url).toEqual('http://cordova.apache.org/featurewithurl');
+            it('should read plugin with src', function(){
+                var plugin = cfg.getPlugin('org.apache.cordova.featurewithurl');
+                expect(plugin.src).toEqual('http://cordova.apache.org/featurewithurl');
             });
-            it('should read feature with version and set \'version\' param', function(){
-                var feature = cfg.getFeature('org.apache.cordova.featurewithversion');
-                expect(feature.version).toEqual('1.1.1');
-                expect(feature.params).toBeDefined();
-                expect(feature.params.version).toBeDefined();
-                expect(feature.params.version).toEqual('1.1.1');
+            it('should read plugin with version', function(){
+                var plugin = cfg.getPlugin('org.apache.cordova.featurewithversion');
+                expect(plugin.version).toEqual('1.1.1');
             });
-            it('should read feature variables', function () {
-                var feature = cfg.getFeature('org.apache.cordova.featurewithvars');
-                expect(feature.variables).toBeDefined();
-                expect(feature.variables.var).toBeDefined();
-                expect(feature.variables.var).toEqual('varvalue');
+            it('should read plugin variables', function () {
+                var plugin = cfg.getPlugin('org.apache.cordova.featurewithvars');
+                expect(plugin.variables).toBeDefined();
+                expect(plugin.variables.var).toBeDefined();
+                expect(plugin.variables.var).toEqual('varvalue');
             });
-            it('should allow adding a new feature', function(){
-                cfg.addFeature('myfeature');
-                var features = cfg.doc.findall('feature');
-                var featureNames = features.map(function(feature){
-                    return feature.attrib.name;
+            it('should allow adding a new plugin', function(){
+                cfg.addPlugin({name:'myfeature'});
+                var plugins = cfg.doc.findall('plugin');
+                var pluginNames = plugins.map(function(plugin){
+                    return plugin.attrib.name;
                 });
-                expect(featureNames).toContain('myfeature');
+                expect(pluginNames).toContain('myfeature');
             });
             it('should allow adding features with params', function(){
-                cfg.addFeature('afeature', JSON.parse('[{"name":"paraname", "value":"paravalue"}]'));
-                var features = cfg.doc.findall('feature');
-                var feature  = (function(){
-                    var i = features.length;
+                cfg.addPlugin({name:'afeature'}, [{name:'paraname',value:'paravalue'}]);
+                var plugins = cfg.doc.findall('plugin');
+                var plugin  = (function(){
+                    var i = plugins.length;
                     var f;
                     while (--i >= 0) {
-                        f = features[i];
+                        f = plugins[i];
                         if ('afeature' === f.attrib.name) return f;
                     }
                     return undefined;
                 })();
-                expect(feature).toBeDefined();
-                var params = feature.findall('param');
-                expect(params[0].attrib.name).toEqual('paraname');
-                expect(params[0].attrib.value).toEqual('paravalue');
+                expect(plugin).toBeDefined();
+                var variables = plugin.findall('variable');
+                expect(variables[0].attrib.name).toEqual('paraname');
+                expect(variables[0].attrib.value).toEqual('paravalue');
+            });
+            it('should be able to read legacy feature entries', function(){
+                var plugin = cfg.getPlugin('org.apache.cordova.legacyfeature');
+                expect(plugin).toBeDefined();
+                expect(plugin.name).toEqual('org.apache.cordova.legacyfeature');
+                expect(plugin.version).toEqual('1.2.3');
+                expect(plugin.variables).toBeDefined();
+                expect(plugin.variables.aVar).toEqual('aValue');
+            });
+            it('it should remove given plugin', function(){
+                cfg.removePlugin('org.apache.cordova.justafeature');
+                var plugins = cfg.doc.findall('plugin');
+                var pluginNames = plugins.map(function(plugin){
+                    return plugin.attrib.name;
+                });
+                expect(pluginNames).not.toContain('org.apache.cordova.justafeature');
+            });
+            it('it should remove given legacy feature id', function(){
+                cfg.removePlugin('org.apache.cordova.legacyfeature');
+                var plugins = cfg.doc.findall('feature');
+                var pluginNames = plugins.map(function(plugin){
+                    return plugin.attrib.name;
+                });
+                expect(pluginNames).not.toContain('org.apache.cordova.legacyfeature');
             });
         });
     });

--- a/cordova-lib/spec-cordova/test-config.xml
+++ b/cordova-lib/spec-cordova/test-config.xml
@@ -1,53 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<widget xmlns     = "http://www.w3.org/ns/widgets"
-        xmlns:cdv = "http://cordova.apache.org/ns/1.0"
-        id        = "io.cordova.hellocordova"
-        version   = "0.0.1"
-        android-packageName="io.cordova.hellocordova.android"
-        ios-CFBundleIdentifier="io.cordova.hellocordova.ios">
+<?xml version='1.0' encoding='utf-8'?>
+<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Hello Cordova</name>
-
     <description>
         A sample Apache Cordova application that responds to the deviceready event.
     </description>
-
-    <author href="http://cordova.io" email="dev@cordova.apache.org">
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
         Apache Cordova Team
     </author>
-
     <content src="index.html" />
-
     <access origin="*" />
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <preference name="orientation" value="portrait" />
     <icon id="icon" src="icon.png" />
-    <icon id="logo" src="logo.png" width="255" height="255" />
+    <icon height="255" id="logo" src="logo.png" width="255" />
     <platform name="android">
-        <icon src="logo-android.png" width="255" height="255" density="mdpi" />
+        <icon density="mdpi" height="255" src="logo-android.png" width="255" />
         <preference name="android-minSdkVersion" value="10" />
         <preference name="orientation" value="landscape" />
     </platform>
-
-    <!-- Features -->
-    <feature name="A feature with preference">
-        <param name="id" value="org.apache.cordova.featurewithvars"/>
-        <param name="var" value="varvalue"/>
-    </feature>
-    <feature name="A feature with url">
-        <param name="id" value="org.apache.cordova.featurewithurl" />
-        <param name="url" value="http://cordova.apache.org/featurewithurl" />
-    </feature>
-    <feature name="A feature with version">
-        <param name="id" value="org.apache.cordova.featurewithversion" />
-        <param name="version" value="1.1.1" />
-    </feature>
-    <feature name="A feature with url and version">
-        <param name="id" value="org.apache.cordova.featurewithurlandversion" />
-        <param name="version" value="1.1.1" />
-        <param name="url" value="http://cordova.apache.org/featurewithurlandversion" />
-    </feature>
-    <feature name="A simple feature">
-        <param name="id" value="org.apache.cordova.justafeature" />
+    <plugin name="org.apache.cordova.featurewithvars">
+        <variable name="var" value="varvalue" />
+    </plugin>
+    <plugin name="org.apache.cordova.featurewithurl" src="http://cordova.apache.org/featurewithurl" />
+    <plugin name="org.apache.cordova.featurewithversion" version="1.1.1" />
+    <plugin name="org.apache.cordova.featurewithurlandversion" src="http://cordova.apache.org/featurewithurlandversion" version="1.1.1" />
+    <plugin name="org.apache.cordova.justafeature" />
+    <feature name="Legacy plugin entry">
+        <param name="id" value="org.apache.cordova.legacyfeature" />
+        <param name="version" value="1.2.3" />
+        <param name="aVar" value="aValue" />
     </feature>
 </widget>

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -257,20 +257,20 @@ function getPlatformDetailsFromDir(dir, platformIfKnown){
     }
 
     return Q({
-	libDir: libDir,
-	platform: platform,
+    libDir: libDir,
+    platform: platform,
         version: version
     });
 }
 
 function getVersionFromConfigFile(platform, cfg) {
     if(!platform || ( !(platform in platforms) )){
-	throw new CordovaError('Invalid platform: ' + platform);
+    throw new CordovaError('Invalid platform: ' + platform);
     }
 
     // Get appropriate version from config.xml
     var engine = _.find(cfg.getEngines(), function(eng){
-	return eng.name.toLowerCase() === platform.toLowerCase();
+    return eng.name.toLowerCase() === platform.toLowerCase();
     });
 
     return engine && engine.version;
@@ -290,16 +290,16 @@ function remove(hooksRunner, projectRoot, targets, opts) {
     }).then(function() {
         var config_json = config.read(projectRoot);
         var autosave =  config_json.auto_save_platforms || false;
-	if(opts.save || autosave){
-	    targets.forEach(function(target) {
-		var platformName = target.split('@')[0];
-		var xml = cordova_util.projectConfig(projectRoot);
-		var cfg = new ConfigParser(xml);
-		events.emit('log', 'Removing ' + target + ' from config.xml file ...');
-		cfg.removeEngine(platformName);
-		cfg.write();
-	    });
-	}
+    if(opts.save || autosave){
+        targets.forEach(function(target) {
+        var platformName = target.split('@')[0];
+        var xml = cordova_util.projectConfig(projectRoot);
+        var cfg = new ConfigParser(xml);
+        events.emit('log', 'Removing ' + target + ' from config.xml file ...');
+        cfg.removeEngine(platformName);
+        cfg.write();
+        });
+    }
     }).then(function() {
         // Remove targets from platforms.json
         targets.forEach(function(target) {
@@ -492,11 +492,11 @@ function platform(command, targets, opts) {
             if (fs.existsSync(pPath)) return;
 
             var msg;
-	    // If target looks like a url, we will try cloning it with git
+        // If target looks like a url, we will try cloning it with git
             if (/[~:/\\.]/.test(t)) {
                 return;
             } else {
-		// Neither path, git-url nor platform name - throw.
+        // Neither path, git-url nor platform name - throw.
                 msg = 'Platform "' + t +
                 '" not recognized as a core cordova platform. See `' +
                 cordova_util.binname + ' platform list`.'
@@ -578,7 +578,6 @@ function getCreateArgs(platDetails, projectRoot, cfg, template_dir, opts) {
     if (opts.link) {
         args.push('--link');
     }
-
     return args;
 }
 
@@ -598,8 +597,8 @@ function installPluginsForNewPlatform(platform, projectRoot, cfg, opts) {
             var options = (function(){
                 // Get plugin preferences from config features if have any
                 // Pass them as cli_variables to plugman
-                var feature = cfg.getFeature(plugin);
-                var variables = feature && feature.variables;
+                var pluginEntry = cfg.getPlugin(plugin);
+                var variables = pluginEntry && pluginEntry.variables;
                 if (!!variables) {
                     events.emit('verbose', 'Found variables for "' + plugin + '". Processing as cli_variables.');
                     return {

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -133,7 +133,7 @@ function prepare(options) {
     });
 }
 
-var BLACKLIST = ['platform', 'feature'];
+var BLACKLIST = ['platform', 'feature','plugin','engine'];
 var SINGLETONS = ['content', 'author'];
 function mergeXml(src, dest, platform, clobber) {
     // Do nothing for blacklisted tags.

--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -82,27 +82,27 @@ function installPluginsFromConfigXML(args) {
     var plugins_dir = path.join(projectRoot, 'plugins');
 
     // Get all configured plugins
-    var features = cfg.getFeatureIdList();
-    if (0 === features.length) {
+    var plugins = cfg.getPluginIdList();
+    if (0 === plugins.length) {
         return Q.all('No config.xml plugins to install');
     }
 
-    var promises = features.map(function(featureId){
+    var promises = plugins.map(function(featureId){
         var pluginPath =  path.join(plugins_dir, featureId);
         if (fs.existsSync(pluginPath)) {
             // Plugin already exists
             return Q();
         }
-        events.emit('log', 'Discovered ' + featureId + ' in config.xml. Installing to the project');
-        var feature = cfg.getFeature(featureId);
+        events.emit('log', 'Discovered plugin "' + featureId + '" in config.xml. Installing to the project');
+        var pluginEntry = cfg.getPlugin(featureId);
 
         // Install from given URL if defined or using a plugin id
-        var installFrom = feature.url || feature.installPath || feature.id;
-        if( feature.version && !feature.url && !feature.installPath ){
-            installFrom += ('@' + feature.version);
+        var installFrom = pluginEntry.src || pluginEntry.name;
+        if( pluginEntry.version && !pluginEntry.src ){
+            installFrom += ('@' + pluginEntry.version);
         }
         // Add feature preferences as CLI variables if have any
-        var options = {cli_variables: feature.variables, 
+        var options = {cli_variables: pluginEntry.variables, 
             searchpath: args.searchpath };
             return plugin('add', installFrom, options);
     });


### PR DESCRIPTION
Deprecates the feature syntax and starts using the new plugin tags for
defining plugins. Adjusts the tests for the new logic. The old feature
syntax is still read or removed but all new entries are done with the new
syntax.