### PR TITLE
CB-9631 Save plugin to config.xml only if installation succeeds

### DIFF
--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -170,20 +170,18 @@ describe('config.xml parser', function () {
             });
             it('should allow adding features with params', function(){
                 cfg.addPlugin({name:'aplugin'}, [{name:'paraname',value:'paravalue'}]);
-                var plugins = cfg.doc.findall('plugin');
-                var plugin  = (function(){
-                    var i = plugins.length;
-                    var f;
-                    while (--i >= 0) {
-                        f = plugins[i];
-                        if ('aplugin' === f.attrib.name) return f;
-                    }
-                    return undefined;
-                })();
-                expect(plugin).toBeDefined();
-                var variables = plugin.findall('variable');
-                expect(variables[0].attrib.name).toEqual('paraname');
-                expect(variables[0].attrib.value).toEqual('paravalue');
+                // Additional check for new parameters syntax
+                cfg.addPlugin({name:'bplugin'}, {paraname: 'paravalue'});
+                var plugins = cfg.doc.findall('plugin')
+                .filter(function (plugin) {
+                    return plugin.attrib.name === 'aplugin' || plugin.attrib.name === 'bplugin';
+                });
+                expect(plugins.length).toBe(2);
+                plugins.forEach(function (plugin) {
+                    var variables = plugin.findall('variable');
+                    expect(variables[0].attrib.name).toEqual('paraname');
+                    expect(variables[0].attrib.value).toEqual('paravalue');
+                });
             });
             it('should be able to read legacy feature entries with a version', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.legacyfeatureversion');

--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -301,7 +301,7 @@ ConfigParser.prototype = {
      * @name addPlugin
      * @function
      * @param {object} attributes name and spec are supported
-     * @param {Array} variables name, value
+     * @param {Array|object} variables name, value or arbitary object
      */
     addPlugin: function (attributes, variables) {
         if (!attributes && !attributes.name) return;
@@ -310,12 +310,18 @@ ConfigParser.prototype = {
         if (attributes.spec) {
             el.attrib.spec = attributes.spec;
         }
+
+        // support arbitrary object as variables source
+        if (variables && typeof variables === 'object' && !Array.isArray(variables)) {
+            variables = Object.keys(variables)
+            .map(function (variableName) {
+                return {name: variableName, value: variables[variableName]};
+            });
+        }
+
         if (variables) {
             variables.forEach(function (variable) {
-                var v = new et.Element('variable');
-                v.attrib.name = variable.name;
-                v.attrib.value = variable.value;
-                el.append(v);
+                el.append(new et.Element('variable', { name: variable.name, value: variable.value }));
             });
         }
         this.doc.getroot().append(el);


### PR DESCRIPTION
This fixes [CB-9631](https://issues.apache.org/jira/browse/CB-9631)

The idea is that we need to save installed plugins to config.xml only if installation succeeds (similar to platform save)