### PR TITLE
Allow hyphen in platform name

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -233,12 +233,8 @@ function downloadPlatform(projectRoot, platform, version, opts) {
 }
 
 function platformFromName(name) {
-    var platMatch = /^cordova-([a-z0-9]+)$/.exec(name);
-    var ret = platMatch && platMatch[1];
-    if (ret == 'amazon') {
-        ret = 'amazon-fireos';
-    }
-    return ret;
+    var platMatch = /^cordova-([a-z0-9-]+)$/.exec(name);
+    return platMatch && platMatch[1];
 }
 
 // Returns a Promise


### PR DESCRIPTION
amazon-fireos was not being recognized as a platform, because 'cordova-amazon-fireos' did not match the given regex.

This was being returned when attempting to add the platform to a project:

`The provided path does not seem to contain a Cordova platform: /home/cris/.cordova/lib/npm_cache/cordova-amazon-fireos/3.6.3/package`