### PR TITLE
CB-9587 Check if browser platform added properly before creating parser

### DIFF
--- a/cordova-lib/src/cordova/metadata/browser_parser.js
+++ b/cordova-lib/src/cordova/metadata/browser_parser.js
@@ -23,10 +23,18 @@ var fs = require('fs'),
     path = require('path'),
     shell = require('shelljs'),
     util = require('../util'),
+    CordovaError = require('../../CordovaError'),
     Q = require('q'),
     Parser = require('./parser');
 
+function dirExists(dir) {
+    return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
+}
+
 function browser_parser(project) {
+    if (!dirExists(project) || !dirExists(path.join(project, 'cordova'))) {
+        throw new CordovaError('The provided path "' + project + '" is not a valid browser project.');
+    }
 
     // Call the base class constructor
     Parser.call(this, 'browser', project);


### PR DESCRIPTION
This fixes weird error when trying to run app on browser platform but the platform isn't added to project. See [CB-9587](https://issues.apache.org/jira/browse/CB-9587) for details and repro steps.