### PR TITLE
CB-8198 Unified console output logic for core platforms

### DIFF
--- a/cordova-lib/cordova-lib.js
+++ b/cordova-lib/cordova-lib.js
@@ -32,7 +32,8 @@ exports = module.exports = {
     cordova_platforms: require('./src/platforms/platforms'),
     ////  MAIN CORDOVA TOOLS API
     PluginInfo: require('./src/PluginInfo'),
-    CordovaError: require('./src/CordovaError')
+    CordovaError: require('./src/CordovaError'),
+    CordovaExternalToolErrorContext: require('./src/CordovaExternalToolErrorContext')
 }
 
 

--- a/cordova-lib/spec-plugman/create.spec.js
+++ b/cordova-lib/spec-plugman/create.spec.js
@@ -74,7 +74,7 @@ describe( 'create plugin in existing plugin', function() {
         });
         waitsFor(function() { return done; }, 'create promise never resolved', 500);
         runs(function() {
-            expect(''+ done ).toContain( 'Error: plugin.xml already exists. Are you already in a plugin?'  );
+            expect(''+ done ).toContain( 'plugin.xml already exists. Are you already in a plugin?'  );
         });
     });
 });

--- a/cordova-lib/src/CordovaError.js
+++ b/cordova-lib/src/CordovaError.js
@@ -19,14 +19,66 @@
 
 /* jshint proto:true */
 
-// A derived exception class. See usage example in cli.js
-// Based on:
-// stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript/8460753#8460753
-function CordovaError(message) {
+var EOL = require('os').EOL;
+
+/**
+ * A derived exception class. See usage example in cli.js
+ * Based on:
+ * stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript/8460753#8460753
+ * @param {String} message Error message
+ * @param {Number} [code] Error code
+ * @param {CordovaExternalToolErrorContext} [context] External tool error context object
+ * @constructor
+ */
+function CordovaError(message, code, context) {
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
     this.message = message;
+    this.code = code || CordovaError.UNKNOWN_ERROR;
+    this.context = context;
 }
 CordovaError.prototype.__proto__ = Error.prototype;
+
+// TODO: Extend error codes according the projects specifics
+CordovaError.UNKNOWN_ERROR = 0;
+CordovaError.EXTERNAL_TOOL_ERROR = 1;
+
+/**
+ * @returns {string} Error code string name
+ */
+CordovaError.prototype.getErrorCodeName = function() {
+    for(var key in CordovaError) {
+        if(CordovaError.hasOwnProperty(key)) {
+            if(CordovaError[key] === this.code) {
+                return key;
+            }
+        }
+    }
+};
+
+CordovaError.prototype.toString = function(isVerbose) {
+    var message = '', codePrefix = '';
+
+    if(this.code !== CordovaError.UNKNOWN_ERROR) {
+        codePrefix = 'code: ' + this.code + (isVerbose ? (' (' + this.getErrorCodeName() + ')') : '') + ' ';
+    }
+
+    if(this.code === CordovaError.EXTERNAL_TOOL_ERROR) {
+        if(typeof this.context !== 'undefined') {
+            if(isVerbose) {
+                message = codePrefix + EOL + this.context.toString(isVerbose) + '\n failed with an error: ' +
+                    this.message + EOL + 'Stack trace: ' + this.stack;
+            } else {
+                message = codePrefix + '\'' + this.context.toString(isVerbose) + '\' ' + this.message;
+            }
+        } else {
+            message = 'External tool failed with an error: ' + this.message;
+        }
+    } else {
+        message = isVerbose ? codePrefix + this.stack : codePrefix + this.message;
+    }
+
+    return message;
+};
 
 module.exports = CordovaError;

--- a/cordova-lib/src/CordovaExternalToolErrorContext.js
+++ b/cordova-lib/src/CordovaExternalToolErrorContext.js
@@ -1,0 +1,48 @@
+/**
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+/* jshint proto:true */
+
+var path = require('path');
+
+/**
+ * @param {String} cmd Command full path
+ * @param {String[]} args Command args
+ * @param {String} [cwd] Command working directory
+ * @constructor
+ */
+function CordovaExternalToolErrorContext(cmd, args, cwd) {
+    this.cmd = cmd;
+    // Helper field for readability
+    this.cmdShortName = path.basename(cmd);
+    this.args = args;
+    this.cwd = cwd;
+}
+
+CordovaExternalToolErrorContext.prototype.toString = function(isVerbose) {
+    if(isVerbose) {
+        return 'External tool \'' + this.cmdShortName + '\'' +
+            '\nCommand full path: ' + this.cmd + '\nCommand args: ' + this.args +
+            (typeof this.cwd !== 'undefined' ? '\nCommand cwd: ' + this.cwd : '');
+    }
+
+    return this.cmdShortName;
+};
+
+module.exports = CordovaExternalToolErrorContext;

--- a/cordova-lib/src/platforms/PlatformApiPoly.js
+++ b/cordova-lib/src/platforms/PlatformApiPoly.js
@@ -47,12 +47,13 @@ var PluginInfoProvider = require('../PluginInfoProvider');
  *
  * * platform: String that defines a platform name.
  */
-function PlatformApiPoly(platform, platformRootDir) {
+function PlatformApiPoly(platform, platformRootDir, events) {
     if (!platform) throw new CordovaError('\'platform\' argument is missing');
     if (!platformRootDir) throw new CordovaError('platformRootDir argument is missing');
 
     this.root = platformRootDir;
     this.platform = platform;
+    this.events = events || require('../events');
 
     if (!(platform in knownPlatforms))
         throw new CordovaError('Unknown platform ' + platform);
@@ -188,7 +189,7 @@ PlatformApiPoly.prototype.prepare = function (cordovaProject) {
     // Otherwise save whatever is there as defaults so it can be
     // restored or copy project config into platform if none exists.
     if (fs.existsSync(defaultConfig)) {
-        // events.emit('verbose', 'Generating config.xml from defaults for platform "' + this.platform + '"');
+        this.events.emit('verbose', 'Generating config.xml from defaults for platform "' + this.platform + '"');
         shell.cp('-f', defaultConfig, ownConfig);
     } else if (fs.existsSync(ownConfig)) {
         shell.cp('-f', ownConfig, defaultConfig);

--- a/cordova-lib/src/platforms/platforms.js
+++ b/cordova-lib/src/platforms/platforms.js
@@ -20,6 +20,7 @@
 var path = require('path');
 var util = require('../cordova/util');
 var platforms = require('./platformsConfig.json');
+var events = require('../events');
 
 // Avoid loading the same platform projects more than once (identified by path)
 var cachedApis = {};
@@ -55,7 +56,7 @@ function getPlatformApi(platform, platformRootDir) {
         PlatformApi = require('./PlatformApiPoly');
     }
 
-    var platformApi = new PlatformApi(platform, platformRootDir);
+    var platformApi = new PlatformApi(platform, platformRootDir, events);
     cachedApis[platformRootDir] = platformApi;
     return platformApi;
 }


### PR DESCRIPTION
[Proposal: Unified logging on cordova-discuss](https://github.com/cordova/cordova-discuss/issues/14)
Passed eventEmitter to PlatformApi poly for logging
Extended CordovaError with code and context, added ErrorCodes, overrode toString method
Introduced CordovaExternalToolErrorContext class

[Corresponding CLI updates PR](https://github.com/apache/cordova-cli/pull/222)
[Jira issue](https://issues.apache.org/jira/browse/CB-8198)