### PR TITLE
CB-9935: Cordova CLI silently fails on node.js v5

### DIFF
--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -55,7 +55,7 @@ function installPlatformsFromConfigXML(platforms, opts) {
     });
 
     if (!targets || !targets.length) {
-        return Q.all('No platforms are listed in config.xml to restore');
+        return Q('No platforms are listed in config.xml to restore');
     }
 
 
@@ -87,7 +87,7 @@ function installPluginsFromConfigXML(args) {
     // Get all configured plugins
     var plugins = cfg.getPluginIdList();
     if (0 === plugins.length) {
-        return Q.all('No config.xml plugins to install');
+        return Q('No config.xml plugins to install');
     }
 
     // CB-9560 : Run `plugin add` serially, one plugin after another


### PR DESCRIPTION
Cordova in a couple places was mis-using the Q.all() function from
the Q promises library. That function expects an array (of values or
promises), but Cordova was passing a single string parameter. The
string was actually being reduced like an array. Previously that
happened to work out OK: the result was an array of fulfilled
single-character promises. But one line of code in Q that worked
on node.js v4 now fails on node.js v5, where because of the bad
parameter it ends up assigning a value to an index of the string:
    exception in cordova-lib\node_modules\q\q.js:1490
    >    promises[index] = value;
    TypeError: Cannot assign to read only property '0' of <string>
It appears the newer version of V8 is a little more strict about
assigning to a string index.

The fix is simply to use Q() instead of Q.all() when the intention
is to return a single fulfilled promise of type string.