### PR TITLE
CB-8791 Recognize UAP as a valid TargetPlatformIdentifier

### DIFF
--- a/cordova-lib/src/util/windows/jsprojManager.js
+++ b/cordova-lib/src/util/windows/jsprojManager.js
@@ -486,11 +486,11 @@ proj.prototype = {
 
 function jsproj(location) {
     function targetPlatformIdentifierToDevice(jsprojPlatform) {
-        var index = ["Windows", "WindowsPhoneApp"].indexOf(jsprojPlatform);
+        var index = ["Windows", "WindowsPhoneApp", "UAP"].indexOf(jsprojPlatform);
         if (index < 0) {
             throw new Error("Unknown TargetPlatformIdentifier '" + jsprojPlatform + "' in project file '" + location + "'");
         }
-        return ["windows", "phone"][index];
+        return ["windows", "phone", "windows"][index];
     }
 
     function validateVersion(version) {


### PR DESCRIPTION
On jsprojManager.js we currently don't have UAP as TargetPlatformIdentifier. We should have UAP as a TargetPlatformIdentifier and treat it as windows.