### PR TITLE
add missing package_suffix function on amazon-fireos platform for plu…

### DIFF
--- a/cordova-lib/src/plugman/platforms/amazon-fireos.js
+++ b/cordova-lib/src/plugman/platforms/amazon-fireos.js
@@ -170,5 +170,10 @@ module.exports = {
         var prefix = module.exports.package_suffix(project_dir);
         var subRelativeDir = path.join(plugin_id, prefix + '-' + path.basename(src));
         return subRelativeDir;
+    },
+    package_suffix: function (project_dir) {
+        var packageName = module.exports.package_name(project_dir);
+        var lastDotIndex = packageName.lastIndexOf('.');
+        return packageName.substring(lastDotIndex + 1);
     }
 };


### PR DESCRIPTION
This came about while trying to install https://github.com/katzer/cordova-plugin-badge to an amazon-fireos platform.  I was getting the error that module.exports.package_suffix was undefined, so I tracked it down to the plugman amazon-fireos.js file and added the same logic as in android.js .