### PR TITLE
CB-8670 Error when set engine name to "cordova-windows" in plugin.xml

### DIFF
--- a/cordova-lib/src/plugman/util/default-engines.js
+++ b/cordova-lib/src/plugman/util/default-engines.js
@@ -35,6 +35,8 @@ module.exports = function(project_dir){
             { 'platform':'wp8', 'scriptSrc': path.join(project_dir,'cordova','version') },
         'cordova-windows8':
             { 'platform':'windows8', 'scriptSrc': path.join(project_dir,'cordova','version') },
+        'cordova-windows':
+            { 'platform':'windows', 'scriptSrc': path.join(project_dir,'cordova','version') },
         'apple-xcode' :
             { 'platform':'ios', 'scriptSrc':  path.join(project_dir,'cordova','apple_xcode_version') },
         'apple-ios' :


### PR DESCRIPTION
If you create an `engine` element with `name="cordova-windows"` (rather than `cordova-windows8`) in `plugin.xml`, like this:

```xml
<engines>
    <engine name="cordova-windows" version=">=3.8.0" />
</engines>
```

You will get an error when you add the plugin:

```
TypeError: Cannot call method 'indexOf' of undefined
    at ...\cordova-lib\src\plugman\install.js:232:45
```

The engines in `default-engines.js` had not been updated to support `cordova-windows` as a platform name.