### PR TITLE
CB-8993 Plugin restore ignores search path

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -160,7 +160,8 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                 }).then(function () {
                     // Call prepare for the current platform.
                     var prepOpts = {
-                        platforms :[platform]
+                        platforms :[platform],
+                        searchpath :opts.searchpath
                     };
                     return require('./cordova').raw.prepare(prepOpts);
                 }).then(function() {

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -30,7 +30,8 @@ var cordova_util      = require('./util'),
     plugman           = require('../plugman/plugman'),
     PlatformMunger    = require('../plugman/util/config-changes').PlatformMunger,
     PlatformJson      = require('../plugman/util/PlatformJson'),
-    restore           = require('./restore-util');
+    restore           = require('./restore-util'),
+    config            = require('./config');
 
 
 var PluginInfoProvider = require('../PluginInfoProvider');
@@ -40,6 +41,7 @@ exports = module.exports = prepare;
 function prepare(options) {
     var projectRoot = cordova_util.cdProjectRoot();
     var xml = cordova_util.projectConfig(projectRoot);
+    var config_json = config.read(projectRoot);
 
     if (!options) {
         options = {
@@ -48,6 +50,8 @@ function prepare(options) {
             options: []
         };
     }
+
+    options.searchpath = options.searchpath || config_json.plugin_search_path;
 
     var hooksRunner = new HooksRunner(projectRoot);
     return hooksRunner.fire('before_prepare', options)


### PR DESCRIPTION
Passes provided searchpath to the plugin restore after adding a platform.  Without this I would get errors sometimes about "loadLocalPlugins called twice with different search paths.Support for this is not implemented. "

Also allowing the prepare command to pull the searchpath from the .cordova/config.json if it is present.  This aligns with what the platform and plugin commands do.