### PR TITLE
CB-9291 Fixes Appveyor build failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ install:
   - cd ..
   - git clone https://github.com/apache/cordova-js --depth 10
   - cd cordova-js
-  - npm install
+  - npm install --msvs_version=2013
   - npm link
   - cd ..\cordova-lib\cordova-lib
   - npm link cordova-js


### PR DESCRIPTION
This fixes Appveyor build failure, introduced by https://github.com/apache/cordova-js/commit/eb620e2934e2d6706e71a2f8957343935d6dcf32