### PR TITLE
CB-6462 CB-6026 Orientation preference now updates value for iPad

### DIFF
--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -151,6 +151,7 @@ describe('ios project parser', function () {
                 getOrientation.andReturn('');
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
+                    expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toBeUndefined();
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toBeUndefined();
                 });
             });
@@ -158,6 +159,7 @@ describe('ios project parser', function () {
                 getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
+                    expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toBeUndefined();
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toBeUndefined();
                 });
             });

--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -143,6 +143,7 @@ describe('ios project parser', function () {
                 getOrientation.andCallThrough();
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ]);
+                    expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ]);
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'UIInterfaceOrientationPortrait' ]);
                 });
             });

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -96,9 +96,11 @@ ios_parser.prototype.update_from_config = function(config) {
             default:
                 infoPlist['UIInterfaceOrientation'] = [ orientation ];
                 delete infoPlist['UISupportedInterfaceOrientations'];
+                delete infoPlist['UISupportedInterfaceOrientations~ipad'];
         }
     } else {
         delete infoPlist['UISupportedInterfaceOrientations'];
+        delete infoPlist['UISupportedInterfaceOrientations~ipad'];
         delete infoPlist['UIInterfaceOrientation'];
     }
 

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -86,10 +86,12 @@ ios_parser.prototype.update_from_config = function(config) {
             case 'portrait':
                 infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationPortrait' ];
                 infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ];
+                infoPlist['UISupportedInterfaceOrientations~ipad'] = [ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ];
                 break;
             case 'landscape':
                 infoPlist['UIInterfaceOrientation'] = [ 'UIInterfaceOrientationLandscapeLeft' ];
                 infoPlist['UISupportedInterfaceOrientations'] = [ 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
+                infoPlist['UISupportedInterfaceOrientations~ipad'] = [ 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ];
                 break;
             default:
                 infoPlist['UIInterfaceOrientation'] = [ orientation ];


### PR DESCRIPTION
As dicussed in #128 (more specifically https://github.com/apache/cordova-lib/pull/128#issuecomment-89316079), currently setting this:
```xml
<preference name="Orientation" value="landscape"/>
```
doesn't affect the iPad.

So I added code and specs for updating `UISupportedInterfaceOrientations~ipad`, as well as `UISupportedInterfaceOrientations`.

This is my first time contributing to Cordova, sorry if something is missing! All input is welcome :)
