### PR TITLE
CB-9834 Introduce cordova modules compatibility map for plugin hooks

### DIFF
--- a/cordova-lib/src/hooks/Context.js
+++ b/cordova-lib/src/hooks/Context.js
@@ -17,6 +17,9 @@
  under the License.
  */
 
+var path = require('path');
+var events = require('cordova-common').events;
+
 /**
  * Creates hook script context
  * @constructor
@@ -39,13 +42,39 @@ function Context(hook, opts) {
     this.cordova = require('../cordova/cordova');
 }
 
+// As per CB-9834 we need to maintain backward compatibility and provide a compat layer
+// for plugins that still require modules, factored to cordova-common.
+var compatMap = {
+    '../configparser/ConfigParser': function () {
+        return require('cordova-common').ConfigParser;
+    },
+    '../util/xml-helpers': function () {
+        return require('cordova-common').xmlHelpers;
+    }
+};
 
 /**
  * Returns a required module
- * @param {String} path Module path
+ * @param {String} modulePath Module path
  * @returns {Object} */
-Context.prototype.requireCordovaModule = function (path) {
-    return require(path);
+Context.prototype.requireCordovaModule = function (modulePath) {
+    // There is a very common mistake, when hook requires some cordova functionality
+    // using 'cordova-lib/...' path.
+    // This path will be resolved only when running cordova from 'normal' installation
+    // (without symlinked modules). If cordova-lib linked to cordova-cli this path is
+    // never resolved, so hook fails with 'Error: Cannot find module 'cordova-lib''
+    var resolvedPath = path.resolve(__dirname, modulePath.replace(/^cordova-lib/, '../../../cordova-lib'));
+    var relativePath = path.relative(__dirname, resolvedPath).replace(/\\/g, '/');
+    events.emit('verbose', 'Resolving module name for ' + modulePath + ' => ' + relativePath);
+
+    var compatRequire = compatMap[relativePath];
+    if (compatRequire) {
+        events.emit('warn', 'The module "' + path.basename(relativePath) + '" has been factored ' +
+            'into "cordova-common". Consider update your plugin hooks.');
+        return compatRequire();
+    }
+
+    return require(relativePath);
 };
 
 module.exports = Context;


### PR DESCRIPTION
This fixes potential issue with third-party plugin hooks, since many of them using internal cordova modules, in particular `ConfigParser` and `xml-helpers`.

The sample case is desribed in [CB-9834](https://issues.apache.org/jira/browse/CB-9834)