### PR TITLE
restore-util.js can't handle git urls

### DIFF
--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -102,7 +102,7 @@ function installPluginsFromConfigXML(args) {
         // Install from given URL if defined or using a plugin id. If spec isn't a valid version or version range,
         // assume it is the location to install from.
         var pluginSpec = pluginEntry.spec;
-        var installFrom = semver.validRange(pluginSpec, true) ? pluginEntry.name + '@' + pluginSpec : pluginSpec;
+        var installFrom = semver.validRange(pluginSpec, true) ? pluginEntry.name + '@' + pluginSpec : pluginEntry.name;
 
         // Add feature preferences as CLI variables if have any
         var options = {cli_variables: pluginEntry.variables,


### PR DESCRIPTION
When adding a plugin to the config.xml using a git url e.g. <plugin name="https://..." /> a spec is not needed because the plugin needs to be checked out by git. The restore-util.js has a bug that uses the spec of a plugin when the spec is not valid. This does not make sense because a) a spec without a name is not a valid plugin and b) a git url doe snot has a spec. This commit changes the resture-util to use the pluginEntry.name instead of the spec if the spec is not valid.