### PR TITLE
CB-8052: [webOS] Update cordova-lib for webOS support

### DIFF
--- a/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
@@ -16,14 +16,13 @@
     specific language governing permissions and limitations
     under the License.
 */
-var platforms = require('../../src/cordova/platforms'),
+var platforms = require('../../src/platforms/platforms'),
     util = require('../../src/cordova/util'),
     path = require('path'),
     shell = require('shelljs'),
     fs = require('fs'),
     config = require('../../src/cordova/config'),
-    ConfigParser = require('../../src/configparser/ConfigParser'),
-    cordova = require('../../src/cordova/cordova');
+    ConfigParser = require('../../src/configparser/ConfigParser');
 
 var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
 describe('webos project parser', function() {

--- a/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
@@ -1,0 +1,74 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+var platforms = require('../../src/cordova/platforms'),
+    util = require('../../src/cordova/util'),
+    path = require('path'),
+    shell = require('shelljs'),
+    fs = require('fs'),
+    config = require('../../src/cordova/config'),
+    ConfigParser = require('../../src/configparser/ConfigParser'),
+    cordova = require('../../src/cordova/cordova');
+
+var cfg = new ConfigParser(path.join(__dirname, '..', 'test-config.xml'));
+describe('webos project parser', function() {
+    var proj = path.join('some', 'path');
+    var exists, exec, custom;
+    beforeEach(function() {
+        exists = spyOn(fs, 'existsSync').andReturn(true);
+        exec = spyOn(shell, 'exec').andCallFake(function(cmd, opts, cb) {
+            cb(0, '');
+        });
+        custom = spyOn(config, 'has_custom_path').andReturn(false);
+    });
+
+    describe('constructions', function() {
+        it('should create an instance with a path', function() {
+            expect(function() {
+                var p = new platforms.android.parser(proj);
+                expect(p.path).toEqual(proj);
+            }).not.toThrow();
+        });
+    });
+
+    describe('instance', function() {
+        var p, cp, rm, is_cordova, write, read;
+        var wos_proj = path.join(proj, 'platforms', 'webos');
+        beforeEach(function() {
+            p = new platforms.webos.parser(wos_proj);
+            cp = spyOn(shell, 'cp');
+            rm = spyOn(shell, 'rm');
+            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            write = spyOn(fs, 'writeFileSync');
+            read = spyOn(fs, 'readFileSync').andReturn('');
+        });
+
+        describe('update_from_config method', function() {
+            beforeEach(function() {
+                cfg.name = function() { return 'testname'; };
+                cfg.packageName = function() { return 'testpkg'; };
+                cfg.version = function() { return '1.0'; };
+            });
+
+          /*  it('should write appinfo.json', function() {
+                //p.update_from_config(cfg);
+                //expect(write.mostRecentCall.args[0]).toEqual('appinfo.json');
+            });*/
+        });
+    });
+});

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -72,11 +72,7 @@ webos_parser.prototype.update_from_config = function(config) {
         if(index===0 || index===1) {
             return src.substring(index+4);
         } else {
-            shell.mkdir('-p', path.join(www, 'assets'));
-            var newSrc = 'assets/' + type + '.png';
-            if(type==='icon') {
-                newSrc = 'icon.png';
-            }
+            var newSrc = type + '.png';
             shell.cp('-f', path.join(projectRoot, src), path.join(www, newSrc));
             return newSrc;
         }

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -1,0 +1,204 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
+          indent:4, unused:vars, latedef:nofunc,
+          sub:true
+*/
+
+var fs = require('fs'),
+    path = require('path'),
+    shell = require('shelljs'),
+    util = require('../util'),
+    Q = require('q'),
+    ConfigParser = require('../../configparser/ConfigParser');
+
+module.exports = function webos_parser(project) {
+    this.path = project;
+};
+
+
+module.exports.prototype = {
+    // Returns a promise.
+    update_from_config: function() {
+        var config = new ConfigParser(this.config_xml());
+        var www = this.www_dir();
+        var manifestPath = path.join(www, 'appinfo.json');
+        var manifest = {type: 'web', uiRevision:2};
+
+        // Load existing manifest
+        if (fs.existsSync(manifestPath)) {
+            manifest = JSON.parse(fs.readFileSync(manifestPath));
+        }
+
+        // overwrite properties existing in config.xml
+        manifest.id = config.packageName() || 'org.apache.cordova.example';
+        var contentNode = config.doc.find('content');
+        var contentSrc = contentNode && contentNode.attrib['src'] || 'index.html';
+        manifest.main = contentSrc;
+        manifest.version = config.version() || '0.0.1';
+        manifest.title = config.name() || 'CordovaExample';
+        manifest.appDescription = config.description() || '';
+        manifest.vendor = config.author() || 'My Company';
+
+        var authorNode = config.doc.find('author');
+        var authorUrl = authorNode && authorNode.attrib['href'];
+        if (authorUrl) {
+            manifest.vendorurl = authorUrl;
+        }
+
+        var projectRoot = util.isCordova(this.path);
+        var copyImg = function(src, type) {
+            var index = src.indexOf('www');
+            if(index===0 || index===1) {
+                return src.substring(index+4);
+            } else {
+                var newSrc = 'assets/' + type + '.png';
+                if(type==='icon') {
+                    newSrc = 'icon.png';
+                }
+                shell.cp('-f', path.join(projectRoot, src), path.join(www, newSrc));
+                return newSrc;
+            }
+        };
+
+        var icons = config.getIcons('webos');
+        // if there are icon elements in config.xml
+        if (icons) {
+            var setIcon = function(type, size) {
+                var item = icons.getBySize(size, size);
+                if(item && item.src) {
+                    manifest[type] = copyImg(item.src, type);
+                } else {
+                    item = icons.getDefault();
+                    if(item && item.src) {
+                        manifest[type] = copyImg(item.src, type);
+                    }
+                }
+            };
+            setIcon('icon', 80, 80);
+            setIcon('largeIcon', 130, 130);
+        }
+
+        var splash = config.getSplashScreens('webos');
+        // if there are icon elements in config.xml
+        if (splash) {
+            var splashImg = splash.getBySize(1920, 1080);
+            if(splashImg && splashImg.src) {
+                manifest.splashBackground = copyImg(splashImg.src, 'splash');
+            }
+        }
+
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, '\t'));
+
+        return Q();
+    },
+
+    www_dir: function() {
+        return path.join(this.path, 'www');
+    },
+
+    // Used for creating platform_www in projects created by older versions.
+    cordovajs_path:function(libDir) {
+        var jsPath = path.join(libDir, 'cordova-lib', 'cordova.js');
+        return path.resolve(jsPath);
+    },
+
+    // Replace the www dir with contents of platform_www and app www.
+    update_www:function() {
+        var projectRoot = util.isCordova(this.path);
+        var app_www = util.projectWww(projectRoot);
+        var platform_www = path.join(this.path, 'platform_www');
+
+        // Clear the www dir
+        shell.rm('-rf', this.www_dir());
+        shell.mkdir(this.www_dir());
+        // Copy over all app www assets
+        if(fs.lstatSync(app_www).isSymbolicLink()) {
+            var real_www = fs.realpathSync(app_www);
+            if(fs.existsSync(path.join(real_www, 'build/enyo.js'))) {
+                // symlinked Enyo bootplate; resolve to bootplate root for
+                // ares-webos-sdk to handle the minification
+                if(fs.existsSync(path.join(real_www, '../enyo'))) {
+                    app_www = path.join(real_www, '..');
+                } else if (fs.existsSync(path.join(real_www, '../../enyo'))) {
+                    app_www = path.join(real_www, '../..');
+                }
+                //double check existence of deploy
+                if(!fs.existsSync(path.join(app_www, 'deploy'))) {
+                    app_www = real_www; //fallback
+                }
+            }
+        }
+        shell.cp('-rf', path.join(app_www, '*'), this.www_dir());
+        // Copy over stock platform www assets (cordova.js)
+        shell.cp('-rf', path.join(platform_www, '*'), this.www_dir());
+
+        // prepare and update deploy.json for cordova components
+        var deploy = path.join(this.www_dir(), 'deploy.json');
+        if(fs.existsSync(deploy)) {
+            try {
+                // make stub file entries to guarantee the dir/files are there
+                shell.mkdir('-p', path.join(this.www_dir(), 'plugins'));
+                var pluginFile = path.join(this.www_dir(), 'cordova_plugins.js');
+                if(!fs.existsSync(pluginFile)) {
+                    fs.writeFileSync(pluginFile, '');
+                }
+                // add to json if not already there, so they don't get minified out during build
+                var obj = JSON.parse(fs.readFileSync(deploy, {encoding:'utf8'}));
+                obj.assets = obj.assets || [];
+                var assets = ['plugins', 'cordova.js', 'cordova_plugins.js'];
+                for(var i=0; i<assets.length; i++) {
+                    var index = obj.assets.indexOf(assets[i]);
+                    if(index<0) {
+                        index = obj.assets.indexOf('./' + assets[i]);
+                    }
+                    if(index<0) {
+                        obj.assets.push('./' + assets[i]);
+                    }
+                    fs.writeFileSync(deploy, JSON.stringify(obj, null, '\t'));
+                }
+            } catch(e) {
+                console.error('Unable to update deploy.json: ' + e);
+            }
+        }
+    },
+
+    update_overrides: function() {
+        var projectRoot = util.isCordova(this.path);
+        var mergesPath = path.join(util.appDir(projectRoot), 'merges', 'webosos');
+        if(fs.existsSync(mergesPath)) {
+            var overrides = path.join(mergesPath, '*');
+            shell.cp('-rf', overrides, this.www_dir());
+        }
+    },
+
+    config_xml:function(){
+        return path.join(this.path, 'config.xml');
+    },
+
+    // Returns a promise.
+    update_project: function(cfg) {
+        return this.update_from_config()
+            .then(function(){
+                this.update_overrides();
+                util.deleteSvnFolders(this.www_dir());
+            }.bind(this));
+    }
+};

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -27,178 +27,188 @@ var fs = require('fs'),
     shell = require('shelljs'),
     util = require('../util'),
     Q = require('q'),
+    Parser = require('./parser'),
     ConfigParser = require('../../configparser/ConfigParser');
 
-module.exports = function webos_parser(project) {
+function webos_parser(project) {
+    // Call the base class constructor
+    Parser.call(this, 'webos', project);
     this.path = project;
 };
 
+require('util').inherits(webos_parser, Parser);
 
-module.exports.prototype = {
-    // Returns a promise.
-    update_from_config: function() {
-        var config = new ConfigParser(this.config_xml());
-        var www = this.www_dir();
-        var manifestPath = path.join(www, 'appinfo.json');
-        var manifest = {type: 'web', uiRevision:2};
+module.exports = webos_parser;
 
-        // Load existing manifest
-        if (fs.existsSync(manifestPath)) {
-            manifest = JSON.parse(fs.readFileSync(manifestPath));
-        }
+// Returns a promise.
+webos_parser.prototype.update_from_config = function(config) {
+    var www = this.www_dir();
+    var manifestPath = path.join(www, 'appinfo.json');
+    var manifest = {type: 'web', uiRevision:2};
 
-        // overwrite properties existing in config.xml
-        manifest.id = config.packageName() || 'org.apache.cordova.example';
-        var contentNode = config.doc.find('content');
-        var contentSrc = contentNode && contentNode.attrib['src'] || 'index.html';
-        manifest.main = contentSrc;
-        manifest.version = config.version() || '0.0.1';
-        manifest.title = config.name() || 'CordovaExample';
-        manifest.appDescription = config.description() || '';
-        manifest.vendor = config.author() || 'My Company';
+    // Load existing manifest
+    if (fs.existsSync(manifestPath)) {
+        manifest = JSON.parse(fs.readFileSync(manifestPath));
+    }
 
-        var authorNode = config.doc.find('author');
-        var authorUrl = authorNode && authorNode.attrib['href'];
-        if (authorUrl) {
-            manifest.vendorurl = authorUrl;
-        }
+    // overwrite properties existing in config.xml
+    manifest.id = config.packageName() || 'org.apache.cordova.example';
+    var contentNode = config.doc.find('content');
+    var contentSrc = contentNode && contentNode.attrib['src'] || 'index.html';
+    manifest.main = contentSrc;
+    manifest.version = config.version() || '0.0.1';
+    manifest.title = config.name() || 'CordovaExample';
+    manifest.appDescription = config.description() || '';
+    manifest.vendor = config.author() || 'My Company';
 
-        var projectRoot = util.isCordova(this.path);
-        var copyImg = function(src, type) {
-            var index = src.indexOf('www');
-            if(index===0 || index===1) {
-                return src.substring(index+4);
-            } else {
-                var newSrc = 'assets/' + type + '.png';
-                if(type==='icon') {
-                    newSrc = 'icon.png';
-                }
-                shell.cp('-f', path.join(projectRoot, src), path.join(www, newSrc));
-                return newSrc;
+    var authorNode = config.doc.find('author');
+    var authorUrl = authorNode && authorNode.attrib['href'];
+    if (authorUrl) {
+        manifest.vendorurl = authorUrl;
+    }
+
+    var projectRoot = util.isCordova(this.path);
+    var copyImg = function(src, type) {
+        var index = src.indexOf('www');
+        if(index===0 || index===1) {
+            return src.substring(index+4);
+        } else {
+            var newSrc = 'assets/' + type + '.png';
+            if(type==='icon') {
+                newSrc = 'icon.png';
             }
-        };
+            shell.cp('-f', path.join(projectRoot, src), path.join(www, newSrc));
+            return newSrc;
+        }
+    };
 
-        var icons = config.getIcons('webos');
-        // if there are icon elements in config.xml
-        if (icons) {
-            var setIcon = function(type, size) {
-                var item = icons.getBySize(size, size);
+    var icons = config.getIcons('webos');
+    // if there are icon elements in config.xml
+    if (icons) {
+        var setIcon = function(type, size) {
+            var item = icons.getBySize(size, size);
+            if(item && item.src) {
+                manifest[type] = copyImg(item.src, type);
+            } else {
+                item = icons.getDefault();
                 if(item && item.src) {
                     manifest[type] = copyImg(item.src, type);
-                } else {
-                    item = icons.getDefault();
-                    if(item && item.src) {
-                        manifest[type] = copyImg(item.src, type);
-                    }
-                }
-            };
-            setIcon('icon', 80, 80);
-            setIcon('largeIcon', 130, 130);
-        }
-
-        var splash = config.getSplashScreens('webos');
-        // if there are icon elements in config.xml
-        if (splash) {
-            var splashImg = splash.getBySize(1920, 1080);
-            if(splashImg && splashImg.src) {
-                manifest.splashBackground = copyImg(splashImg.src, 'splash');
-            }
-        }
-
-        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, '\t'));
-
-        return Q();
-    },
-
-    www_dir: function() {
-        return path.join(this.path, 'www');
-    },
-
-    // Used for creating platform_www in projects created by older versions.
-    cordovajs_path:function(libDir) {
-        var jsPath = path.join(libDir, 'cordova-lib', 'cordova.js');
-        return path.resolve(jsPath);
-    },
-
-    // Replace the www dir with contents of platform_www and app www.
-    update_www:function() {
-        var projectRoot = util.isCordova(this.path);
-        var app_www = util.projectWww(projectRoot);
-        var platform_www = path.join(this.path, 'platform_www');
-
-        // Clear the www dir
-        shell.rm('-rf', this.www_dir());
-        shell.mkdir(this.www_dir());
-        // Copy over all app www assets
-        if(fs.lstatSync(app_www).isSymbolicLink()) {
-            var real_www = fs.realpathSync(app_www);
-            if(fs.existsSync(path.join(real_www, 'build/enyo.js'))) {
-                // symlinked Enyo bootplate; resolve to bootplate root for
-                // ares-webos-sdk to handle the minification
-                if(fs.existsSync(path.join(real_www, '../enyo'))) {
-                    app_www = path.join(real_www, '..');
-                } else if (fs.existsSync(path.join(real_www, '../../enyo'))) {
-                    app_www = path.join(real_www, '../..');
-                }
-                //double check existence of deploy
-                if(!fs.existsSync(path.join(app_www, 'deploy'))) {
-                    app_www = real_www; //fallback
                 }
             }
-        }
-        shell.cp('-rf', path.join(app_www, '*'), this.www_dir());
-        // Copy over stock platform www assets (cordova.js)
-        shell.cp('-rf', path.join(platform_www, '*'), this.www_dir());
+        };
+        setIcon('icon', 80, 80);
+        setIcon('largeIcon', 130, 130);
+    }
 
-        // prepare and update deploy.json for cordova components
-        var deploy = path.join(this.www_dir(), 'deploy.json');
-        if(fs.existsSync(deploy)) {
-            try {
-                // make stub file entries to guarantee the dir/files are there
-                shell.mkdir('-p', path.join(this.www_dir(), 'plugins'));
-                var pluginFile = path.join(this.www_dir(), 'cordova_plugins.js');
-                if(!fs.existsSync(pluginFile)) {
-                    fs.writeFileSync(pluginFile, '');
-                }
-                // add to json if not already there, so they don't get minified out during build
-                var obj = JSON.parse(fs.readFileSync(deploy, {encoding:'utf8'}));
-                obj.assets = obj.assets || [];
-                var assets = ['plugins', 'cordova.js', 'cordova_plugins.js'];
-                for(var i=0; i<assets.length; i++) {
-                    var index = obj.assets.indexOf(assets[i]);
-                    if(index<0) {
-                        index = obj.assets.indexOf('./' + assets[i]);
-                    }
-                    if(index<0) {
-                        obj.assets.push('./' + assets[i]);
-                    }
-                    fs.writeFileSync(deploy, JSON.stringify(obj, null, '\t'));
-                }
-            } catch(e) {
-                console.error('Unable to update deploy.json: ' + e);
+    var splash = config.getSplashScreens('webos');
+    // if there are icon elements in config.xml
+    if (splash) {
+        var splashImg = splash.getBySize(1920, 1080);
+        if(splashImg && splashImg.src) {
+            manifest.splashBackground = copyImg(splashImg.src, 'splash');
+        }
+    }
+
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, '\t'));
+
+    return Q();
+};
+
+webos_parser.prototype.www_dir = function() {
+    return path.join(this.path, 'www');
+};
+
+// Used for creating platform_www in projects created by older versions.
+webos_parser.prototype.cordovajs_path = function(libDir) {
+    var jsPath = path.join(libDir, 'cordova-lib', 'cordova.js');
+    return path.resolve(jsPath);
+};
+
+webos_parser.prototype.cordovajs_src_path = function(libDir) {
+    var jsPath = path.join(libDir, 'cordova-js-src');
+    return path.resolve(jsPath);
+};
+
+// Replace the www dir with contents of platform_www and app www.
+webos_parser.prototype.update_www = function() {
+    var projectRoot = util.isCordova(this.path);
+    var app_www = util.projectWww(projectRoot);
+    var platform_www = path.join(this.path, 'platform_www');
+
+    // Clear the www dir
+    shell.rm('-rf', this.www_dir());
+    shell.mkdir(this.www_dir());
+    // Copy over all app www assets
+    if(fs.lstatSync(app_www).isSymbolicLink()) {
+        var real_www = fs.realpathSync(app_www);
+        if(fs.existsSync(path.join(real_www, 'build/enyo.js'))) {
+            // symlinked Enyo bootplate; resolve to bootplate root for
+            // ares-webos-sdk to handle the minification
+            if(fs.existsSync(path.join(real_www, '../enyo'))) {
+                app_www = path.join(real_www, '..');
+            } else if (fs.existsSync(path.join(real_www, '../../enyo'))) {
+                app_www = path.join(real_www, '../..');
+            }
+            //double check existence of deploy
+            if(!fs.existsSync(path.join(app_www, 'deploy'))) {
+                app_www = real_www; //fallback
             }
         }
-    },
+    }
+    shell.cp('-rf', path.join(app_www, '*'), this.www_dir());
+    // Copy over stock platform www assets (cordova.js)
+    shell.cp('-rf', path.join(platform_www, '*'), this.www_dir());
 
-    update_overrides: function() {
-        var projectRoot = util.isCordova(this.path);
-        var mergesPath = path.join(util.appDir(projectRoot), 'merges', 'webosos');
-        if(fs.existsSync(mergesPath)) {
-            var overrides = path.join(mergesPath, '*');
-            shell.cp('-rf', overrides, this.www_dir());
+    // prepare and update deploy.json for cordova components
+    var deploy = path.join(this.www_dir(), 'deploy.json');
+    if(fs.existsSync(deploy)) {
+        try {
+            // make stub file entries to guarantee the dir/files are there
+            shell.mkdir('-p', path.join(this.www_dir(), 'plugins'));
+            var pluginFile = path.join(this.www_dir(), 'cordova_plugins.js');
+            if(!fs.existsSync(pluginFile)) {
+                fs.writeFileSync(pluginFile, '');
+            }
+            // add to json if not already there, so they don't get minified out during build
+            var obj = JSON.parse(fs.readFileSync(deploy, {encoding:'utf8'}));
+            obj.assets = obj.assets || [];
+            var assets = ['plugins', 'cordova.js', 'cordova_plugins.js'];
+            for(var i=0; i<assets.length; i++) {
+                var index = obj.assets.indexOf(assets[i]);
+                if(index<0) {
+                    index = obj.assets.indexOf('./' + assets[i]);
+                }
+                if(index<0) {
+                    obj.assets.push('./' + assets[i]);
+                }
+                fs.writeFileSync(deploy, JSON.stringify(obj, null, '\t'));
+            }
+        } catch(e) {
+            console.error('Unable to update deploy.json: ' + e);
         }
-    },
-
-    config_xml:function(){
-        return path.join(this.path, 'config.xml');
-    },
-
-    // Returns a promise.
-    update_project: function(cfg) {
-        return this.update_from_config()
-            .then(function(){
-                this.update_overrides();
-                util.deleteSvnFolders(this.www_dir());
-            }.bind(this));
     }
 };
+
+webos_parser.prototype.update_overrides = function() {
+    var projectRoot = util.isCordova(this.path);
+    var mergesPath = path.join(util.appDir(projectRoot), 'merges', 'webosos');
+    if(fs.existsSync(mergesPath)) {
+        var overrides = path.join(mergesPath, '*');
+        shell.cp('-rf', overrides, this.www_dir());
+    }
+};
+
+webos_parser.prototype.config_xml = function(){
+    return path.join(this.path, 'config.xml');
+};
+
+// Returns a promise.
+webos_parser.prototype.update_project = function(cfg) {
+    return this.update_from_config(cfg)
+        .then(function(){
+            this.update_overrides();
+            util.deleteSvnFolders(this.www_dir());
+        }.bind(this));
+};
+
+

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -27,14 +27,13 @@ var fs = require('fs'),
     shell = require('shelljs'),
     util = require('../util'),
     Q = require('q'),
-    Parser = require('./parser'),
-    ConfigParser = require('../../configparser/ConfigParser');
+    Parser = require('./parser');
 
 function webos_parser(project) {
     // Call the base class constructor
     Parser.call(this, 'webos', project);
     this.path = project;
-};
+}
 
 require('util').inherits(webos_parser, Parser);
 

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -72,6 +72,7 @@ webos_parser.prototype.update_from_config = function(config) {
         if(index===0 || index===1) {
             return src.substring(index+4);
         } else {
+            shell.mkdir('-p', path.join(www, 'assets'));
             var newSrc = 'assets/' + type + '.png';
             if(type==='icon') {
                 newSrc = 'icon.png';

--- a/cordova-lib/src/platforms/platformsConfig.json
+++ b/cordova-lib/src/platforms/platformsConfig.json
@@ -65,6 +65,12 @@
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",
         "version": "~4.0.0"
     },
+    "webos": {
+        "parser_file": "../cordova/metadata/webos_parser",
+        "handler_file": "../plugman/platforms/webos",
+        "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-webos.git",
+        "version": "~3.7.0"
+    },
     "browser": {
         "parser_file": "../cordova/metadata/browser_parser",
         "handler_file": "../plugman/platforms/browser",

--- a/cordova-lib/src/plugman/platforms/webos.js
+++ b/cordova-lib/src/plugman/platforms/webos.js
@@ -55,12 +55,12 @@ module.exports = {
         return widget_doc._root.attrib['id'];
     },
     'source-file':{
-        install:function(source_el, plugin_dir, project_dir, plugin_id) {
-            var dest = path.join(source_el.attrib['target-dir'], path.basename(source_el.attrib['src']));
-            common.copyFile(plugin_dir, source_el.attrib['src'], project_dir, dest);
+        install:function(obj, plugin_dir, project_dir, plugin_id, options) {
+            var dest = path.join(obj.targetDir, path.basename(obj.src));
+            common.copyFile(plugin_dir, obj.src, project_dir, dest);
         },
-        uninstall:function(source_el, project_dir, plugin_id) {
-            var dest = path.join(source_el.attrib['target-dir'], path.basename(source_el.attrib['src']));
+        uninstall:function(obj, project_dir, plugin_id, options) {
+            var dest = path.join(obj.targetDir, path.basename(obj.src));
             common.removeFile(project_dir, dest);
         }
     },

--- a/cordova-lib/src/plugman/platforms/webos.js
+++ b/cordova-lib/src/plugman/platforms/webos.js
@@ -1,0 +1,99 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+/* jshint node:true, bitwise:true, undef:true, trailing:true, quotmark:true,
+          indent:4, unused:vars, latedef:nofunc,
+          laxcomma:true, sub:true
+*/
+
+var path = require('path')
+    , fs = require('fs')
+    , common = require('./common')
+    , events = require('../../events')
+    , xml_helpers = require(path.join(__dirname, '..', '..', 'util', 'xml-helpers'))
+    ;
+
+module.exports = {
+    www_dir: function(project_dir) {
+        return path.join(project_dir, 'www');
+    },
+    package_name:function(project_dir) {
+        // preferred location if cordova >= 3.4
+        var preferred_path = path.join(project_dir, 'config.xml');
+        var config_path;
+
+        if (!fs.existsSync(preferred_path)) {
+            // older location
+            var old_config_path = path.join(module.exports.www_dir(project_dir), 'config.xml');
+            if (!fs.existsSync(old_config_path)) {
+                // output newer location and fail reading
+                config_path = preferred_path;
+                events.emit('verbose', 'unable to find '+config_path);
+            } else {
+                config_path = old_config_path;
+            }
+        } else {
+            config_path = preferred_path;
+        }
+        var widget_doc = xml_helpers.parseElementtreeSync(config_path);
+        return widget_doc._root.attrib['id'];
+    },
+    'source-file':{
+        install:function(source_el, plugin_dir, project_dir, plugin_id) {
+            var dest = path.join(source_el.attrib['target-dir'], path.basename(source_el.attrib['src']));
+            common.copyFile(plugin_dir, source_el.attrib['src'], project_dir, dest);
+        },
+        uninstall:function(source_el, project_dir, plugin_id) {
+            var dest = path.join(source_el.attrib['target-dir'], path.basename(source_el.attrib['src']));
+            common.removeFile(project_dir, dest);
+        }
+    },
+    'header-file': {
+        install:function(source_el, plugin_dir, project_dir, plugin_id) {
+            events.emit('verbose', 'header-fileinstall is not supported for webos');
+        },
+        uninstall:function(source_el, project_dir, plugin_id) {
+            events.emit('verbose', 'header-file.uninstall is not supported for webos');
+        }
+    },
+    'resource-file':{
+        install:function(el, plugin_dir, project_dir, plugin_id) {
+            events.emit('verbose', 'resource-file.install is not supported for webos');
+        },
+        uninstall:function(el, project_dir, plugin_id) {
+            events.emit('verbose', 'resource-file.uninstall is not supported for webos');
+        }
+    },
+    'framework': {
+        install:function(source_el, plugin_dir, project_dir, plugin_id) {
+            events.emit('verbose', 'framework.install is not supported for webos');
+        },
+        uninstall:function(source_el, project_dir, plugin_id) {
+            events.emit('verbose', 'framework.uninstall is not supported for webos');
+        }
+    },
+    'lib-file': {
+        install:function(source_el, plugin_dir, project_dir, plugin_id) {
+            events.emit('verbose', 'lib-file.install is not supported for webos');
+        },
+        uninstall:function(source_el, project_dir, plugin_id) {
+            events.emit('verbose', 'lib-file.uninstall is not supported for webos');
+        }
+    }
+};


### PR DESCRIPTION
Allows for Cordova CLI and Plugman to work with webOS in the Cordova project environment.

Naturally it relies on https://github.com/apache/cordova-webos/pull/3 having been merged and added to NPM to work via the webos shorthand.