### PR TITLE
CB-9023 Add support to specify a build config file. If none is specified `bui…

### DIFF
--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -243,6 +243,13 @@ function preProcessOptions (inputOptions) {
         result.platforms = projectPlatforms;
     }
 
+    var buildConfigFound = result.options.some(function (option) {
+        return option.indexOf('--buildConfig') === 0;
+    });
+    if (!buildConfigFound && fs.existsSync(path.join(projectRoot, 'build.json'))) {
+        result.options.push('--buildConfig=' + path.join(projectRoot, 'build.json'));
+    }
+
     return result;
 }
 


### PR DESCRIPTION
…ld.json` in the project root is used as a default