### PR TITLE
CB-9546 cordova-serve.servePlatform() should provide project folders

### DIFF
--- a/cordova-serve/src/platform.js
+++ b/cordova-serve/src/platform.js
@@ -37,12 +37,17 @@ module.exports = function (platform, opts) {
         }
 
         opts = opts || {};
-        opts.root = util.getPlatformWwwRoot(findProjectRoot(opts.root), platform);
+        var projectRoot = findProjectRoot(opts.root);
+        var platformRoot = opts.root = util.getPlatformWwwRoot(projectRoot, platform);
         if (!fs.existsSync(opts.root)) {
             throw new Error('Project does not include the specified platform: ' + platform);
         }
 
-        return server(opts);
+        return server(opts).then(function (serverInfo) {
+            serverInfo.projectRoot = projectRoot;
+            serverInfo.platformRoot = platformRoot;
+            return serverInfo;
+        });
     });
 };
 


### PR DESCRIPTION
The `servePlatform()` method provided by `cordova-serve` figures out the project and platform root directories (either from the cwd or a provided path). Since this information is potentially useful to the caller, it is now provided in the return value.