### PR TITLE
CB-8993 Plugin restore ignores search path

### DIFF
--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -56,7 +56,7 @@ function prepare(options) {
     var hooksRunner = new HooksRunner(projectRoot);
     return hooksRunner.fire('before_prepare', options)
     .then(function(){
-        return restore.installPlatformsFromConfigXML(options.platforms);
+        return restore.installPlatformsFromConfigXML(options.platforms, { searchpath : options.searchpath });
     })
     .then(function(){
         options = cordova_util.preProcessOptions(options);

--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -32,7 +32,7 @@ exports.installPluginsFromConfigXML = installPluginsFromConfigXML;
 exports.installPlatformsFromConfigXML = installPlatformsFromConfigXML;
 
 
-function installPlatformsFromConfigXML(platforms) {
+function installPlatformsFromConfigXML(platforms, opts) {
     var projectHome = cordova_util.cdProjectRoot();
     var configPath = cordova_util.projectConfig(projectHome);
     var cfg = new ConfigParser(configPath);
@@ -68,7 +68,7 @@ function installPlatformsFromConfigXML(platforms) {
     return promiseutil.Q_chainmap_graceful(targets, function(target) {
         if (target) {
             events.emit('log', 'Restoring platform ' + target + ' referenced on config.xml');
-            return cordova.raw.platform('add', target);
+            return cordova.raw.platform('add', target, opts);
         }
         return Q();
     }, function(err) {


### PR DESCRIPTION
When restoring a platform the search path needs to be provided otherwise
plugins will always be resolved to npm.