### PR TITLE
CB-9813 Keep module-to-plugin mapping at hand.

### DIFF
--- a/cordova-lib/src/platforms/PlatformApiPoly.js
+++ b/cordova-lib/src/platforms/PlatformApiPoly.js
@@ -566,7 +566,8 @@ PlatformApiPoly.prototype._addModulesInfo = function(plugin, targetDir) {
         var moduleName = plugin.id + '.' + ( moduleToInstall.name || moduleToInstall.src.match(/([^\/]+)\.js/)[1] );
         var obj = {
             file: ['plugins', plugin.id, moduleToInstall.src].join('/'),
-            id: moduleName
+            id: moduleName,
+            pluginId: plugin.id
         };
         if (moduleToInstall.clobbers.length > 0) {
             obj.clobbers = moduleToInstall.clobbers.map(function(o) { return o.target; });

--- a/cordova-lib/src/plugman/browserify.js
+++ b/cordova-lib/src/plugman/browserify.js
@@ -129,7 +129,12 @@ module.exports = function doBrowserify (project, platformApi, pluginInfoProvider
             .forEach(function(jsModule) {
                 var moduleName = jsModule.name ? jsModule.name : path.basename(jsModule.src, '.js');
                 var moduleId = pluginInfo.id + '.' + moduleName;
-                var moduleMetadata = {file: jsModule.src, id: moduleId, name: moduleName};
+                var moduleMetadata = {
+                    file: jsModule.src,
+                    id: moduleId,
+                    name: moduleName,
+                    pluginId: pluginInfo.id
+                };
 
                 if (jsModule.clobbers.length > 0) {
                     moduleMetadata.clobbers = jsModule.clobbers.map(function(o) { return o.target; });


### PR DESCRIPTION
This information is handy for various use-cases. E.g. for preview application to
provide only the plugins which are used by the application (instead of all of
them, since they are built-in in the preview app on the device). The other is
simulation (taco-simulation does need this info).

Instead of trying to (unreliably) recover this information from module list,
just keep track of it when it's known (at the prepare stage).

CC: @tony-- 