### PR TITLE
On Windows, verify browsers installed before launching.

### DIFF
--- a/cordova-serve/package.json
+++ b/cordova-serve/package.json
@@ -22,7 +22,8 @@
     "chalk": "^1.1.1",
     "compression": "^1.6.0",
     "express": "^4.13.3",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "shelljs": "^0.5.3"
   },
   "devDependencies": {
     "jshint": "^2.8.0"


### PR DESCRIPTION
Do this to avoid dialog that pops up on Windows if browser is not installed, and provide more meaningful error messages.