### PR TITLE
The concat() method returns a new array.

### DIFF
--- a/cordova-lib/src/plugman/util/plist-helpers.js
+++ b/cordova-lib/src/plugman/util/plist-helpers.js
@@ -28,7 +28,7 @@ function graftPLIST(doc, xml, selector) {
 
     var node = doc[selector];
     if (node && Array.isArray(node) && Array.isArray(obj)){
-        node.concat(obj);
+        node = node.concat(obj);
         for (var i =0;i<node.length; i++){
           for (var j=i+1; j<node.length; ++j) {
             if (node[i] === node[j])


### PR DESCRIPTION
the ios plist file can not add more than one dict CFBundleURLTypes arrays  when use cordova plugman add plugin in ios platform.