### PR TITLE
CB-9177 Use tilde instead of caret when save to config.xml.

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -186,8 +186,8 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
 
                     if(opts.save || autosave){
                         // Similarly here, we save the source location if that was specified, otherwise the version that
-                        // was installed. However, we save it with the "^" attribute.
-                        spec = saveVersion ? '^' + platDetails.version : spec;
+                        // was installed. However, we save it with the "~" attribute (this allows for patch updates).
+                        spec = saveVersion ? '~' + platDetails.version : spec;
 
                         // Save target into config.xml, overriding already existing settings
                         events.emit('log', '--save flag or autosave detected');
@@ -216,10 +216,16 @@ function save(hooksRunner, projectRoot, opts) {
     // Save installed platforms into config.xml
     return platformMetadata.getPlatformVersions(projectRoot).then(function(platformVersions){
         platformVersions.forEach(function(platVer){
-            cfg.addEngine(platVer.platform, platVer.version);
+            cfg.addEngine(platVer.platform, getSpecString(platVer.version));
         });
         cfg.write();
     });
+}
+
+function getSpecString(spec) {
+    var validVersion = semver.valid(spec, true);
+    return validVersion ? '~' + validVersion : spec;
+
 }
 
 // Downloads via npm or via git clone (tries both)

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -147,7 +147,7 @@ module.exports = function plugin(command, targets, opts) {
                             attributes.name = pluginInfo.id;
 
                             var src = parseSource(target, opts);
-                            attributes.spec = src ? src : '^' + pluginInfo.version;
+                            attributes.spec = src ? src : '~' + pluginInfo.version;
 
                             var variables = [];
                             if (opts.cli_variables) {
@@ -481,7 +481,7 @@ function getSpec(pluginSource, projectRoot, pluginName) {
 function versionString(version) {
     var validVersion = semver.valid(version, true);
     if (validVersion) {
-        return '^' + validVersion;
+        return '~' + validVersion;
     }
 
     if (semver.validRange(version, true)) {


### PR DESCRIPTION
Also ensures `platform save` saves version with tilde.