### PR TITLE
Updated Android pinned version for Cordova 4.3.x to 3.7.2 (security patch).

### DIFF
--- a/cordova-lib/src/cordova/platformsConfig.json
+++ b/cordova-lib/src/cordova/platformsConfig.json
@@ -3,62 +3,62 @@
         "hostos": ["darwin"],
         "parser": "./metadata/ios_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-ios.git",
-        "version": "3.8.0"
+        "version": "~3.8.0"
     },
     "android": {
         "parser": "./metadata/android_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-android.git",
-        "version": "3.7.1"
+        "version": "~3.7.2"
     },
     "ubuntu": {
         "hostos": ["linux"],
         "parser": "./metadata/ubuntu_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-ubuntu.git",
-        "version": "4.0.0"
+        "version": "~4.0.0"
     },
     "amazon-fireos": {
         "parser": "./metadata/amazon_fireos_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-amazon-fireos.git",
-        "version": "3.6.3"
+        "version": "~3.6.3"
     },
     "wp8": {
         "hostos": ["win32"],
         "parser": "./metadata/wp8_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-wp8.git",
-        "version": "3.7.1",
+        "version": "~3.7.1",
         "altplatform": "wp"
     },
     "blackberry10": {
         "parser": "./metadata/blackberry10_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-blackberry.git",
-        "version": "3.7.0"
+        "version": "~3.7.0"
     },
     "www": {
         "hostos": [],
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-app-hello-world.git",
         "source": "git",
-        "version": "3.6.3"
+        "version": "~3.6.3"
     },
     "firefoxos": {
         "parser": "./metadata/firefoxos_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-firefoxos.git",
-        "version": "3.6.3"
+        "version": "~3.6.3"
     },
     "windows8": {
         "hostos": ["win32"],
         "parser": "./metadata/windows_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",
-        "version": "3.8.0"
+        "version": "~3.8.0"
     },
     "windows": {
         "hostos": ["win32"],
         "parser": "./metadata/windows_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",
-        "version": "3.8.0"
+        "version": "~3.8.0"
     },
     "browser": {
         "parser": "./metadata/browser_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-browser.git",
-        "version": "3.6.0"
+        "version": "~3.6.0"
     }
 }


### PR DESCRIPTION
Also update pinned platforms to use '~' version, so we get patch updates automatically.