### PR TITLE
CB-9114: Log deprecation message when --usegit flag is used

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -68,6 +68,13 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
         }
     }
 
+    if (opts.usegit) {
+        msg = '\nWARNING: The --usegit flag has been deprecated! \n' +
+              'Instead, please use: `cordova platform add git-url#custom-branch`. \n' +
+              'e.g: cordova platform add https://github.com/apache/cordova-android.git#2.4.0 \n';
+        events.emit('warning', msg);
+    }
+
     var xml = cordova_util.projectConfig(projectRoot);
     var cfg = new ConfigParser(xml);
     var config_json = config.read(projectRoot);


### PR DESCRIPTION
CB-9114: Log deprecation message when --usegit flag is used
                Moving towards using `cordova platform add git-url#my-branch` instead.

Background:
http://apache.markmail.org/message/7cf5zovxcgdxgwa2?q=ommenjik+list:org%2Eapache%2Eincubator%2Ecallback-dev+order:date-backward&page=1#query:ommenjik%20list%3Aorg.apache.incubator.callback-dev%20order%3Adate-backward+page:1+mid:c3cep6d3eez5kefe+state:results