### PR TITLE
Update create, allow cfg.lib.www.url and dir to be siblings

### DIFF
--- a/cordova-lib/src/cordova/create.js
+++ b/cordova-lib/src/cordova/create.js
@@ -132,9 +132,11 @@ function create(dir, optionalId, optionalName, cfg) {
         // must start by going up at least one directory or with a drive
         // letter for Windows.
         var rel_path = path.relative(cfg.lib.www.url, dir);
-        var goes_up = rel_path.split(path.sep)[0] == '..';
+        var rel_parts = rel_path.split(path.sep);
+        var goes_up = rel_parts[0] == '..';
+        var is_sibling = rel_parts.length === 1;
 
-        if (!(goes_up || rel_path[1] == ':')) {
+        if (!(goes_up || rel_path[1] == ':' || is_sibling)) {
             throw new CordovaError(
                 'Project dir "' + dir +
                 '" must not be created at/inside the template used to create the project "' +


### PR DESCRIPTION
I am trying to get some practice with Node and various modules and build methods.

While trying to create a project using gulp I had `www/` and `config.xml` going to `./build/`. I went over the source of Cordova Create to work out how best to use my own config.xml. Based on how things worked I tried to output my Cordova project to `./build/mobile` expecting it to get my www and the config.xml file and put them both under `mobile/`. This would have prevented me having to store my config in my www but create errored.