### PR TITLE
CB-9408: Added support for `windows-packageVersion` on `<widget>`.

### DIFF
--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -122,6 +122,9 @@ ConfigParser.prototype = {
     version: function() {
         return this.doc.getroot().attrib['version'];
     },
+    windows_packageVersion: function() {
+        return this.doc.getroot().attrib('windows-packageVersion');
+    },
     android_versionCode: function() {
         return this.doc.getroot().attrib['android-versionCode'];
     },


### PR DESCRIPTION
Corresponds to a similar change on cordova-windows.