### PR TITLE
CB-9147 Adding a platform via caret version adds wrong version

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -139,7 +139,9 @@ function cordova_npm(platform) {
             return Q(git_dload_dir);
         }
 
-        var pkg = platform.packageName + '@' + platform.version;
+        // Note that because the version of npm we use internally doesn't support caret versions, in order to allow them
+        // from the command line and in config.xml, we use the actual version returned by getLatestMatchingNpmVersion().
+        var pkg = platform.packageName + '@' + version;
         return exports.npm_cache_add(pkg);
     });
 }

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -360,6 +360,14 @@ function getPluginVariables(variables){
 
 function getVersionFromConfigFile(plugin, cfg){
     var pluginEntry = cfg.getPlugin(plugin);
+    if (!pluginEntry) {
+        // If the provided plugin id is in the new format (e.g. cordova-plugin-camera), it might be stored in config.xml
+        // under the old format (e.g. org.apache.cordova.camera), so check for that.
+        var oldStylePluginId = pluginMapper[plugin];
+        if (oldStylePluginId) {
+            pluginEntry = cfg.getPlugin(oldStylePluginId);
+        }
+    }
     return pluginEntry && pluginEntry.spec;
 }
 


### PR DESCRIPTION
It adds the very latest version rather than the latest matching version.

Internally we are using a version of `npm` that doesn't understand caret versions, so it just gets the latest. I missed this previously because when I tried this, the latest version **was also** the latest matching version.

The same problem also applies to plugins.

I've made a slightly different fix in each case:

For platforms, we already had the latest matching version as a result of our call to `getLatestMatchingNpmVersion()`, so I just use that.

For plugins, in this specific scenario (a caret version) I turn it into a standard range using a version of `semver` that understands caret ranges (so `^1.2.3` becomes `>=1.2.3 <2.0.0`) and use that instead.

Note that this is currently an issue with platforms and plugin versions saved to `config.xml`.

Also, I noticed that we failed to find the version in `config.xml` if you added it using the new form (`cordova-plugin-camera`, for example), but it was stored in `config.xml` using the id, so fixed that.