### PR TITLE
Remove hardcoded reference to registry.npmjs.org

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -145,8 +145,7 @@ function npm_cache_add(pkg) {
     // does not ask the registry if it got a fresher version.
     var platformNpmConfig = {
         'cache-min': 3600*24,
-        cache: npm_cache_dir,
-        registry: 'https://registry.npmjs.org'
+        cache: npm_cache_dir
     };
 
     return npmhelper.loadWithSettingsThenRestore(platformNpmConfig, function () {


### PR DESCRIPTION
My company runs an internally-hosted NPM server, which both hosts private modules and proxies to the public registry. We are also behind a corporate proxy, and as such `https://registry.npmjs.org` is not available.

When I try to run `cordova platform add [platform]`, it fails:

```
$ cordova platform add android
npm http GET https://registry.npmjs.org/cordova-android/4.0.0
npm http 401 https://registry.npmjs.org/cordova-android/4.0.0
Unable to fetch platform android: Error: unauthorized Name or password is incorrect.: cordova-android/4.0.0
```

This change removes the hardcoded NPM registry, and allows whichever registry has been configured in `~.npmrc` to be used.