### PR TITLE
Fall back to platform's default orientation only if using the 'default' global orientation

### DIFF
--- a/cordova-lib/spec-cordova/metadata/android_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/android_parser.spec.js
@@ -130,7 +130,7 @@ describe('android project parser', function() {
             it('should handle no orientation', function() {
                 getOrientation.andReturn('');
                 p.update_from_config(cfg);
-                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toBeUndefined();
+                expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('VAL');
             });
             it('should handle default orientation', function() {
                 getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);

--- a/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
@@ -110,7 +110,7 @@ describe('firefoxos project parser', function() {
             it('should handle no orientation', function () {
                 getOrientation.andReturn('');
                 p.update_from_config(cfg);
-                expect(manifestJson.orientation).toBeUndefined();
+                expect(manifestJson.orientation).toEqual([ 'portrait' ]);
             });
             it('should handle default orientation', function () {
                 getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);

--- a/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
@@ -173,8 +173,8 @@ describe('wp8 project parser', function() {
             it('should handle no orientation', function() {
                 getOrientation.andReturn('');
                 p.update_from_config(cfg);
-                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
-                expect(mainPageXamlXml.getroot().attrib['Orientation']).toBeUndefined();
+                expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('PortraitOrLandscape');
+                expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('VAL');
             });
             it('should handle default orientation', function() {
                 getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);

--- a/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
+++ b/cordova-lib/src/cordova/metadata/amazon_fireos_parser.js
@@ -230,10 +230,12 @@ amazon_fireos_parser.prototype.update_from_config = function(config) {
     // Set the android:screenOrientation in the AndroidManifest
     var orientation = this.helper.getOrientation(config);
 
-    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
-        act.attrib['android:screenOrientation'] = orientation;
-    } else {
-        delete act.attrib['android:screenOrientation'];
+    if (orientation) {
+        if (this.helper.isDefaultOrientation(orientation)) {
+            delete act.attrib['android:screenOrientation'];
+        } else {
+            act.attrib['android:screenOrientation'] = orientation;
+        }
     }
 
     // Set android:launchMode in AndroidManifest

--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -227,10 +227,12 @@ android_parser.prototype.update_from_config = function(config) {
     // Set the android:screenOrientation in the AndroidManifest
     var orientation = this.helper.getOrientation(config);
 
-    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
-        act.attrib['android:screenOrientation'] = orientation;
-    } else {
-        delete act.attrib['android:screenOrientation'];
+    if (orientation) {
+        if (this.helper.isDefaultOrientation(orientation)) {
+            delete act.attrib['android:screenOrientation'];
+        } else {
+            act.attrib['android:screenOrientation'] = orientation;
+        }
     }
 
     // Set android:launchMode in AndroidManifest

--- a/cordova-lib/src/cordova/metadata/firefoxos_parser.js
+++ b/cordova-lib/src/cordova/metadata/firefoxos_parser.js
@@ -125,10 +125,12 @@ firefoxos_parser.prototype.update_from_config = function(config) {
     // Set orientation preference
     var orientation = this.helper.getOrientation(config);
 
-    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
-        manifest.orientation = [ orientation ];
-    } else {
-        delete manifest.orientation;
+    if (orientation) {
+        if (this.helper.isDefaultOrientation(orientation)) {
+            delete manifest.orientation;
+        } else {
+            manifest.orientation = [ orientation ];
+        }
     }
 
     var permissionNodes = config.doc.findall('permission');

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -81,23 +81,27 @@ ios_parser.prototype.update_from_config = function(config) {
 
     var orientation = this.helper.getOrientation(config);
 
-    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
-        switch (orientation.toLowerCase()) {
-            case 'portrait':
-                infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationPortrait' ];
-                infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ];
-                break;
-            case 'landscape':
-                infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationLandscapeLeft' ];
-                infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
-                break;
-            default:
-                infoPlist['UIInterfaceOrientation'] = [ orientation ];
-                delete infoPlist['UISupportedInterfaceOrientations'];
+    if (orientation) {
+
+        if (this.helper.isDefaultOrientation(orientation)) {
+            delete infoPlist['UISupportedInterfaceOrientations'];
+            delete infoPlist['UIInterfaceOrientation'];
+        } else {
+            switch (orientation.toLowerCase()) {
+                case 'portrait':
+                    infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationPortrait' ];
+                    infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ];
+                    break;
+                case 'landscape':
+                    infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationLandscapeLeft' ];
+                    infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
+                    break;
+                default:
+                    infoPlist['UIInterfaceOrientation'] = [ orientation ];
+                    delete infoPlist['UISupportedInterfaceOrientations'];
+            }
         }
-    } else {
-        delete infoPlist['UISupportedInterfaceOrientations'];
-        delete infoPlist['UIInterfaceOrientation'];
+
     }
 
     var info_contents = plist.build(infoPlist);

--- a/cordova-lib/src/cordova/metadata/wp8_parser.js
+++ b/cordova-lib/src/cordova/metadata/wp8_parser.js
@@ -65,18 +65,21 @@ wp8_parser.prototype.update_from_config = function(config) {
     var mainPageXAML = xml.parseElementtreeSync(path.join(this.wp8_proj_dir, 'MainPage.xaml'));
 
     var orientation = this.helper.getOrientation(config);
-    if (orientation && !this.helper.isDefaultOrientation(orientation)) {
 
-        mainPageXAML.getroot().attrib['Orientation'] = orientation;
-        mainPageXAML.getroot().attrib['SupportedOrientations'] = orientation;
+    if (orientation) {
 
-        if (!this.helper.isGlobalOrientation(orientation)) {
+        if (this.helper.isDefaultOrientation(orientation)) {
             delete mainPageXAML.getroot().attrib['SupportedOrientations'];
+            delete mainPageXAML.getroot().attrib['Orientation'];
+        } else {
+            mainPageXAML.getroot().attrib['Orientation'] = orientation;
+            mainPageXAML.getroot().attrib['SupportedOrientations'] = orientation;
+
+            if (!this.helper.isGlobalOrientation(orientation)) {
+                delete mainPageXAML.getroot().attrib['SupportedOrientations'];
+            }
         }
 
-    } else {
-        delete mainPageXAML.getroot().attrib['SupportedOrientations'];
-        delete mainPageXAML.getroot().attrib['Orientation'];
     }
 
     //Update app version


### PR DESCRIPTION
In regards to the changes introduced in #128 a small change would probably be in place.

Currently, if no orientation is specified in `config.xml` Cordova will delete the orientation entry from the manifest/config of a given platform letting the platform fall back to its default behaviour. That is, the behaviour of undefined orientation is currently identical to the `default` global orientation. In retrospect, it would probably lead to less confusion if a platform's orientation setting would be left untouched if no orientation is specified in `config.xml`.

