### PR TITLE
CB-9407 FFOS permissions missing in manifest

### DIFF
--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -127,7 +127,7 @@ function prepare(options) {
     
                 platform_cfg.write();
     
-                return parser.update_project(cfg);
+                return parser.update_project(platform_cfg);
             });
         })).then(function() {
             return hooksRunner.fire('after_prepare', options);


### PR DESCRIPTION
CB-9407
running an update on platform_cfg allows permissions from plugins to feed the manifest.