### PR TITLE
CB-8596 Expose APIs to retrieve platforms and plugins from config.xml

### DIFF
--- a/cordova-lib/spec-cordova/Projects/ProjectMetadata/config.xml
+++ b/cordova-lib/spec-cordova/Projects/ProjectMetadata/config.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="io.cordova.projectmetadata" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>ProjectMetadata</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+    <engine name="android" version="3.7.1" />
+    <engine name="browser" version="https://github.com/apache/cordova-browser.git" />
+    <plugin name="org.apache.cordova.device" version="0.3.0" />
+    <plugin name="org.apache.cordova.camera" src="https://github.com/apache/cordova-plugin-camera.git">
+        <variable name="TEST_VARIABLE" value="My Test Variable" />
+	</plugin>
+</widget>

--- a/cordova-lib/spec-cordova/project-metadata-apis.spec.js
+++ b/cordova-lib/spec-cordova/project-metadata-apis.spec.js
@@ -1,0 +1,103 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var cordova = require('../src/cordova/cordova'),
+    path = require('path');
+
+describe('retrieval of project metadata', function () {
+    var projectRoot = path.resolve(__dirname, 'Projects/ProjectMetadata');
+
+    it('retrieve platforms saved in config.xml', function (done) {
+        var androidVersion = '3.7.1';
+        var browserSrc = 'https://github.com/apache/cordova-browser.git';
+
+        cordova.raw.projectMetadata.getPlatforms(projectRoot)
+            .then(function (platforms) {
+                expect(platforms.length).toBe(2);
+
+                // Android platform has version defined, not source
+                var androidPlatform = findPlatform(platforms, 'android');
+                expect(androidPlatform).not.toBeNull();
+                expect(androidPlatform.version).toBe(androidVersion);
+                expect(androidPlatform.src).toBeUndefined();
+
+                // Browser platform has source defined in the version field
+                var browserPlatform = findPlatform(platforms, 'browser');
+                expect(browserPlatform).not.toBeNull();
+                expect(browserPlatform.version).toBeUndefined();
+                expect(browserPlatform.src).toBe(browserSrc);
+            }).finally(done);
+    });
+
+    it('retrieve plugins saved in config.xml', function (done) {
+        var deviceId = 'org.apache.cordova.device';
+        var deviceVersion = '0.3.0';
+
+        var cameraId = 'org.apache.cordova.camera';
+        var cameraSrc = 'https://github.com/apache/cordova-plugin-camera.git';
+        var cameraVariableName = 'TEST_VARIABLE';
+        var cameraVariableValue = 'My Test Variable';
+
+        cordova.raw.projectMetadata.getPlugins(projectRoot)
+            .then(function (plugins) {
+                expect(plugins.length).toBe(2);
+
+                // Device plugin
+                var devicePlugin = findPlugin(plugins, deviceId);
+                expect(devicePlugin).not.toBeNull();
+                expect(devicePlugin.version).toBe(deviceVersion);
+                expect(devicePlugin.src).toBeUndefined();
+
+                var deviceVariables = devicePlugin.variables;
+                expect(deviceVariables).not.toBeNull();
+                expect(Array.isArray(deviceVariables)).toBeTruthy();
+                expect(deviceVariables.length).toBe(0);
+
+                // Camera plugin
+                var cameraPlugin = findPlugin(plugins, cameraId);
+                expect(cameraPlugin).not.toBeNull();
+                expect(cameraPlugin.src).toBe(cameraSrc);
+                expect(cameraPlugin.version).toBeUndefined();
+
+                var cameraVariables = cameraPlugin.variables;
+                expect(cameraVariables).not.toBeNull();
+                expect(cameraVariables.length).toBe(1);
+                expect(cameraVariables[0].name).toBe(cameraVariableName);
+                expect(cameraVariables[0].value).toBe(cameraVariableValue);
+            }).finally(done);
+    });
+});
+
+function findPlatform(platforms, platformName) {
+    for (var i = 0; i < platforms.length; i++) {
+        if (platforms[i].name === platformName) {
+            return platforms[i];
+        }
+    }
+    return null;
+}
+
+function findPlugin(plugins, pluginId) {
+    for (var i = 0; i < plugins.length; i++) {
+        if (plugins[i].name === pluginId) {
+            return plugins[i];
+        }
+    }
+    return null;
+}

