### PR TITLE
CB-9545 Cordova-serve's 'noCache' option does not work in IE.

### DIFF
--- a/cordova-serve/src/stream.js
+++ b/cordova-serve/src/stream.js
@@ -63,7 +63,7 @@ module.exports = function (filePath, request, response, readStream, noCache) {
 
     respHeaders['Last-Modified'] = new Date(fs.statSync(filePath).mtime).format('r');
     if (noCache) {
-        respHeaders['Cache-Control'] = 'no-cache';
+        respHeaders['Cache-Control'] = 'no-store';
     }
     console.log('200 ' + request.url + ' (' + filePath + ')');
     response.writeHead(200, respHeaders);


### PR DESCRIPTION
Switched to using `Cache-Control` value of `no-store` instead of `no-cache`.