### PR TITLE
CB-9030: Shell scripts can't execute when pulled from Windows to *nix via source control

### DIFF
--- a/cordova-lib/src/cordova/compile.js
+++ b/cordova-lib/src/cordova/compile.js
@@ -34,7 +34,7 @@ module.exports = function compile(options) {
     options.platforms.forEach(function(platform) {
         ret = ret.then(function() {
             var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'build');
-            return superspawn.spawn(cmd, options.options, { stdio: 'inherit', printCommand: true });
+            return superspawn.spawn(cmd, options.options, { stdio: 'inherit', printCommand: true, chmod: true });
         });
     });
     ret = ret.then(function() {

--- a/cordova-lib/src/cordova/emulate.js
+++ b/cordova-lib/src/cordova/emulate.js
@@ -39,7 +39,7 @@ module.exports = function emulate(options) {
             var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'run');
             var args = ['--emulator'].concat(options.options);
 
-            return superspawn.spawn(cmd, args, {stdio: 'inherit', printCommand: true});
+            return superspawn.spawn(cmd, args, {stdio: 'inherit', printCommand: true, chmod: true});
         }));
     }).then(function() {
         return hooksRunner.fire('after_emulate', options);

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -149,7 +149,7 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     }
                 }).then(function(args) {
                     var bin = path.join(platDetails.libDir, 'bin', cmd == 'add' ? 'create' : 'update');
-                    var copts = { stdio: 'inherit' };
+                    var copts = { stdio: 'inherit', chmod: true };
                     if ('spawnoutput' in opts) {
                         copts = { stdio: opts.spawnoutput };
                     }
@@ -368,7 +368,7 @@ function check(hooksRunner, projectRoot) {
                 d_cur = Q.defer();
             add(h, scratch, [p], {spawnoutput: {stdio: 'ignore'}})
             .then(function() {
-                superspawn.maybeSpawn(path.join(scratch, 'platforms', p, 'cordova', 'version'))
+                superspawn.maybeSpawn(path.join(scratch, 'platforms', p, 'cordova', 'version'), [], { chmod: true })
                 .then(function(avail) {
                     if (!avail) {
                         /* Platform version script was silent, we can't work with this */
@@ -386,7 +386,7 @@ function check(hooksRunner, projectRoot) {
                 d_avail.resolve('install-failed');
             });
 
-            superspawn.maybeSpawn(path.join(projectRoot, 'platforms', p, 'cordova', 'version'))
+            superspawn.maybeSpawn(path.join(projectRoot, 'platforms', p, 'cordova', 'version'), [], { chmod: true })
             .then(function(v) {
                 d_cur.resolve(v || '');
             }).catch(function () {
@@ -460,7 +460,7 @@ function list(hooksRunner, projectRoot) {
     .then(function() {
         // Acquire the version number of each platform we have installed, and output that too.
         return Q.all(platforms_on_fs.map(function(p) {
-            return superspawn.maybeSpawn(path.join(projectRoot, 'platforms', p, 'cordova', 'version'))
+            return superspawn.maybeSpawn(path.join(projectRoot, 'platforms', p, 'cordova', 'version'), [], { chmod: true })
             .then(function(v) {
                 if (!v) return p;
                 return p + ' ' + v;

--- a/cordova-lib/src/cordova/run.js
+++ b/cordova-lib/src/cordova/run.js
@@ -38,7 +38,7 @@ module.exports = function run(options) {
         // Deploy in parallel (output gets intermixed though...)
         return Q.all(options.platforms.map(function(platform) {
             var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'run');
-            return superspawn.spawn(cmd, options.options, { printCommand: true, stdio: 'inherit' });
+            return superspawn.spawn(cmd, options.options, { printCommand: true, stdio: 'inherit', chmod: true });
         }));
     }).then(function() {
         return hooksRunner.fire('after_run', options);

--- a/cordova-lib/src/cordova/superspawn.js
+++ b/cordova-lib/src/cordova/superspawn.js
@@ -61,6 +61,7 @@ function maybeQuote(a) {
 //          'inherit' means pipe the input & output. This is required for anything that prompts.
 //   env: Map of extra environment variables.
 //   cwd: Working directory for the command.
+//   chmod: If truthy, will attempt to set the execute bit before executing on non-Windows platforms.
 // Returns a promise that succeeds only for return code = 0.
 exports.spawn = function(cmd, args, opts) {
     args = args || [];
@@ -93,6 +94,9 @@ exports.spawn = function(cmd, args, opts) {
     }
     if (opts.env) {
         spawnOpts.env = _.extend(_.extend({}, process.env), opts.env);
+    }
+    if (opts.chmod && !iswin32) {
+        fs.chmodSync(cmd, '755');
     }
 
     events.emit(opts.printCommand ? 'log' : 'verbose', 'Running command: ' + maybeQuote(cmd) + ' ' + args.map(maybeQuote).join(' '));

--- a/cordova-lib/src/cordova/targets.js
+++ b/cordova-lib/src/cordova/targets.js
@@ -35,14 +35,14 @@ function displayDevices(projectRoot, platform, options) {
     var caller = { 'script': 'list-devices' };
     events.emit('log', 'Available ' + platform + ' devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-devices');
-    return superspawn.spawn(cmd, options, { stdio: 'inherit' }).catch(handleError.bind(caller));
+    return superspawn.spawn(cmd, options, { stdio: 'inherit', chmod: true }).catch(handleError.bind(caller));
 }
 
 function displayVirtualDevices(projectRoot, platform, options) {
     var caller = { 'script': 'list-emulator-images' };
     events.emit('log', 'Available ' + platform + ' virtual devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-emulator-images');
-    return superspawn.spawn(cmd, options, { stdio: 'inherit' }).catch(handleError.bind(caller));
+    return superspawn.spawn(cmd, options, { stdio: 'inherit', chmod: true }).catch(handleError.bind(caller));
 }
 
 module.exports = function targets(options) {

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -288,7 +288,7 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
         if (options.platformVersion) {
             return Q(options.platformVersion);
         }
-        return Q(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version')));
+        return Q(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version'), [], { chmod: true }));
     }).then(function(platformVersion) {
         options.platformVersion = platformVersion;
         return callEngineScripts(theEngines);

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -88,7 +88,7 @@ module.exports.uninstallPlatform = function(platform, project_dir, id, plugins_d
         if (options.platformVersion) {
             return Q(options.platformVersion);
         }
-        return Q(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version')));
+        return Q(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version'), [], { chmod: true }));
     }).then(function(platformVersion) {
         options.platformVersion = platformVersion;
         return runUninstallPlatform(current_stack, platform, project_dir, plugin_dir, plugins_dir, options);


### PR DESCRIPTION
Modifies superspawn to support a "chmod" option. When truthy, attempts to set the target file mode to 755 before executing.  Specifies this argument as truthy for common CLI operations (compile, run, and steps in plugman).  Didn't add it for hooks runner since that particular mode is in legacy support.