### PR TITLE
CB-9569 - Support <access> and <allow-navigation> tag translation to Application Transport Security (ATS) Info.plist directives

### DIFF
--- a/cordova-lib/spec-cordova/ConfigParser.spec.js
+++ b/cordova-lib/spec-cordova/ConfigParser.spec.js
@@ -219,6 +219,14 @@ describe('config.xml parser', function () {
                 });
                 expect(pluginNames).not.toContain('org.apache.cordova.legacyplugin');
             });
+            it('it should read <access> tag entries', function(){
+                var accesses = cfg.getAccesses();
+                expect(accesses.length).not.toEqual(0);
+            });
+            it('it should read <allow-navigation> tag entries', function(){
+                var navigations = cfg.getAllowNavigations();
+                expect(navigations.length).not.toEqual(0);
+            });
         });
     });
 });

--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -187,6 +187,315 @@ describe('ios project parser', function () {
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'some-custom-orientation' ]);
                 });
             });
+            ///// App Transport Security Tests /////////////////////////////
+            it('<access> - should handle wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    expect(ats.NSAllowsArbitraryLoads).toEqual(true);
+                });
+            });
+            it('<access> - https, subdomain wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server01.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+                    
+                    d = exceptionDomains['server02.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server03.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+                    
+                    d = exceptionDomains['server04.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<access> - http, no wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server05.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server06.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server07.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server08.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<access> - https, no wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server09.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server10.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server11.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server12.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<allow-navigation> - should handle wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    expect(ats.NSAllowsArbitraryLoads).toEqual(true);
+                });
+            });
+            it('<allow-navigation> - https, subdomain wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server21.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+                    
+                    d = exceptionDomains['server22.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server23.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+                    
+                    d = exceptionDomains['server24.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<allow-navigation> - http, no wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server25.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server26.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server27.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server28.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<allow-navigation> - https, no wildcard', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server29.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server30.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server31.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server32.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(null);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<allow-navigation> - wildcard scheme, wildcard subdomain', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server33.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server34.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server35.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server36.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(true);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
+            it('<allow-navigation> - wildcard scheme, no subdomain', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    var d;
+                    
+                    expect(exceptionDomains).toBeTruthy();
+                    
+                    d = exceptionDomains['server37.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server38.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual(null);
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+
+                    d = exceptionDomains['server39.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(null);
+
+                    d = exceptionDomains['server40.com'];
+                    expect(d).toBeTruthy();
+                    expect(d.NSIncludesSubdomains).toEqual(null);
+                    expect(d.NSExceptionAllowsInsecureHTTPLoads).toEqual(true);
+                    expect(d.NSExceptionMinimumTLSVersion).toEqual('TLSv1.1');
+                    expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
+                });
+            });
         });
         describe('www_dir method', function() {
             it('should return /www', function() {

--- a/cordova-lib/spec-cordova/test-config.xml
+++ b/cordova-lib/spec-cordova/test-config.xml
@@ -8,7 +8,71 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
+    
+    <!-- 
+        <access> tests
+        
+        Test wildcard allow all. Note in ATS you can open up all, and have restrictions for certain domains.
+        This is to allow for example, an in-app-browser (*) but your own server communications must be https, for example.
+     -->
     <access origin="*" />
+    <!-- https, with subdomain wildcard, with attribute differences -->
+    <access origin="https://*.server01.com" /> <!-- equivalent to the next line -->
+    <access origin="https://*.server01.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <access origin="https://*.server02.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <access origin="https://*.server03.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <access origin="https://*.server04.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- http, no subdomain wildcard, with attribute differences -->
+    <access origin="http://server05.com" /> <!-- equivalent to the next line -->
+    <access origin="http://server05.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <access origin="http://server06.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <access origin="http://server07.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <access origin="http://server08.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- https, no subdomain wildcard, with attribute differences -->
+    <access origin="https://server09.com" /> <!-- equivalent to the next line -->
+    <access origin="https://server09.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <access origin="https://server10.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <access origin="https://server11.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <access origin="https://server12.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+
+    <!-- 
+        <allow-navigation> tests
+        
+        Test wildcard allow all. Note in ATS you can open up all, and have restrictions for certain domains.
+        This is to allow for example, an in-app-browser (*) but your own server communications must be https, for example.
+     -->
+    <allow-navigation href="*" />
+    <!-- https, with subdomain wildcard, attribute differences -->
+    <allow-navigation href="https://*.server21.com" /> <!-- equivalent to the next line -->
+    <allow-navigation href="https://*.server21.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <allow-navigation href="https://*.server22.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <allow-navigation href="https://*.server23.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <allow-navigation href="https://*.server24.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- http, no subdomain, with attribute differences -->
+    <allow-navigation href="http://server25.com" /> <!-- equivalent to the next line -->
+    <allow-navigation href="http://server25.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <allow-navigation href="http://server26.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <allow-navigation href="http://server27.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <allow-navigation href="http://server28.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- https, no subdomain, with attribute differences -->
+    <allow-navigation href="https://server29.com" /> <!-- equivalent to the next line -->
+    <allow-navigation href="https://server29.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <allow-navigation href="https://server30.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <allow-navigation href="https://server31.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <allow-navigation href="https://server32.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- wildcard scheme, with subdomain wildcard, with attribute differences -->
+    <allow-navigation href="*://*.server33.com" /> <!-- equivalent to the next line -->
+    <allow-navigation href="*://*.server33.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <allow-navigation href="*://*.server34.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <allow-navigation href="*://*.server35.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <allow-navigation href="*://*.server36.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+    <!-- wildcard scheme, no subdomain, with attribute differences -->
+    <allow-navigation href="*://server37.com" /> <!-- equivalent to the next line -->
+    <allow-navigation href="*://server37.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="true" />
+    <allow-navigation href="*://server38.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
+    <allow-navigation href="*://server39.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
+    <allow-navigation href="*://server40.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
+        
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <preference name="orientation" value="portrait" />

--- a/cordova-lib/src/configparser/ConfigParser.js
+++ b/cordova-lib/src/configparser/ConfigParser.js
@@ -437,6 +437,32 @@ ConfigParser.prototype = {
             };
         });
     },
+    /* Get all the access tags */
+    getAccesses: function() {
+        var accesses = this.doc.findall('./access');
+        return accesses.map(function(access){
+            var minimum_tls_version = access.attrib['minimum-tls-version']; /* String */
+            var requires_forward_secrecy = access.attrib['requires-forward-secrecy']; /* Boolean */
+            return {
+                'origin': access.attrib.origin,
+                'minimum_tls_version': minimum_tls_version,
+                'requires_forward_secrecy' : requires_forward_secrecy 
+            };
+        });
+    },
+    /* Get all the allow-navigation tags */
+    getAllowNavigations: function() {
+        var allow_navigations = this.doc.findall('./allow-navigation');
+        return allow_navigations.map(function(allow_navigation){
+            var minimum_tls_version = allow_navigation.attrib['minimum-tls-version']; /* String */
+            var requires_forward_secrecy = allow_navigation.attrib['requires-forward-secrecy']; /* Boolean */
+            return {
+                'href': allow_navigation.attrib.href,
+                'minimum_tls_version': minimum_tls_version,
+                'requires_forward_secrecy' : requires_forward_secrecy 
+            };
+        });
+    },
     write:function() {
         fs.writeFileSync(this.path, this.doc.write({indent: 4}), 'utf-8');
     }

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -30,6 +30,7 @@ var fs            = require('fs'),
     Q             = require('q'),
     Parser        = require('./parser'),
     ConfigParser  = require('../../configparser/ConfigParser'),
+    URL           = require('url'),
     CordovaError  = require('../../CordovaError');
 
 function ios_parser(project) {
@@ -108,6 +109,11 @@ ios_parser.prototype.update_from_config = function(config) {
         delete infoPlist['UISupportedInterfaceOrientations~ipad'];
         delete infoPlist['UIInterfaceOrientation'];
     }
+    
+    var ats = (infoPlist['NSAppTransportSecurity'] || {});
+    ats = processAccessEntriesAsATS(config, ats);
+    ats = processAllowNavigationEntriesAsATS(config, ats);
+    infoPlist['NSAppTransportSecurity'] = ats;
 
     var info_contents = plist.build(infoPlist);
     info_contents = info_contents.replace(/<string>[\s\r\n]*<\/string>/g,'<string></string>');
@@ -316,6 +322,112 @@ ios_parser.prototype.update_build_settings = function(config) {
 
     return Q();
 };
+
+function processAccessEntriesAsATS(config, ats) {
+    // CB-9569 - Support <access> tag to Application Transport Security (ATS) in iOS 9+
+    var accesses = config.getAccesses();
+    
+    // the default is the wildcard, so if there are no access tags, we add the wildcard in
+    if (accesses.length === 0) {
+        accesses.push({ 'origin' : '*'});
+    }
+    
+    if (!ats) {
+        ats = {};
+    }
+    
+    accesses.forEach(function(access) {
+        ats = processUrlAsATS(ats, access.origin, access.minimum_tls_version, access.requires_forward_secrecy);
+    });
+    
+    return ats;
+}
+
+function processAllowNavigationEntriesAsATS(config, ats) {
+    // CB-9569 - Support <allow-navigation> tag to Application Transport Security (ATS) in iOS 9+
+    var allow_navigations = config.getAllowNavigations();
+
+    if (!ats) {
+        ats = {};
+    }
+    
+    allow_navigations.forEach(function(allow_navigation) {
+        ats = processUrlAsATS(ats, allow_navigation.href, allow_navigation.minimum_tls_version, allow_navigation.requires_forward_secrecy);
+    });
+    
+    return ats;
+}
+
+function processUrlAsATS(ats0, url, minimum_tls_version, requires_forward_secrecy) {
+    
+    var ats = JSON.parse(JSON.stringify(ats0)); // (shallow) copy, to prevent side effects, +testable
+    
+    if (url === '*') {
+        ats['NSAllowsArbitraryLoads'] = true;
+        return ats;
+    }
+
+    if (!ats['NSExceptionDomains']) {
+        ats['NSExceptionDomains'] = {};
+    }
+
+    var href = URL.parse(url);
+    var includesSubdomains = false;
+    var hostname = href.hostname;
+
+    if (!hostname) {
+        // check origin, if it allows subdomains (wildcard in hostname), we set NSIncludesSubdomains to YES. Default is NO
+        var subdomain1 = '/*.'; // wildcard in hostname
+        var subdomain2 = '*://*.'; // wildcard in hostname and protocol
+        var subdomain3 = '*://'; // wildcard in protocol only
+        if (href.pathname.indexOf(subdomain1) === 0) {
+            includesSubdomains = true;
+            hostname = href.pathname.substring(subdomain1.length);
+        } else if (href.pathname.indexOf(subdomain2) === 0) {
+            includesSubdomains = true;
+            hostname = href.pathname.substring(subdomain2.length);
+        } else if (href.pathname.indexOf(subdomain3) === 0) {
+            includesSubdomains = false;
+            hostname = href.pathname.substring(subdomain3.length);
+        } 
+    }
+
+    // get existing entry, if any
+    var exceptionDomain = ats['NSExceptionDomains'][hostname] || {};
+
+    if (includesSubdomains) {
+        exceptionDomain['NSIncludesSubdomains'] = true;
+    } else {
+        delete exceptionDomain['NSIncludesSubdomains'];
+    }
+
+    if (minimum_tls_version && minimum_tls_version !== 'TLSv1.2') { // default is TLSv1.2
+        exceptionDomain['NSExceptionMinimumTLSVersion'] = minimum_tls_version;
+    } else {
+        delete exceptionDomain['NSExceptionMinimumTLSVersion'];
+    }
+
+    var rfs = (requires_forward_secrecy === 'true');
+    if (requires_forward_secrecy && !rfs) { // default is true
+        exceptionDomain['NSExceptionRequiresForwardSecrecy'] = rfs;
+    } else {
+        delete exceptionDomain['NSExceptionRequiresForwardSecrecy'];
+    }
+
+    // if the scheme is HTTP, we set NSExceptionAllowsInsecureHTTPLoads to YES. Default is NO
+    if (href.protocol === 'http:') {
+        exceptionDomain['NSExceptionAllowsInsecureHTTPLoads'] = true;
+    }
+    else if (!href.protocol && href.pathname.indexOf('*:/') === 0) { // wilcard in protocol
+        exceptionDomain['NSExceptionAllowsInsecureHTTPLoads'] = true;
+    } else {
+        delete exceptionDomain['NSExceptionAllowsInsecureHTTPLoads'];
+    }
+
+    ats['NSExceptionDomains'][hostname] = exceptionDomain;
+
+    return ats;
+}
 
 function folderExists(folderPath) {
     try {


### PR DESCRIPTION
Tests are included as well. &lt;access&gt; and &lt;allow-navigation&gt; tags have two new attributes to account for ATS: `minimum-tls-version` (defaults to 'TLSv1.2') and `requires-forward-secrecy` (defaults to 'true').

If the defaults are set, there will be *no* corresponding entry in ATS, to reduce verbosity in the Info.plist.