### PR TITLE
CVE: Update tar in order to prevent symlink file overwriting

### DIFF
--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -38,7 +38,7 @@
     "request": "2.47.0",
     "semver": "^4.3.x",
     "shelljs": "0.3.0",
-    "tar": "1.0.2",
+    "tar": "2.2.1",
     "underscore": "1.7.0",
     "unorm": "1.3.3",
     "valid-identifier": "0.0.1",


### PR DESCRIPTION
I managed to run all the tests and seems like nothing was broken. This issue was already publicly disclosed here: https://nodesecurity.io/advisories/57 and here https://github.com/npm/npm/releases/tag/v2.7.5
