### PR TITLE
CB-9559 Adding a plugin with caret in version results in an error

### DIFF
--- a/cordova-lib/src/plugman/registry/registry.js
+++ b/cordova-lib/src/plugman/registry/registry.js
@@ -19,8 +19,7 @@
 
 /* jshint laxcomma:true */
 
-var semver = require('semver'),
-    npm = require('npm'),
+var npm = require('npm'),
     path = require('path'),
     url = require('url'),
     fs = require('fs'),
@@ -267,7 +266,7 @@ function fetchPlugin(plugin, client, useNpmRegistry) {
 
     return initThenLoadSettingsWithRestore(useNpmRegistry, function () {
         events.emit('log', 'Fetching plugin "' + plugin + '" via ' + registryName);
-        return Q.ninvoke(npm.commands, 'cache', ['add', processPluginVersion(plugin)])
+        return Q.ninvoke(npm.commands, 'cache', ['add', plugin])
         .then(function (info) {
             var cl = (client === 'plugman' ? 'plugman' : 'cordova-cli');
             bumpCounter(info, cl);
@@ -277,26 +276,6 @@ function fetchPlugin(plugin, client, useNpmRegistry) {
             return unpack.unpackTgz(package_tgz, pluginDir);
         });
     });
-}
-
-function processPluginVersion(plugin) {
-    // If plugin includes a version that is a caret range, the ancient version of npm we're using won't know how to
-    // handle it. So we'll use our current version of semver to turn it into a usable range.
-
-    var parts = plugin.split('@');
-    var version = parts[1];
-
-    if (!version || version.charAt(0) !== '^') {
-        return plugin;
-    }
-
-    var validRange = semver.validRange(version, /* loose */ true);
-    if (!validRange) {
-        return plugin;
-    }
-
-    // Because validRange may include spaces, we need to wrap it in quotes.
-    return parts[0] + '@"' + validRange + '"';
 }
 
 /**


### PR DESCRIPTION
When Cordova used `npm 1.3.x` internally, we had to process "caret versions" since `npm 1.3.x` didn't understand them. As part of that, we'd turn the caret version into a fully defined version range, which contained a space, and `npm 1.3.x` required that we wrap such a range in quotes.

This logic broke when we upgraded to `npm 2.10.x` - it no longer requires the quotes in this scenario, and in fact fails if we include them. However, we also no longer need to do this processing (since `npm 2.10.x` understands caret versions), so we can just remove that code altogether.