### PR TITLE
fix CB-9145 prepare can lose data during config munge

### DIFF
--- a/cordova-lib/spec-cordova/prepare.spec.js
+++ b/cordova-lib/spec-cordova/prepare.spec.js
@@ -271,4 +271,25 @@ describe('prepare._mergeXml', function () {
         var testElements = dstXml.findall('preference');
         expect(testElements.length).toEqual(2);
     });
+
+    it('should not skip partial duplicate non singelton children', function () {
+        //remove access tags from dstXML
+        var testElements = dstXml.findall('access');
+        for(var i = 0; i < testElements.length; i++) {
+            dstXml.remove(testElements[i]);
+        }
+        testElements = dstXml.findall('access');
+        expect(testElements.length).toEqual(0);
+        //add an external whitelist access tag
+        var testXml = et.XML('<widget><access origin="*" launch-external="yes"/></widget>');
+        prepare._mergeXml(testXml, dstXml, '', true);
+        testElements = dstXml.findall('access');
+        expect(testElements.length).toEqual(1);
+        //add an internal whitelist access tag
+        testXml = et.XML('<widget><access origin="*"/></widget>');
+        prepare._mergeXml(testXml, dstXml, '', true);
+        testElements = dstXml.findall('access');
+        expect(testElements.length).toEqual(2);
+
+    });    
 });

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -181,11 +181,15 @@ function mergeXml(src, dest, platform, clobber) {
                 Object.getOwnPropertyNames(srcChild.attrib).forEach(function (attribute) {
                     query += '[@' + attribute + '="' + srcChild.attrib[attribute] + '"]';
                 });
-                foundChild = dest.find(query);
-                if (foundChild && textMatch(srcChild, foundChild)) {
-                    destChild = foundChild;
-                    dest.remove(destChild);
-                    shouldMerge = false;
+                var foundChildren = dest.findall(query);
+                for(var i = 0; i < foundChildren.length; i++) {
+                    foundChild = foundChildren[i];
+                    if (foundChild && textMatch(srcChild, foundChild) && (Object.keys(srcChild.attrib).length==Object.keys(foundChild.attrib).length)) {
+                        destChild = foundChild;
+                        dest.remove(destChild);
+                        shouldMerge = false;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
I added a test that adds access tags as described in CB-9145.  This test fails when run against master.
This is because the current exact match detection assumes that the query returning a result is sufficient to identify an exact attribute match.  However, the query may also return results with additional attributes and these should be excluded.  

Originally I added a utility function that handles this case by performing a 2-way comparison.  However, we already know that foundChild.attr matches srcChild.attr because foundChild is a query result.  We only need to determine if foundChild has extra attributes, so simply comparing the number of attributes is sufficient.  

After making this change, all tests are green - including the newly added test that fails against master.