### PR TITLE
CB-9051 Plugins don't get re-added if platforms folder deleted.

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -122,6 +122,12 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                         if (platformAlreadyAdded) {
                             throw new CordovaError('Platform ' + platform + ' already added.');
                         }
+
+                        // Remove the <platform>.json file from the plugins directory, so we start clean (otherwise we
+                        // can get into trouble not installing plugins if someone deletes the platform folder but
+                        // <platform>.json still exists).
+                        removePlatformPluginsJson(projectRoot, target);
+
                         var template_dir = config_json && config_json.lib && config_json.lib[platform] && config_json.lib[platform].template || null;
                         events.emit('log', 'Adding ' + platform + ' project...');
 
@@ -302,8 +308,7 @@ function remove(hooksRunner, projectRoot, targets, opts) {
     .then(function() {
         targets.forEach(function(target) {
             shell.rm('-rf', path.join(projectRoot, 'platforms', target));
-            var plugins_json = path.join(projectRoot, 'plugins', target + '.json');
-            if (fs.existsSync(plugins_json)) shell.rm(plugins_json);
+            removePlatformPluginsJson(projectRoot, target);
         });
     }).then(function() {
         var config_json = config.read(projectRoot);
@@ -661,6 +666,12 @@ function copy_cordovajs_src(projectRoot, platform, platLib) {
     if(fs.existsSync(cordovaJsSrcPath)) {
         shell.cp('-rf', cordovaJsSrcPath, platform_www);
     } 
+}
+
+// Remove <platform>.json file from plugins directory.
+function removePlatformPluginsJson(projectRoot, target) {
+    var plugins_json = path.join(projectRoot, 'plugins', target + '.json');
+    shell.rm('-f', plugins_json);
 }
 
 module.exports.add = add;


### PR DESCRIPTION
To avoid attempting to add a plugin twice while adding a platform (a scenario that can occur now with automatic restore of plugins and platforms), when adding plugins to a newly added platform we check to see if the plugin has already been added, by calling plugman's `PlatformJson.isPluginInstalled()`, which looks in `plugins/<platform>.json` to see if the plugin has been installed for a platform.

If you delete a platform's folder from the platforms folder, it's `plugins/<platform>.json` file still exists, so if you add the platform again, we think all plugins are already installed for it and don't try to install them.

Simple fix is to delete the platform's `plugins/<platform>.json` file before adding a platform, so we start with a clean slate.