### PR TITLE
CB-9617 Do not restore plugins immediately after plugin removal

### DIFF
--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -31,8 +31,7 @@ var cordova_util  = require('./util'),
     pluginMapper  = require('cordova-registry-mapper').newToOld,
     events        = require('../events'),
     metadata      = require('../plugman/util/metadata'),
-    chainMap      = require('../util/promise-util').Q_chainmap,
-    cordova       = require('./cordova');
+    chainMap      = require('../util/promise-util').Q_chainmap;
 
 // Returns a promise.
 module.exports = function plugin(command, targets, opts) {
@@ -205,7 +204,9 @@ module.exports = function plugin(command, targets, opts) {
                     });
                 }, Q()); // end Q.all
             }).then(function() {
-                return cordova.raw.prepare(opts);
+                // Need to require right here instead of doing this at the beginning of file
+                // otherwise tests are failing without any real reason.
+                return require('./prepare').preparePlatforms(platformList, projectRoot, opts);
             }).then(function() {
                 opts.cordova = { plugins: cordova_util.findPlugins(pluginPath) };
                 return hooksRunner.fire('after_plugin_add', opts);
@@ -233,7 +234,7 @@ module.exports = function plugin(command, targets, opts) {
                     return platformList.reduce(function(soFar, platform) {
                         return soFar.then(function() {
                             var platformRoot = path.join(projectRoot, 'platforms', platform);
-                             events.emit('verbose', 'Calling plugman.uninstall on plugin "' + target + '" for platform "' + platform + '"');
+                            events.emit('verbose', 'Calling plugman.uninstall on plugin "' + target + '" for platform "' + platform + '"');
                             return plugman.raw.uninstall.uninstallPlatform(platform, platformRoot, target, pluginPath);
                         });
                     }, Q())
@@ -259,7 +260,7 @@ module.exports = function plugin(command, targets, opts) {
                     });
                 }, Q());
             }).then(function () {
-                return cordova.raw.prepare(opts);
+                return require('./prepare').preparePlatforms(platformList, projectRoot, opts);
             }).then(function() {
                 opts.cordova = { plugins: cordova_util.findPlugins(pluginPath) };
                 return hooksRunner.fire('after_plugin_rm', opts);


### PR DESCRIPTION
https://github.com/apache/cordova-lib/commit/14675051c400a6811a6c6171fbf92f3475244630 introduced `cordova.prepare` call after each plugin uninstallation (see [CB-9617](https://issues.apache.org/jira/browse/CB-9617)). This results in a weird behaviour, when removed plugin immediately restored if it was saved in config.xml.