### PR TITLE
CB-9758 Mobilespec crashes adding plugins on OS X

### DIFF
--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -496,6 +496,15 @@ describe('ios project parser', function () {
                     expect(d.NSExceptionRequiresForwardSecrecy).toEqual(false);
                 });
             });
+            it('<allow-navigation> - should ignore wildcards like data:*, https:*, https://*', function(done) {
+                wrapper(p.update_from_config(cfg), done, function() {
+                    var ats = plist_build.mostRecentCall.args[0].NSAppTransportSecurity;
+                    var exceptionDomains = ats.NSExceptionDomains;
+                    expect(exceptionDomains['']).toBeUndefined();
+                    expect(exceptionDomains['null']).toBeUndefined();
+                    expect(exceptionDomains['undefined']).toBeUndefined();
+                });
+            });
         });
         describe('www_dir method', function() {
             it('should return /www', function() {

--- a/cordova-lib/spec-cordova/test-config.xml
+++ b/cordova-lib/spec-cordova/test-config.xml
@@ -72,7 +72,14 @@
     <allow-navigation href="*://server38.com" minimum-tls-version="TLSv1.2" requires-forward-secrecy="false" />
     <allow-navigation href="*://server39.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
     <allow-navigation href="*://server40.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
-        
+
+    <!-- https://issues.apache.org/jira/browse/CB-9758 Mobilespec crashes adding plugins on OS X -->
+    <allow-navigation href="data:*" />
+    <allow-navigation href="http:*" />
+    <allow-navigation href="https:*" />
+    <allow-navigation href="http://*" />
+    <allow-navigation href="https://*" />
+
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <preference name="orientation" value="portrait" />

--- a/cordova-lib/src/cordova/metadata/ios_parser.js
+++ b/cordova-lib/src/cordova/metadata/ios_parser.js
@@ -389,7 +389,10 @@ function processUrlAsATS(ats0, url, minimum_tls_version, requires_forward_secrec
         } else if (href.pathname.indexOf(subdomain3) === 0) {
             includesSubdomains = false;
             hostname = href.pathname.substring(subdomain3.length);
-        } 
+        } else {
+            // Handling "scheme:*" case to avoid creating of a blank key in NSExceptionDomains.
+            return ats;
+        }
     }
 
     // get existing entry, if any


### PR DESCRIPTION
Avoid empty keys in NSExceptionDomains

[Jira issue](https://issues.apache.org/jira/browse/CB-9758)