### PR TITLE
CB-9712 CLI 5.3 breaks with node 3.3.3

### DIFF
--- a/cordova-lib/src/cordova/create.js
+++ b/cordova-lib/src/cordova/create.js
@@ -113,7 +113,13 @@ function create(dir, optionalId, optionalName, cfg) {
         cfg.lib.www.url = cfg.lib.www.url || cfg.lib.www.uri;
 
         if (!cfg.lib.www.url) {
-            cfg.lib.www.url = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world');
+            try {
+                cfg.lib.www.url = require('cordova-app-hello-world').dirname;
+            } catch (e) {
+                // Falling back on npm@2 path hierarchy
+                // TODO: Remove fallback after cordova-app-hello-world release
+                cfg.lib.www.url = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world');
+            }
         }
 
         // TODO (kamrik): extend lazy_load for retrieval without caching to allow net urls for --src.
@@ -192,7 +198,13 @@ function create(dir, optionalId, optionalName, cfg) {
             paths.configXml = path.join(paths.root, 'config.xml');
             paths.configXmlLinkable = true;
         } else {
-            paths.configXml = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world', 'config.xml');
+            try {
+                paths.configXml = path.join(require('cordova-app-hello-world').dirname, 'config.xml');
+            } catch (e) {
+                // Falling back on npm@2 path hierarchy
+                // TODO: Remove fallback after cordova-app-hello-world release
+                paths.configXml = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world', 'config.xml');
+            }
         }
         if (fs.existsSync(path.join(paths.root, 'merges'))) {
             paths.merges = path.join(paths.root, 'merges');
@@ -203,7 +215,13 @@ function create(dir, optionalId, optionalName, cfg) {
             paths.hooks = path.join(paths.root, 'hooks');
             paths.hooksLinkable = true;
         } else {
-            paths.hooks = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world', 'hooks');
+            try {
+                paths.hooks = path.join(require('cordova-app-hello-world').dirname, 'hooks');
+            } catch (e) {
+                // Falling back on npm@2 path hierarchy
+                // TODO: Remove fallback after cordova-app-hello-world release
+                paths.hooks = path.join(__dirname, '..', '..', 'node_modules', 'cordova-app-hello-world', 'hooks');
+            }
         }
 
         var dirAlreadyExisted = fs.existsSync(dir);


### PR DESCRIPTION
I could repro the issue using npm@3.3.6 as npm@3.3.5 seems to have issues with Cordova installation.

Requires [cordova-app-hello-world#14](https://github.com/apache/cordova-app-hello-world/pull/14) changes in order for require to work.

[Jira issue](https://issues.apache.org/jira/browse/CB-9712)