### PR TITLE
CB-8756 Make 'plugin --save' work more like 'npm install'

### DIFF
--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -58,7 +58,7 @@ exports.isUrl = isUrl;
 
 function isUrl(value) {
     var u = value && url.parse(value);
-    return !!(u && u.protocol && u.protocol.length > 1); // Account for windows c:/ paths
+    return !!(u && u.protocol && u.protocol.length > 2); // Account for windows c:/ paths
 }
 
 function isRootDir(dir) {
@@ -238,9 +238,9 @@ function preProcessOptions (inputOptions) {
 
 function isDirectory(dir) {
     try {
-	return fs.lstatSync(dir).isDirectory();
-    } catch(e) {
-	return false;
+        return fs.lstatSync(dir).isDirectory();
+    } catch (e) {
+        return false;
     }
 }
 


### PR DESCRIPTION
1. `plugin add --save` now always saves version (in the form `^x.y.z`)
2. `plugin add --save` now always overwrites an existing entry.
3. `plugin add` now honors an existing version specified in `config.xml` when a plugin is added without a specific version, even if the `--save` flag is specified.

I also fixed a bug in `isUrl()` (in `util.js`) - `url.protocol` includes the colon, so the protocol for a windows path is something like `c:` - 2 characters, not one.

Note that I'm current finishing off a similar change for `platform add --save`.