### PR TITLE
CB-6698 Fix directory resolution of framework with parent

### DIFF
--- a/cordova-lib/spec-plugman/platforms/android.spec.js
+++ b/cordova-lib/spec-plugman/platforms/android.spec.js
@@ -213,6 +213,77 @@ describe('android project handler', function() {
             finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).not.toMatch('\ncordova.system.library.1=' + 'extras/android/support/v4', 'Sublibrary not added');
         });
+        it('with custom=true and parent', function () {
+            var packageIdSuffix = 'childapp';
+            var frameworkElement = { src: 'plugin-lib', custom: true };
+            var frameworkElementChild = { src: 'plugin-lib2', custom: true, parent: 'plugin-lib' };
+            var parentDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElementChild.parent);
+            var parentProjectPropsFile = path.resolve(parentDir, 'project.properties');
+            var subDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElement.src);
+            var subProjectPropsFile = path.resolve(subDir, 'project.properties');
+
+            var exec = spyOn(shell, 'exec');
+
+            android['framework'].install(frameworkElement, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            android['framework'].install(frameworkElementChild, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            var finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).toMatch('\nandroid.library.reference.1=../' + packageIdSuffix + '-plugin-lib2', 'Reference to library not added');
+            var subProjectProperties = fs.readFileSync(subProjectPropsFile, 'utf8');
+            expect(subProjectProperties).toMatch(/\btarget=android-19$/m, 'target SDK version not copied to library');
+            expect(exec).toHaveBeenCalledWith('android update lib-project --path "' + subDir + '"');
+
+            // Now test uninstall
+            android.purgeProjectFileCache(temp);
+            android['framework'].uninstall(frameworkElementChild, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).not.toMatch('\nandroid.library.reference.1=../' + packageIdSuffix + '-plugin-lib2', 'Reference to library not removed');
+
+            android['framework'].uninstall(frameworkElement, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            expect(fs.existsSync(subDir)).toBe(false, 'Should delete subdir');
+        });
+        it('with custom=false and parent', function () {
+            var packageIdSuffix = 'childapp';
+            var frameworkElement = { src: 'plugin-lib', custom: true };
+            var frameworkElementChild = { src: 'extras/android/support/v4', custom: false, parent: 'plugin-lib' };
+            var parentDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElementChild.parent);
+            var parentProjectPropsFile = path.resolve(parentDir, 'project.properties');
+            var sdkLibRelativeDir = path.join('..', 'SDK', 'extras', 'android', 'support', 'v4');
+            var exec = spyOn(shell, 'exec');
+
+            android['framework'].install(frameworkElement, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            fs.writeFileSync(path.join(temp, 'local.properties'), 'sdk.dir=' + path.join(temp, '..', 'SDK').replace(/\\/g, '/'));
+            android['framework'].install(frameworkElementChild, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+
+            android.parseProjectFile(temp).write();
+            android.parseProjectFile(parentDir).write();
+
+            exec.reset();
+
+            var finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            var libReference = '\nandroid.library.reference.1=' + path.join('..', '..', sdkLibRelativeDir).replace(/\\/g, '/');
+            expect(finalProjectProperties).toMatch(libReference, 'Reference to library not added');
+            // exec doesn't get called since sublibrary dir doesn't actually exist.
+            expect(exec).not.toHaveBeenCalled();
+
+            // Now test uninstall
+            android.purgeProjectFileCache(temp);
+            android.purgeProjectFileCache(parentDir);
+            android['framework'].uninstall(frameworkElementChild, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+            android.parseProjectFile(parentDir).write();
+
+            finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).not.toMatch(libReference, 'Reference to library not removed');
+
+            android['framework'].uninstall(frameworkElement, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+        });
     });
     describe('uninstallation', function() {
         beforeEach(function() {

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/AndroidManifest.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  android:versionCode="1" package="com.test.somelib">
+    <uses-sdk android:minSdkVersion="9"/>
+    <application/>
+</manifest>

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/libFile
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/libFile
@@ -1,0 +1,1 @@
+libFile contents

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/project.properties
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/project.properties
@@ -1,0 +1,1 @@
+target=android-11

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
@@ -51,6 +51,7 @@
         </config-file>
 
         <framework src="plugin-lib" custom="true" />
+        <framework src="plugin-lib2" custom="true" parent="plugin-lib" />
         <framework src="extras/android/support/v7/appcompat" />
         <framework src="extra.gradle" type="gradleReference" />
         <resource-file src="android-resource.xml" target="res/xml/dummy.xml" />

--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -122,7 +122,10 @@ module.exports = {
 
             events.emit('verbose', 'Installing Android library: ' + src);
             var parent = obj.parent;
-            var parentDir = parent ? path.resolve(project_dir, parent) : project_dir;
+            var parentDir = parent ?
+                    path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) :
+                    project_dir;
+
             var subDir;
             var type = obj.type;
 
@@ -157,7 +160,9 @@ module.exports = {
 
             events.emit('verbose', 'Uninstalling Android library: ' + src);
             var parent = obj.parent;
-            var parentDir = parent ? path.resolve(project_dir, parent) : project_dir;
+            var parentDir = parent ?
+                    path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) :
+                    project_dir;
             var subDir;
             var type = obj.type;
 

--- a/cordova-lib/src/plugman/util/android-project.js
+++ b/cordova-lib/src/plugman/util/android-project.js
@@ -118,7 +118,11 @@ AndroidProject.prototype = {
         for (var filename in this._propertiesEditors) {
             var editor = this._propertiesEditors[filename];
             if (editor.dirty) {
-                fs.writeFileSync(filename, editor.toString());
+                // Check for parent directory existence before attempting write 
+                // (when uninstalling a plugin its subprojects' directories are deleted)
+                if (fs.existsSync(path.dirname(filename))) {
+                    fs.writeFileSync(filename, editor.toString());
+                }
                 editor.dirty = false;
             }
         }


### PR DESCRIPTION
Due to a refactoring after the original implementation the installation of plugins containing frameworks with parent=true were broken. 
This pull request fixes the paths and adds two unit tests for such frameworks

Refs https://issues.apache.org/jira/browse/CB-6698