### PR TITLE
Updated Android pinned version to 3.7.2 (security patch).

### DIFF
--- a/cordova-lib/src/cordova/platformsConfig.json
+++ b/cordova-lib/src/cordova/platformsConfig.json
@@ -8,7 +8,7 @@
     "android": {
         "parser": "./metadata/android_parser",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-android.git",
-        "version": "3.7.1"
+        "version": "3.7.2"
     },
     "ubuntu": {
         "hostos": ["linux"],


### PR DESCRIPTION
Updates the Android pinned version for Cordova 4.3.x to 3.7.2, which contains the recent security patch.