### PR TITLE
CB-8754 Auto-restoring a plugin fails when adding a platform.

### DIFF
--- a/cordova-lib/spec-plugman/registry/registry.spec.js
+++ b/cordova-lib/spec-plugman/registry/registry.spec.js
@@ -100,7 +100,7 @@ describe('registry', function() {
             };
 
             registry.settings = fakeSettings;
-            fakeLoad = spyOn(npm, 'load').andCallFake(function(settings, cb) { cb(null, true); });
+            fakeLoad = spyOn(npm, 'load').andCallFake(function () { arguments[arguments.length - 1](null, true); });
 
             fakeNPMCommands = {};
             ['config', 'adduser', 'cache', 'publish', 'unpublish', 'search'].forEach(function(cmd) {
@@ -109,17 +109,19 @@ describe('registry', function() {
 
             npm.commands = fakeNPMCommands;
             npm.config.set = function(){};
+            npm.config.get = function(){};
+            npm.config.del = function(){};
         });
         it('should run config', function() {
             var params = ['set', 'registry', 'http://registry.cordova.io'];
             registryPromise(true, registry.config(params).then(function() {
-                expect(fakeLoad).toHaveBeenCalledWith(registry.settings, jasmine.any(Function));
+                expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Function));
                 expect(fakeNPMCommands.config).toHaveBeenCalledWith(params, jasmine.any(Function));
             }));
         });
         it('should run adduser', function() {
             registryPromise(true, registry.adduser(null).then(function() {
-                expect(fakeLoad).toHaveBeenCalledWith(registry.settings, jasmine.any(Function));
+                expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Function));
                 expect(fakeNPMCommands.adduser).toHaveBeenCalledWith(null, jasmine.any(Function));
             }));
         });
@@ -128,7 +130,7 @@ describe('registry', function() {
             var spyGenerate = spyOn(manifest, 'generatePackageJsonFromPluginXml').andReturn(Q());
             var spyUnlink = spyOn(fs, 'unlink');
             registryPromise(true, registry.publish(params).then(function() {
-                expect(fakeLoad).toHaveBeenCalledWith(registry.settings, jasmine.any(Function));
+                expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Function));
                 expect(spyGenerate).toHaveBeenCalledWith(params[0]);
                 expect(fakeNPMCommands.publish).toHaveBeenCalledWith(params, jasmine.any(Function));
                 expect(spyUnlink).toHaveBeenCalledWith(path.resolve(params[0], 'package.json'));
@@ -137,7 +139,7 @@ describe('registry', function() {
         it('should run unpublish', function() {
             var params = ['dummyplugin@0.6.0'];
             registryPromise(true, registry.unpublish(params).then(function() {
-                expect(fakeLoad).toHaveBeenCalledWith(registry.settings, jasmine.any(Function));
+                expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Function));
                 expect(fakeNPMCommands.unpublish).toHaveBeenCalledWith(params, jasmine.any(Function));
                 expect(fakeNPMCommands.cache).toHaveBeenCalledWith(['clean'], jasmine.any(Function));
             }));
@@ -145,7 +147,7 @@ describe('registry', function() {
         it('should run search', function() {
             var params = ['dummyplugin', 'plugin'];
             registryPromise(true, registry.search(params).then(function() {
-                expect(fakeLoad).toHaveBeenCalledWith(registry.settings, jasmine.any(Function));
+                expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Function));
                 expect(fakeNPMCommands.search).toHaveBeenCalledWith(params, true, jasmine.any(Function));
             }));
         });

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -63,9 +63,6 @@ function prepare(options) {
         });
         options.paths = paths;
     })
-    .then(function(){
-        return restore.installPluginsFromConfigXML(options);
-    })
     .then(function() {
         var pluginInfoProvider = new PluginInfoProvider();
 
@@ -130,6 +127,8 @@ function prepare(options) {
         })).then(function() {
             return hooksRunner.fire('after_prepare', options);
         });
+    }).then(function () {
+        return restore.installPluginsFromConfigXML(options);
     });
 }
 

