### PR TITLE
Adds license headers to files in templates folder.

### DIFF
--- a/cordova-lib/src/plugman/create.js
+++ b/cordova-lib/src/plugman/create.js
@@ -22,7 +22,9 @@ var Q = require('q'),
     path = require('path'),
     shell = require('shelljs'),
     et = require('elementtree'),
-    CordovaError  = require('../CordovaError');
+    CordovaError  = require('../CordovaError'),
+    stripLicense = require('./util/strip-license');
+
 
 module.exports = function create( name, id, version, pluginPath, options ) {
     var cwd = pluginPath + '/' + name + '/',
@@ -62,7 +64,7 @@ module.exports = function create( name, id, version, pluginPath, options ) {
     shell.mkdir( '-p', cwd + 'src' );
 
     // Create a base plugin.js file
-    baseJS = fs.readFileSync( templatesDir + 'base.js', 'utf-8').replace( /%pluginName%/g, name );
+    baseJS = stripLicense.fromCode(fs.readFileSync(templatesDir + 'base.js', 'utf-8').replace(/%pluginName%/g, name));
     fs.writeFileSync( cwd + 'www/' + name + '.js', baseJS, 'utf-8' );
     // Add it to the xml as a js module
     jsMod = et.Element( 'js-module' );

--- a/cordova-lib/src/plugman/platform.js
+++ b/cordova-lib/src/plugman/platform.js
@@ -23,7 +23,8 @@ var Q = require('q'),
     et = require('elementtree'),
     fs = require('fs'),
     shell = require('shelljs'),
-    path = require('path');
+    path = require('path'),
+    stripLicense = require('./util/strip-license');
 
 /**
  * Used for adding templates for plugin platforms to plugin.xml
@@ -115,9 +116,9 @@ function doPlatformBase( templatesDir, platformName, pluginName, pluginID, plugi
     case 'android':
         baseFiles.push (
             {
-                file: fs.readFileSync( templatesDir + "base.java", "utf-8" )
-                    .replace( /%pluginName%/g, pluginName )
-                    .replace( /%pluginID%/g, pluginID ),
+                file: stripLicense.fromCode(fs.readFileSync(templatesDir + "base.java", "utf-8")
+                    .replace(/%pluginName%/g, pluginName)
+                    .replace(/%pluginID%/g, pluginID)),
                 extension: "java"
             }
         );
@@ -126,8 +127,8 @@ function doPlatformBase( templatesDir, platformName, pluginName, pluginID, plugi
     case 'ios':
         baseFiles.push(
             {
-                file: fs.readFileSync( templatesDir + "base.m", "utf-8" )
-                    .replace( /%pluginName%/g, pluginName ),
+                file: stripLicense.fromCode(fs.readFileSync(templatesDir + "base.m", "utf-8")
+                    .replace(/%pluginName%/g, pluginName)),
                 extension: "m"
             }
         );

--- a/cordova-lib/src/plugman/util/strip-license.js
+++ b/cordova-lib/src/plugman/util/strip-license.js
@@ -17,31 +17,9 @@
  under the License.
  */
 
-/********* %pluginName%.m Cordova Plugin Implementation *******/
-
-#import <Cordova/CDV.h>
-
-@interface %pluginName% : CDVPlugin {
-  // Member variables go here.
-}
-
-- (void)coolMethod:(CDVInvokedUrlCommand*)command;
-@end
-
-@implementation %pluginName%
-
-- (void)coolMethod:(CDVInvokedUrlCommand*)command
-{
-    CDVPluginResult* pluginResult = nil;
-    NSString* echo = [command.arguments objectAtIndex:0];
-
-    if (echo != nil && [echo length] > 0) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:echo];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+module.exports = {
+    fromCode: function (code) {
+        // For simplicity, relies on the fact that the Apache license header doesn't contain a "*"
+        return code.replace(/^\s*\/\*\*[^\*]*\*\/\s*/, "");
     }
-
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-}
-
-@end
+};

--- a/cordova-lib/templates/base.js
+++ b/cordova-lib/templates/base.js
@@ -1,3 +1,22 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
 var exec = require('cordova/exec');
 
 exports.coolMethod = function(arg0, success, error) {

--- a/cordova-lib/templates/platforms/android/android.xml
+++ b/cordova-lib/templates/platforms/android/android.xml
@@ -1,3 +1,22 @@
+<!--
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+-->
+
 <platform name="android">
     <config-file target="res/xml/config.xml" parent="/*">
         <feature name="%pluginName%">

--- a/cordova-lib/templates/platforms/android/base.java
+++ b/cordova-lib/templates/platforms/android/base.java
@@ -1,3 +1,22 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
 package %pluginID%;
 
 import org.apache.cordova.CordovaPlugin;

--- a/cordova-lib/templates/platforms/ios/ios.xml
+++ b/cordova-lib/templates/platforms/ios/ios.xml
@@ -1,3 +1,22 @@
+<!--
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+-->
+
 <platform name="ios">
     <config-file target="config.xml" parent="/*">
         <feature name="%pluginName%">


### PR DESCRIPTION
Also, updates code that uses the template files when building plugins to strip the license so its not included in users' projects (note we don't need to strip the license from the XML files as we immediately generate an element tree with `ElementTree`).