### PR TITLE
CB-9126 Fix ios pbxproj' resources paths when adding ios platform on non-OSX environment

### DIFF
--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -42,7 +42,7 @@
     "underscore": "1.7.0",
     "unorm": "1.3.3",
     "valid-identifier": "0.0.1",
-    "xcode": "0.6.7"
+    "xcode": "0.7.0"
   },
   "devDependencies": {
     "istanbul": "^0.3.4",


### PR DESCRIPTION
[Jira issue with details](https://issues.apache.org/jira/browse/CB-9126)