### PR TITLE
Add support for --target=edge to launch app in Edge browser.

### DIFF
--- a/cordova-serve/src/browser.js
+++ b/cordova-serve/src/browser.js
@@ -30,12 +30,13 @@ var exec = require('./exec'),
  * @return {Q} Promise to launch the specified browser
  */
 module.exports = function (opts) {
-    //target, url, dataDir
     var target = opts.target || 'chrome';
     var url = opts.url || '';
 
     return getBrowser(target, opts.dataDir).then(function (browser) {
         var args;
+
+        var urlAdded = false;
         switch (process.platform) {
             case 'darwin':
                 args = ['open'];
@@ -51,7 +52,13 @@ module.exports = function (opts) {
                 // responsibility to "cmd /c", which has that logic built in. 
                 // 
                 // Furthermore, if "cmd /c" double-quoted the first parameter, then "start" will interpret it as a window title, 
-                // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191 
+                // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191
+
+                if (target === 'edge') {
+                    browser += ':' + url;
+                    urlAdded = true;
+                }
+
                 args = ['cmd /c start ""', browser];
                 break;
             case 'linux':
@@ -60,7 +67,10 @@ module.exports = function (opts) {
                 args = [browser];
                 break;
         }
-        args.push(url);
+
+        if (!urlAdded) {
+            args.push(url);
+        }
         var command = args.join(' ');
         console.log('Executing command: ' + command);
         return exec(command);
@@ -77,7 +87,8 @@ function getBrowser(target, dataDir) {
             'chrome': 'chrome --user-data-dir=%TEMP%\\' + dataDir,
             'safari': 'safari',
             'opera': 'opera',
-            'firefox': 'firefox'
+            'firefox': 'firefox',
+            'edge': 'microsoft-edge'
         },
         'darwin': {
             'chrome': '"Google Chrome" --args' + chromeArgs,


### PR DESCRIPTION
Note that this requires a fairly recent Windows 10 build (`10166` or later for Edge to support `localhost`, and probably around `10158` or later for the command line launch of Edge to work). 