### PR TITLE
CB-9590 - Ubuntu support for the new plugin naming convention

### DIFF
--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -29,14 +29,47 @@ function toCamelCase(str) {
     }).join('');
 }
 
-function findClassName(str) {
+function getPluginXml(plugin_dir) {
+    var et = require('elementtree'),
+    fs = require('fs'),
+    shell = require('shelljs'),
+    path = require('path');
+
+    var pluginxml = undefined;
+    var config_path = path.join(plugin_dir, 'plugin.xml');
+
+    if (fs.existsSync(config_path)) {
+        // Get the current plugin.xml file
+        pluginxml = et.parse(fs.readFileSync(config_path, 'utf-8'));
+    }
+ 
+    return pluginxml;
+}
+
+function findClassName(pluginxml, plugin_id) {
     var class_name;
 
-    if (str.match(/\.[^.]+$/)) {
+    // first check if we have a class-name parameter in the plugin config
+    if (pluginxml) {
+	var platform = pluginxml.find("./platform/[@name='ubuntu']/");
+	if (platform) {
+	    var param = platform.find("./config-file/[@target='config.xml']/feature/param/[@name='ubuntu-package']");
+	    if (param && param.attrib) {
+		class_name = param.attrib.value;
+		return class_name;
+	    }
+	}
+    }
+
+    // fallback to guess work, based on the plugin package name
+
+    if (plugin_id.match(/\.[^.]+$/)) {
         // old-style plugin name
-        class_name = str.match(/\.[^.]+$/)[0].substr(1);
+        class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+        class_name = toCamelCase(class_name);
     } else {
-        class_name = str.match(/cordova\-plugin\-([\w\-]+)$/)[0].substr(15);
+        class_name = plugin_id.match(/cordova\-plugin\-([\w\-]+)$/)[0].substr(15);
+        class_name = toCamelCase(class_name);
     }
 
     return class_name;
@@ -84,8 +117,9 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('INSERT_HEADER_HERE', '#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"\nINSERT_HEADER_HERE');
-            var class_name = findClassName(plugin_id);
-            class_name = toCamelCase(class_name);
+
+            var pluginxml  = getPluginXml(plugin_dir);
+            var class_name = findClassName(pluginxml, plugin_id);
             src = src.replace('INSERT_PLUGIN_HERE', 'INIT_PLUGIN(' + class_name + ');INSERT_PLUGIN_HERE');
 
             fs.writeFileSync(plugins, src);
@@ -98,8 +132,7 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"', '');
-            var class_name = findClassName(plugin_id);
-            class_name = toCamelCase(class_name);
+            var class_name = findClassName(undefined, plugin_id);
             src = src.replace('INIT_PLUGIN(' + class_name + ');', '');
 
             fs.writeFileSync(plugins, src);

--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -71,7 +71,13 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('INSERT_HEADER_HERE', '#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"\nINSERT_HEADER_HERE');
-            var class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            var class_name;
+            if (plugin_id.match(/\.[^.]+$/)) {
+            // old-style plugin name
+                class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            } else {
+               class_name = plugin_id.match(/\-[^\-]+$/)[0].substr(1);
+            }
             class_name = toCamelCase(class_name);
             src = src.replace('INSERT_PLUGIN_HERE', 'INIT_PLUGIN(' + class_name + ');INSERT_PLUGIN_HERE');
 
@@ -85,7 +91,13 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"', '');
-            var class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            var class_name;
+            if (plugin_id.match(/\.[^.]+$/)) {
+                // old-style plugin name
+                class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            } else {
+                class_name = plugin_id.match(/\-[^\-]+$/)[0].substr(1);
+            }
             class_name = toCamelCase(class_name);
             src = src.replace('INIT_PLUGIN(' + class_name + ');', '');
 

--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -32,10 +32,9 @@ function toCamelCase(str) {
 function getPluginXml(plugin_dir) {
     var et = require('elementtree'),
     fs = require('fs'),
-    shell = require('shelljs'),
     path = require('path');
 
-    var pluginxml = undefined;
+    var pluginxml;
     var config_path = path.join(plugin_dir, 'plugin.xml');
 
     if (fs.existsSync(config_path)) {

--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -29,6 +29,19 @@ function toCamelCase(str) {
     }).join('');
 }
 
+function findClassName(str) {
+    var class_name;
+
+    if (str.match(/\.[^.]+$/)) {
+        // old-style plugin name
+        class_name = str.match(/\.[^.]+$/)[0].substr(1);
+    } else {
+        class_name = str.match(/cordova\-plugin\-([\w\-]+)$/)[0].substr(15);
+    }
+
+    return class_name;
+}
+
 var shell = require('shelljs')
    , fs = require('fs')
    , path = require('path')
@@ -71,13 +84,7 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('INSERT_HEADER_HERE', '#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"\nINSERT_HEADER_HERE');
-            var class_name;
-            if (plugin_id.match(/\.[^.]+$/)) {
-            // old-style plugin name
-                class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
-            } else {
-               class_name = plugin_id.match(/\-[^\-]+$/)[0].substr(1);
-            }
+            var class_name = findClassName(plugin_id);
             class_name = toCamelCase(class_name);
             src = src.replace('INSERT_PLUGIN_HERE', 'INIT_PLUGIN(' + class_name + ');INSERT_PLUGIN_HERE');
 
@@ -91,13 +98,7 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"', '');
-            var class_name;
-            if (plugin_id.match(/\.[^.]+$/)) {
-                // old-style plugin name
-                class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
-            } else {
-                class_name = plugin_id.match(/\-[^\-]+$/)[0].substr(1);
-            }
+            var class_name = findClassName(plugin_id);
             class_name = toCamelCase(class_name);
             src = src.replace('INIT_PLUGIN(' + class_name + ');', '');
 


### PR DESCRIPTION
This patch allows ubuntu users to add plugins using the new naming convention and build properly. This also leaves support in place for the old style plugin names, during the transition.