--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -216,7 +216,7 @@ function initSettings(returnEmptySettings) {
 
     // check if settings already set
     if(settings !== null) {
-        return Q(settings);
+        return Q(returnEmptySettings ? {} : settings);
     }
 
     // setting up settings

--- a/cordova-lib/src/util/npm-helper.js
+++ b/cordova-lib/src/util/npm-helper.js
@@ -1,0 +1,76 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+// Helper methods to help keep npm operations separated.
+
+var npm = require('npm'),
+    Q = require('q'),
+    cachedSettings = null,
+    cachedSettingsValues = null;
+
+/**
+ * @description Calls npm.load, then initializes npm.config with the specified settings. Then executes a chain of
+ * promises that rely on those npm settings, then restores npm settings back to their previous value. Use this rather
+ * than passing settings to npm.load, since that only works the first time you try to load npm.
+ * @param {Object} settings
+ * @param {Function} promiseChain
+ */
+function loadWithSettingsThenRestore(settings, promiseChain) {
+    return loadWithSettings(settings).then(promiseChain).then(restoreSettings);
+}
+
+function loadWithSettings(settings) {
+    if (cachedSettings) {
+        throw new Error('Trying to initialize npm when settings have not been restored from a previous initialization.');
+    }
+
+    return Q.nfcall(npm.load).then(function () {
+        for (var prop in settings) {
+            var currentValue = npm.config.get(prop);
+            var newValue = settings[prop];
+
+            if (currentValue !== newValue) {
+                cachedSettingsValues = cachedSettingsValues || {};
+                cachedSettings = cachedSettings || [];
+                cachedSettings.push(prop);
+                if (typeof currentValue !== 'undefined') {
+                    cachedSettingsValues[prop] = currentValue;
+                }
+                npm.config.set(prop, newValue);
+            }
+        }
+    });
+}
+
+function restoreSettings(passthrough) {
+    if (cachedSettings) {
+        cachedSettings.forEach(function (prop) {
+            if (prop in cachedSettingsValues) {
+                npm.config.set(prop, cachedSettingsValues[prop]);
+            } else {
+                npm.config.del(prop);
+            }
+        });
+        cachedSettings = null;
+        cachedSettingsValues = null;
+    }
+    return passthrough;
+}
+
+module.exports.loadWithSettingsThenRestore = loadWithSettingsThenRestore;

--- a/cordova-lib/src/util/npm-helper.js
+++ b/cordova-lib/src/util/npm-helper.js
@@ -32,7 +32,7 @@ var npm = require('npm'),
  * @param {Function} promiseChain
  */
 function loadWithSettingsThenRestore(settings, promiseChain) {
-    return loadWithSettings(settings).then(promiseChain).then(restoreSettings);
+    return loadWithSettings(settings).then(promiseChain).finally(restoreSettings);
 }
 
 function loadWithSettings(settings) {
@@ -58,7 +58,7 @@ function loadWithSettings(settings) {
     });
 }
 
-function restoreSettings(passthrough) {
+function restoreSettings() {
     if (cachedSettings) {
         cachedSettings.forEach(function (prop) {
             if (prop in cachedSettingsValues) {
@@ -70,7 +70,6 @@ function restoreSettings(passthrough) {
         cachedSettings = null;
         cachedSettingsValues = null;
     }
-    return passthrough;
 }
 
 module.exports.loadWithSettingsThenRestore = loadWithSettingsThenRestore;


### PR DESCRIPTION
Start with a blank Cordova app, then enter the following:

    cordova plugin add org.apache.cordova.camera --save
    cordova plugin remove org.apache.cordova.camera
    cordova platform add browser

The final step should restore the camera plugin, but it fails with the following exception:

    TypeError: Cannot read property 'latest' of undefined
        at next (D:\GIT\Cordova\cordova-lib\cordova-lib\node_modules\npm\lib\cache.js:694:35)
        at D:\GIT\Cordova\cordova-lib\cordova-lib\node_modules\npm\lib\cache.js:682:5
        at RegClient.get_ (D:\GIT\Cordova\cordova-lib\cordova-lib\node_modules\npm\node_modules\npm-registry-client\lib\get.js:105:14)
        at RegClient.<anonymous> (D:\GIT\Cordova\cordova-lib\cordova-lib\node_modules\npm\node_modules\npm-registry-client\lib\get.js:41:12)
        at fs.js:336:14
        at D:\GIT\Cordova\cordova-lib\cordova-lib\node_modules\npm\node_modules\graceful-fs\graceful-fs.js:103:5
        at FSReqWrap.oncomplete (fs.js:99:15)

The core problem here is an issue with how we work with npm. Every time we are going to use npm (when dealing with plugins), we call `npm.load()` passing it our settings. But `npm.load()` can only be called once per session - subsequent calls are ignored. The correct approach is to call `npm.load()` without any settings (to make sure npm is loaded), then call `npm.config.set()` for each setting. This change had been made for platforms, but not plugins.

I also wanted to make sure each time we worked with npm we had a clean config (for example, if we get an npm package from the Cordova Plugin Respository, then later from the npm repository, it would try to get the second package from the CPR because that setting would still be around and not get overridden). So now any code that wants to load and init npm I pass through a central "load and restore" method. You pass this method your npm settings and the chain of promises you want to execute with those settings applied. It loads and initializes npm, executes the promises, then restores npm's configuration to what it was before we started.

Finally, once that problem was fixed there was an additional problem - we were adding plugins too early and the platform wasn't fully initialized, so we'd get an error about not being able to find the platform's `config.xml` file.