### PR TITLE
Fix four failing tests on Windows.

### DIFF
--- a/cordova-lib/spec-plugman/platforms/android.spec.js
+++ b/cordova-lib/spec-plugman/platforms/android.spec.js
@@ -137,7 +137,7 @@ describe('android project handler', function() {
             var finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).toMatch('\nandroid.library.reference.3='+dummy_id+'/'+packageIdSuffix+'-plugin-lib', 'Reference to library not added');
             var subProjectProperties = fs.readFileSync(subProjectPropsFile, 'utf8');
-            expect(subProjectProperties).toMatch(/\btarget=android-19\n/, 'target SDK version not copied to library');
+            expect(subProjectProperties).toMatch(/\btarget=android-19$/m, 'target SDK version not copied to library');
             expect(exec).toHaveBeenCalledWith('android update lib-project --path "' + subDir + '"');
 
             // Now test uninstall


### PR DESCRIPTION
Two tests fail on Windows in a non-admin command window because they rely on creating symlinks. Since creating the symlinks isn't the purpose of the test but just setup for the test, if that fails and the platform is `win32`, we now just bail on the test.

Another test failed because a folder unexpectedly exists when run from a non-admin prompt. I'm not 100% sure why the folder exists, but the test was bogus... the test actually ends up testing that we throw if `src` does not exist, which is something that we verify in an earlier test, while the intent of the test was to verify we throw if `dest` *already* exists. Since it is `copyNewFile()` that is supposed to throw in that scenario, so I updated the test to check for that.

Finally, a fourth test failed on Windows (admin or non-admin) because of different line endings. Changed that to handle either line ending.

Verified all tests now pass on Windows and still pass on OS X.

Note: I don't believe this is the cause of the AppVeyor failures we are seeing.