--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -298,6 +298,11 @@ ConfigParser.prototype = {
         });
         return result;
     },
+    getPlugins: function () {
+        return this.getPluginIdList().map(function (pluginId) {
+            return this.getPlugin(pluginId);
+        }, this);
+    },
     /**
      * Adds a plugin element. Does not check for duplicates.
      * @name addPlugin

--- a/cordova-lib/src/cordova/cordova.js
+++ b/cordova-lib/src/cordova/cordova.js
@@ -68,5 +68,6 @@ addModuleProperty(module, 'compile', './compile', true);
 addModuleProperty(module, 'run', './run', true);
 addModuleProperty(module, 'info', './info', true);
 addModuleProperty(module, 'targets', './targets', true);
+addModuleProperty(module, 'projectMetadata', './project_metadata', true);
 
 

--- a/cordova-lib/src/cordova/project_metadata.js
+++ b/cordova-lib/src/cordova/project_metadata.js
@@ -1,0 +1,76 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var cordova_util = require('./util'),
+    ConfigParser = require('../configparser/ConfigParser'),
+    Q            = require('q'),
+    semver       = require('semver');
+
+
+/** Returns all the platforms that are currently saved into config.xml
+ *  @return {Promise<{name: string, version: string, src: string}[]>}
+ *      e.g: [ {name: 'android', version: '3.5.0'}, {name: 'wp8', src: 'C:/path/to/platform'}, {name: 'ios', src: 'git://...'} ]
+ */
+function getPlatforms(projectRoot){
+    var xml = cordova_util.projectConfig(projectRoot);
+    var cfg = new ConfigParser(xml);
+
+    // If an engine's 'version' property is really its source, map that to the appropriate field.
+    var engines = cfg.getEngines().map(function (engine) {
+        if (engine.version && !engine.src && !semver.validRange(engine.version)) {
+            engine.src = engine.version;
+            delete engine.version;
+        }
+        return engine;
+    });
+
+    return Q(engines);
+}
+
+/** Returns all the plugins that are currently saved into config.xml
+ *  @return {Promise<{id: string, version: string, variables: {name: string, value: string}[]}[]>}
+ *      e.g: [ {id: 'org.apache.cordova.device', variables: [{name: 'APP_ID', value: 'my-app-id'}, {name: 'APP_NAME', value: 'my-app-name'}]} ]
+ */
+function getPlugins(projectRoot){
+    var xml = cordova_util.projectConfig(projectRoot);
+    var cfg = new ConfigParser(xml);
+
+    // Map variables object to an array
+    var plugins = cfg.getPlugins().map(function (plugin) {
+        var variablesObject = plugin.variables;
+        var variablesArray = [];
+        if (variablesObject) {
+            for (var variable in variablesObject) {
+                variablesArray.push({
+                    name: variable,
+                    value: variablesObject[variable]
+                });
+            }
+        }
+        plugin.variables = variablesArray;
+        return plugin;
+    });
+
+    return Q(plugins);
+}
+
+module.exports = {
+    getPlatforms: getPlatforms,
+    getPlugins: getPlugins
+};


### PR DESCRIPTION
Provides third parties access to platform and plugin information stored in `config.xml` without having to go through ConfigParser.

Based on work by @omefire, with the following changes:

* Tests simplified to use predefined `config.xml`.
* Updated to use `plugin` calls instead of `feature` calls (which have been removed).
* Updates plugin metadata to return `variables` property as an array.
* Maps platform `version` to `src` if it doesn't look like a version (to handle the fact that platform stores either version or source in the `version` property).
* Removed `getProjectMetadata` method and renamed `getProjectMetadata` property to `projectMetadata`. So api is now simply `cordova.projectMetadata.getPlatforms()` and `cordova.projectMetadata.getPlugins()`.