### PR TITLE
Cb 9618 - Icon parameter should not be relative to the www directory on Ubuntu

### DIFF
--- a/cordova-lib/src/cordova/metadata/ubuntu_parser.js
+++ b/cordova-lib/src/cordova/metadata/ubuntu_parser.js
@@ -100,7 +100,7 @@ ubuntu_parser.prototype.update_manifest = function() {
     var content = '[Desktop Entry]\nName=' + name + '\nExec=./cordova-ubuntu www/\nTerminal=false\nType=Application\nX-Ubuntu-Touch=true';
 
     if (this.config.doc.find('icon') && this.config.doc.find('icon').attrib.src) {
-        var iconPath = path.join(this.path, this.config.doc.find('icon').attrib.src);
+        var iconPath = path.join(this.path, '../..', this.config.doc.find('icon').attrib.src);
         if (fs.existsSync(iconPath))
             content += '\nIcon=www/' + this.config.doc.find('icon').attrib.src;
         else

--- a/cordova-lib/src/cordova/metadata/ubuntu_parser.js
+++ b/cordova-lib/src/cordova/metadata/ubuntu_parser.js
@@ -102,7 +102,7 @@ ubuntu_parser.prototype.update_manifest = function() {
     if (this.config.doc.find('icon') && this.config.doc.find('icon').attrib.src) {
         var iconPath = path.join(this.path, '../..', this.config.doc.find('icon').attrib.src);
         if (fs.existsSync(iconPath))
-            content += '\nIcon=www/' + this.config.doc.find('icon').attrib.src;
+            content += '\nIcon=' + this.config.doc.find('icon').attrib.src;
         else
             return Q.reject(new Error('icon does not exist: ' + iconPath));
     } else {

--- a/cordova-lib/src/cordova/metadata/ubuntu_parser.js
+++ b/cordova-lib/src/cordova/metadata/ubuntu_parser.js
@@ -100,7 +100,7 @@ ubuntu_parser.prototype.update_manifest = function() {
     var content = '[Desktop Entry]\nName=' + name + '\nExec=./cordova-ubuntu www/\nTerminal=false\nType=Application\nX-Ubuntu-Touch=true';
 
     if (this.config.doc.find('icon') && this.config.doc.find('icon').attrib.src) {
-        var iconPath = path.join(this.path, 'www', this.config.doc.find('icon').attrib.src);
+        var iconPath = path.join(this.path, this.config.doc.find('icon').attrib.src);
         if (fs.existsSync(iconPath))
             content += '\nIcon=www/' + this.config.doc.find('icon').attrib.src;
         else


### PR DESCRIPTION
This patch fixes a long standing issue, whereby the icon parameter in the app manifest was prefixed with a www directory while it is not in other parts of the tools or runtime.