### PR TITLE
Fix plugman install failure on iOS containing &

### DIFF
--- a/cordova-lib/src/plugman/platforms/ios.js
+++ b/cordova-lib/src/plugman/platforms/ios.js
@@ -185,7 +185,7 @@ module.exports = {
 
         var xcBuildConfiguration = xcodeproj.pbxXCBuildConfigurationSection();
         var plist_file_entry = _.find(xcBuildConfiguration, function (entry) { return entry.buildSettings && entry.buildSettings.INFOPLIST_FILE; });
-        var plist_file = path.join(project_dir, plist_file_entry.buildSettings.INFOPLIST_FILE.replace(/^"(.*)"$/g, '$1'));
+        var plist_file = path.join(project_dir, plist_file_entry.buildSettings.INFOPLIST_FILE.replace(/^"(.*)"$/g, '$1').replace(/\\&/g, '&'));
         var config_file = path.join(path.dirname(plist_file), 'config.xml');
 
         if (!fs.existsSync(plist_file) || !fs.existsSync(config_file)) {


### PR DESCRIPTION
I have an iOS project named `Foo & Bar`. When trying to run `cordova plugin add <anything>` an error is thrown:

```
Failed to install 'org.apache.cordova.splashscreen':CordovaError: could not find -Info.plist file, or config.xml file.
    at Object.module.exports.parseProjectFile (/Users/casey/projects/example/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/ios.js:193:19)
    at Object.ActionStack.process (/Users/casey/projects/example/node_modules/cordova/node_modules/cordova-lib/src/plugman/util/action-stack.js:55:49)
    at handleInstall (/Users/casey/projects/example/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:575:20)
    at /Users/casey/projects/example/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:335:28
    at _fulfilled (/Users/casey/projects/example/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/Users/casey/projects/example/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/Users/casey/projects/example/node_modules/cordova/node_modules/q/q.js:749:13)
    at /Users/casey/projects/example/node_modules/cordova/node_modules/q/q.js:509:49
    at flush (/Users/casey/projects/example/node_modules/cordova/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:355:11)
could not find -Info.plist file, or config.xml file.
```

The problem is that the xcode parser is saying that the plist path is `Foo \& Bar-Info.plist`, which is obviously wrong as there is no actual backslash. The ampersand seems to be escaped in the `project.pbxproj` file, so I'm not sure this is the best place for the fix, or if this might even be a bug in https://github.com/alunny/node-xcode