### PR TITLE
CB-9048 Clean up git cloned directories

### DIFF
--- a/cordova-lib/src/gitclone.js
+++ b/cordova-lib/src/gitclone.js
@@ -68,7 +68,7 @@ function clone(git_url, git_ref, clone_dir){
             });
         }
     }).then(function(){
-        events.emit('log', 'Repository "' + git_url + '" checked out to git ref "' + (git_ref || "master") + '".');
+        events.emit('log', 'Repository "' + git_url + '" checked out to git ref "' + (git_ref || 'master') + '".');
         return tmp_dir;
     }).fail(function (err) {
         shell.rm('-rf', tmp_dir);

--- a/cordova-lib/src/plugman/util/plugins.js
+++ b/cordova-lib/src/plugman/util/plugins.js
@@ -49,7 +49,9 @@ module.exports = {
             // should probably copy over entire plugin git repo contents into plugins_dir and handle subdir separately during install.
             var plugin_dir = path.join(plugins_dir, plugin_id);
             events.emit('verbose', 'Copying fetched plugin over "' + plugin_dir + '"...');
-            shell.cp('-R', path.join(tmp_dir, '*'), plugin_dir);
+            shell.mkdir('-p', plugin_dir);
+            shell.mv(path.join(tmp_dir, '*'), plugin_dir);
+            shell.rm('-Rf', tmp_dir);
             pluginInfo.dir = plugin_dir;
             if (pluginInfoProvider) {
                 pluginInfoProvider.put(pluginInfo);


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CB-9048
Also fix ***jshint*** error: `src/gitclone.js: line 71, col 106, Mixed double and single quotes.`