### PR TITLE
CB-9521 Do not pass removed platform to `after_platform_rm` hook

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -363,6 +363,7 @@ function remove(hooksRunner, projectRoot, targets, opts) {
             platformMetadata.remove(projectRoot, target);
         });
     }).then(function() {
+        opts.cordova.platforms = cordova_util.listPlatforms(opts.projectRoot);
         return hooksRunner.fire('after_platform_rm', opts);
     });
 }


### PR DESCRIPTION
This fixes annoying issue, already described in [CB-9521](https://issues.apache.org/jira/browse/CB-9521).