### PR TITLE
CB-8737 Available platforms list includes extraneous values.

### DIFF
--- a/cordova-lib/src/platforms/platforms.js
+++ b/cordova-lib/src/platforms/platforms.js
@@ -102,5 +102,10 @@ function getPlatformProject(platform, platformRootDir) {
 }
 
 module.exports = platforms;
-module.exports.getPlatformProject = getPlatformProject;
-module.exports.PlatformProjectAdapter = PlatformProjectAdapter;
+
+// We don't want these methods to be enumerable on the platforms object, because we expect enumerable properties of the
+// platforms object to be platforms.
+Object.defineProperties(module.exports, {
+    'getPlatformProject': {value: getPlatformProject},
+    'PlatformProjectAdapter': {value: PlatformProjectAdapter}
+});


### PR DESCRIPTION
Using the latest sources, if you list available platforms the output includes two extraneous values (`getPlatformProject` and `PlatformProjectAdapter`):

    $ cordova platform
    Installed platforms: windows
    Available platforms: PlatformProjectAdapter, amazon-fireos, android, blackberry10, browser, firefoxos, getPlatformProject, windows8, wp8

These are methods added to the platforms object. Fix is to make them non-enumerable.