### PR TITLE
CB-8703: Add support for semver and device-specific targeting of config-file to Windows

### DIFF
--- a/cordova-lib/spec-plugman/platforms/windows.spec.js
+++ b/cordova-lib/spec-plugman/platforms/windows.spec.js
@@ -330,19 +330,19 @@ beforeEach(function () {
                         .then(function () {
                             var path = 'ItemGroup/SDKReference';
                             var incText = 'TestSDK1, Version=1.0';
-                            var targetConditions = {versions: undefined, target: undefined, arch: 'x86'};
+                            var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
                             validateUninstalledProjects('lib-file', libfiles[0], path, incText, targetConditions, ['all']);
 
                             incText = 'TestSDK2, Version=1.0';
-                            targetConditions = {versions: '>=8.1', target: undefined, arch: undefined};
+                            targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[1], path, incText, targetConditions, ['windows', 'phone']);
 
                             incText = 'TestSDK3, Version=1.0';
-                            targetConditions = {versions: undefined, target: 'phone', arch: undefined};
+                            targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[2], path, incText, targetConditions, ['phone']);
 
                             incText = 'TestSDK4, Version=1.0';
-                            targetConditions = {versions: '8.0', target: 'windows', arch: 'x86'};
+                            targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x86'};
                             validateUninstalledProjects('lib-file', libfiles[3], path, incText, targetConditions, ['windows8']);
 
                             done();
@@ -360,19 +360,19 @@ beforeEach(function () {
                         .then(function () {
                             var path = 'ItemGroup/Reference';
                             var incText = 'dummy1';
-                            var targetConditions = {versions: undefined, target: undefined, arch: 'x64'};
+                            var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                             validateUninstalledProjects('framework', frameworks[0], path, incText, targetConditions, ['all']);
 
                             incText = 'dummy2';
-                            targetConditions = {versions: '>=8.0', target: undefined, arch: undefined};
+                            targetConditions = {versions: '>=8.0', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[1], path, incText, targetConditions, ['all']);
 
                             incText = 'dummy3';
-                            targetConditions = {versions: undefined, target: 'windows', arch: undefined};
+                            targetConditions = {versions: undefined, deviceTarget: 'windows', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[2], path, incText, targetConditions, ['windows', 'windows8']);
 
                             incText = 'dummy4';
-                            targetConditions = {versions: '8.1', target: 'phone', arch: 'ARM'};
+                            targetConditions = {versions: '8.1', deviceTarget: 'phone', arch: 'ARM'};
                             validateUninstalledProjects('framework', frameworks[3], path, incText, targetConditions, ['phone']);
 
                             done();
@@ -390,19 +390,19 @@ beforeEach(function () {
                         .then(function () {
                             var xmlPath = 'ItemGroup/ProjectReference';
                             var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy1.vcxproj');
-                            var targetConditions = {versions: undefined, target: undefined, arch: 'x64'};
+                            var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                             validateUninstalledProjects('framework', frameworks[4], xmlPath, incText, targetConditions, ['all']);
 
                             incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy2.vcxproj');
-                            targetConditions = {versions: '<8.1', target: undefined, arch: undefined};
+                            targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[5], xmlPath, incText, targetConditions, ['windows8']);
 
                             incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy3.vcxproj');
-                            targetConditions = {versions: undefined, target: 'win', arch: undefined};
+                            targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[6], xmlPath, incText, targetConditions, ['windows', 'windows8']);
 
                             incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy4.vcxproj');
-                            targetConditions = {versions: '8.1', target: 'all', arch: 'x86'};
+                            targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
                             validateUninstalledProjects('framework', frameworks[7], xmlPath, incText, targetConditions, ['windows', 'phone']);
 
                             done();

--- a/cordova-lib/spec-plugman/plugins/org.test.configtest/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.configtest/plugin.xml
@@ -34,4 +34,28 @@
             <poop/>
         </config-file>
     </platform>
+
+    <platform name="windows">
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities">
+            <Capability Note="should-exist-for-all-appxmanifest-target-files" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="<=8.0.0">
+            <Capability Note="should-exist-for-win8-only" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="=8.1.0">
+            <Capability Note="should-exist-for-win81-win-and-phone" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="<=8.1.0" device-target="windows">
+            <Capability Note="should-exist-for-win8-and-win81-win-only" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="<=8.1.0" device-target="phone">
+            <Capability Note="should-exist-for-win81-phone-only" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions="<=8.1.0" device-target="all">
+            <Capability Note="should-exist-for-win8-and-win81-both" />
+        </config-file>
+        <config-file target="package.appxmanifest" parent="/Parent/Capabilities" versions=">=10.0.0">
+            <Capability Note="should-exist-in-win10-only" />
+        </config-file>
+    </platform>
 </plugin>

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
@@ -185,18 +185,19 @@
 
         <lib-file src="TestSDK1, Version=1.0" arch="x86"/>
         <lib-file src="TestSDK2, Version=1.0" versions=">=8.1"/>
-        <lib-file src="TestSDK3, Version=1.0" target="phone"/>
-        <lib-file src="TestSDK4, Version=1.0" target="windows" versions="8.0" arch="x86"/>
+        <lib-file src="TestSDK3, Version=1.0" device-target="phone"/>
+        <lib-file src="TestSDK4, Version=1.0" device-target="windows" versions="8.0" arch="x86"/>
 
         <framework src="src/windows/dummy1.dll" arch="x64"/>
         <framework src="src/windows/dummy2.dll" versions=">=8.0"/>
-        <framework src="src/windows/dummy3.dll" target="windows"/>
-        <framework src="src/windows/dummy4.dll" target="phone" versions="8.1" arch="ARM"/>
+        <framework src="src/windows/dummy3.dll" device-target="windows"/>
+        <framework src="src/windows/dummy4.dll" device-target="phone" versions="8.1" arch="ARM"/>
 
         <framework src="src/windows/dummy1.vcxproj" type="projectReference" arch="x64"/>
         <framework src="src/windows/dummy2.vcxproj" type="projectReference" versions="<8.1"/>
+        <!-- "target" attribute is an alias for "device-target" (but is deprecated) - test for it here -->
         <framework src="src/windows/dummy3.vcxproj" type="projectReference" target="win"/>
-        <framework src="src/windows/dummy4.vcxproj" type="projectReference" target="all" versions="8.1" arch="x86"/>
+        <framework src="src/windows/dummy4.vcxproj" type="projectReference" device-target="all" versions="8.1" arch="x86"/>
 
         <js-module src="www/dummyplugin.js" name="Dummy">
             <clobbers target="dummy" />

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.faultyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.faultyplugin/plugin.xml
@@ -143,7 +143,7 @@
 
         <lib-file src="TestSDK1, Version=1.0" arch="x85"/>
         <lib-file src="TestSDK2, Version=1.0" versions="8.0a"/>
-        <lib-file src="TestSDK3, Version=1.0" target="daphne"/>
+        <lib-file src="TestSDK3, Version=1.0" device-target="daphne"/>
 
         <!-- does not exist -->
         <source-file src="src/windows/NotHere.js" />

--- a/cordova-lib/spec-plugman/util/config-changes.spec.js
+++ b/cordova-lib/spec-plugman/util/config-changes.spec.js
@@ -216,6 +216,33 @@ describe('config-changes module', function() {
                 expect(munge.files['framework'].parents['Custom.framework']).not.toBeDefined();
             });
         });
+        describe('for windows project', function() {
+            it('should special case config-file elements for windows', function() {
+                var munger = new configChanges.PlatformMunger('windows', temp, 'unused', null, pluginInfoProvider);
+                // Unit testing causes a failure when the package_name function is called from generate_plugin_config_munge
+                // the results aren't really important during the unit test
+                munger.platform_handler.package_name = function() { return 'org.apache.testapppackage'; };
+
+                var munge = munger.generate_plugin_config_munge(configplugin, {});
+                var packageAppxManifest = munge.files['package.appxmanifest'];
+                var windows80AppxManifest = munge.files['package.windows80.appxmanifest'];
+                var windows81AppxManifest = munge.files['package.windows.appxmanifest'];
+                var winphone81AppxManifest = munge.files['package.phone.appxmanifest'];
+                var windows10AppxManifest = munge.files['package.windows10.appxmanifest'];
+
+                expect(packageAppxManifest.parents['/Parent/Capabilities'][0].xml).toBe('<Capability Note="should-exist-for-all-appxmanifest-target-files" />');
+                expect(windows80AppxManifest.parents['/Parent/Capabilities'][0].xml).toBe('<Capability Note="should-exist-for-win8-only" />');
+                expect(windows80AppxManifest.parents['/Parent/Capabilities'][1].xml).toBe('<Capability Note="should-exist-for-win8-and-win81-win-only" />');
+                expect(windows80AppxManifest.parents['/Parent/Capabilities'][2].xml).toBe('<Capability Note="should-exist-for-win8-and-win81-both" />');
+                expect(windows81AppxManifest.parents['/Parent/Capabilities'][0].xml).toBe('<Capability Note="should-exist-for-win81-win-and-phone" />');
+                expect(windows81AppxManifest.parents['/Parent/Capabilities'][1].xml).toBe('<Capability Note="should-exist-for-win8-and-win81-win-only" />');
+                expect(windows81AppxManifest.parents['/Parent/Capabilities'][2].xml).toBe('<Capability Note="should-exist-for-win8-and-win81-both" />');
+                expect(winphone81AppxManifest.parents['/Parent/Capabilities'][0].xml).toBe('<Capability Note="should-exist-for-win81-win-and-phone" />');
+                expect(winphone81AppxManifest.parents['/Parent/Capabilities'][1].xml).toBe('<Capability Note="should-exist-for-win81-phone-only" />');
+                expect(winphone81AppxManifest.parents['/Parent/Capabilities'][2].xml).toBe('<Capability Note="should-exist-for-win8-and-win81-both" />');
+                expect(windows10AppxManifest.parents['/Parent/Capabilities'][0].xml).toBe('<Capability Note="should-exist-in-win10-only" />');
+            });
+        });
     });
 
     describe('processing of plugins (via process method)', function() {

--- a/cordova-lib/spec-plugman/util/config-changes.spec.js
+++ b/cordova-lib/spec-plugman/util/config-changes.spec.js
@@ -39,6 +39,7 @@ var configChanges = require('../../src/plugman/util/config-changes'),
     android_two_project = path.join(__dirname, '..', 'projects', 'android_two', '*'),
     android_two_no_perms_project = path.join(__dirname, '..', 'projects', 'android_two_no_perms', '*'),
     ios_config_xml = path.join(__dirname, '..', 'projects', 'ios-config-xml', '*'),
+    windows_testapp_jsproj = path.join(__dirname, '..', 'projects', 'windows8', 'TestApp.jsproj'),
     plugins_dir = path.join(temp, 'cordova', 'plugins');
 var mungeutil = require('../../src/plugman/util/munge-util');
 var PlatformJson = require('../../src/plugman/util/PlatformJson');
@@ -217,6 +218,9 @@ describe('config-changes module', function() {
             });
         });
         describe('for windows project', function() {
+            beforeEach(function() {
+                shell.cp('-rf', windows_testapp_jsproj, temp);
+            });
             it('should special case config-file elements for windows', function() {
                 var munger = new configChanges.PlatformMunger('windows', temp, 'unused', null, pluginInfoProvider);
                 // Unit testing causes a failure when the package_name function is called from generate_plugin_config_munge

--- a/cordova-lib/src/PluginInfo.js
+++ b/cordova-lib/src/PluginInfo.js
@@ -129,6 +129,9 @@ function PluginInfo(dirname) {
             , parent : tag.attrib['parent']
             , after : tag.attrib['after']
             , xmls : tag.getchildren()
+            // To support demuxing via versions
+            , versions : tag.attrib['versions']
+            , deviceTarget: tag.attrib['device-target']
             };
         return configFile;
     }
@@ -211,7 +214,7 @@ function PluginInfo(dirname) {
                 arch: tag.attrib.arch,
                 Include: tag.attrib.Include,
                 versions: tag.attrib.versions,
-                target: tag.attrib.target
+                deviceTarget: tag.attrib['device-target'] || tag.attrib.target
             };
         });
         return libFiles;
@@ -287,7 +290,7 @@ function PluginInfo(dirname) {
                 src: el.attrib.src,
                 weak: isStrTrue(el.attrib.weak),
                 versions: el.attrib.versions,
-                target: el.attrib.target,
+                deviceTarget: el.attrib['device-target'] || el.attrib.target,
                 arch: el.attrib.arch
             };
             return ret;

--- a/cordova-lib/src/plugman/platforms/windows.js
+++ b/cordova-lib/src/plugman/platforms/windows.js
@@ -150,5 +150,5 @@ module.exports = {
 };
 
 function getTargetConditions(obj) {
-    return {versions: obj.versions, target: obj.target, arch: obj.arch};
+    return { versions: obj.versions, deviceTarget: obj.deviceTarget, arch: obj.arch };
 }

--- a/cordova-lib/src/plugman/util/config-changes.js
+++ b/cordova-lib/src/plugman/util/config-changes.js
@@ -156,11 +156,13 @@ function remove_plugin_changes(plugin_name, plugin_id, is_top_level) {
         if (self.platform == 'windows' && file == 'package.appxmanifest' &&
             !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
             // New windows template separate manifest files for Windows8, Windows8.1 and WP8.1
-            var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest'];
-            for (var subst in substs) {
-                events.emit('verbose', 'Applying munge to ' + substs[subst]);
-                self.apply_file_munge(substs[subst], munge.files[file], true);
-            }
+            var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest', 'package.windows10.appxmanifest'];
+            /* jshint loopfunc:true */
+            substs.forEach(function(subst) {
+                events.emit('verbose', 'Applying munge to ' + subst);
+                self.apply_file_munge(subst, munge.files[file], true);
+            });
+            /* jshint loopfunc:false */
         }
         self.apply_file_munge(file, munge.files[file], /* remove = */ true);
     }
@@ -209,11 +211,13 @@ function add_plugin_changes(plugin_id, plugin_vars, is_top_level, should_increme
         // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
         if (self.platform == 'windows' && file == 'package.appxmanifest' &&
             !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
-            var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest'];
-            for (var subst in substs) {
-                events.emit('verbose', 'Applying munge to ' + substs[subst]);
-                self.apply_file_munge(substs[subst], munge.files[file]);
-            }
+            var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest', 'package.windows10.appxmanifest'];
+            /* jshint loopfunc:true */
+            substs.forEach(function(subst) {
+                events.emit('verbose', 'Applying munge to ' + subst);
+                self.apply_file_munge(subst, munge.files[file]);
+            });
+            /* jshint loopfunc:false */
         }
         self.apply_file_munge(file, munge.files[file]);
     }
@@ -277,6 +281,90 @@ function generate_plugin_config_munge(plugin_dir, vars) {
             if (!f.custom) {
                 mungeutil.deep_add(munge, 'framework', f.src, { xml: f.weak, count: 1 });
             }
+        });
+    }
+    
+    // Demux 'package.appxmanifest' into relevant platform-specific appx manifests.
+    // Only spend the cycles if there are version-specific plugin settings
+    if (self.platform === 'windows' && changes.some(function(change) { return ((typeof change.versions !== 'undefined') || (typeof change.deviceTarget !== 'undefined')); })) 
+    {
+        var manifests = {
+            'windows': {
+                '8.0.0': 'package.windows80.appxmanifest',
+                '8.1.0': 'package.windows.appxmanifest',
+                '10.0.0': 'package.windows10.appxmanifest'
+            },
+            'phone': {
+                '8.1.0': 'package.phone.appxmanifest',
+                '10.0.0': 'package.windows10.appxmanifest'
+            },
+            'all': {
+                '8.0.0': 'package.windows80.appxmanifest',
+                '8.1.0': ['package.windows.appxmanifest', 'package.phone.appxmanifest'],
+                '10.0.0': 'package.windows10.appxmanifest'
+            }
+        };
+
+        var oldChanges = changes;
+        changes = [];
+
+        oldChanges.forEach(function(change, changeIndex) {
+            // Only support semver/device-target demux for package.appxmanifest
+            // Pass through in case something downstream wants to use it
+            if (change.target !== 'package.appxmanifest') {
+                changes.push(change);
+                return;
+            }
+
+            var hasVersion = (typeof change.versions !== 'undefined');
+            var hasTargets = (typeof change.deviceTarget !== 'undefined');
+
+            // No semver/device-target for this config-file, pass it through
+            if (!(hasVersion || hasTargets)) {
+                changes.push(change);
+                return;
+            }
+
+            var targetDeviceSet = hasTargets ? change.deviceTarget : 'all';
+            if (['windows', 'phone', 'all'].indexOf(targetDeviceSet) === -1) {
+                // target-device couldn't be resolved, fix it up here to a valid value
+                targetDeviceSet = 'all';
+            }
+            var knownWindowsVersionsForTargetDeviceSet = Object.keys(manifests[targetDeviceSet]);
+
+            // at this point, 'change' targets package.appxmanifest and has a version attribute
+            knownWindowsVersionsForTargetDeviceSet.forEach(function(winver) {
+                // This is a local function that creates the new replacement representing the 
+                // mutation.  Used to save code further down.
+                var createReplacement = function(manifestFile, originalChange) {
+                    var replacement = {
+                        target:         manifestFile,
+                        parent:         originalChange.parent,
+                        after:          originalChange.after,
+                        xmls:           originalChange.xmls,
+                        versions:       originalChange.versions,
+                        deviceTarget:   originalChange.deviceTarget
+                    };
+                    return replacement;
+                };
+
+                // version doesn't satisfy, so skip
+                if (hasVersion && !semver.satisfies(winver, change.versions)) {
+                    return;
+                }
+
+                var versionSpecificManifests = manifests[targetDeviceSet][winver];
+                if (versionSpecificManifests.constructor === Array) {
+                    // e.g. all['8.1.0'] === ['pkg.windows.appxmanifest', 'pkg.phone.appxmanifest']
+                    versionSpecificManifests.forEach(function(manifestFile) {
+                        changes.push(createReplacement(manifestFile, change));
+                    });
+                }
+                else {
+                    // versionSpecificManifests is actually a single string
+                    changes.push(createReplacement(versionSpecificManifests, change));
+                }
+            });
         });
     }
 

--- a/cordova-lib/src/util/windows/jsprojManager.js
+++ b/cordova-lib/src/util/windows/jsprojManager.js
@@ -360,7 +360,7 @@ function createReferenceElement(path, incText, targetConditions, children) {
 }
 
 function getTarget(targetConditions) {
-    var target = targetConditions.target;
+    var target = targetConditions.deviceTarget;
     if (target) {
         target = target.toLowerCase().trim();
         if (target === "all") {


### PR DESCRIPTION
Allows config-file to target a virtual "package.appxmanifest" (already supported) and specify versions of Windows via new versions and device-target attributes:

 <config-file target="package.appxmanifest" versions=">=8.1.0" ... />
 <config.file target="package.appxmanifest" device-target="phone" />

This change also modifies the related <lib-file> and <framework> elements for Windows to rename the "target" attribute to "device-target" in order to align the meaning across elements. ("target" is preserved as an alias in order to be backwards-compatible).

There is a matching PR for cordova-docs.
