### PR TITLE
CB-10125: Android build fails on read-only image files

### DIFF
--- a/cordova-lib/src/cordova/metadata/android_parser.js
+++ b/cordova-lib/src/cordova/metadata/android_parser.js
@@ -77,11 +77,13 @@ android_parser.prototype.deleteDefaultResource = function(name) {
         if (filename.indexOf('drawable-') === 0) {
             var imgPath = path.join(res, filename, name);
             if (fs.existsSync(imgPath)) {
+                shell.chmod('u+w', imgPath);
                 fs.unlinkSync(imgPath);
                 events.emit('verbose', 'deleted: ' + imgPath);
             }
             imgPath = imgPath.replace(/\.png$/, '.9.png');
             if (fs.existsSync(imgPath)) {
+                shell.chmod('u+w', imgPath);
                 fs.unlinkSync(imgPath);
                 events.emit('verbose', 'deleted: ' + imgPath);
             }


### PR DESCRIPTION
Ensure image files are writeable before trying to delete them.

I considered an alternative: ensuring files are writeable after copying them. But that seemed less robust, and other parts of the build are already able to overwrite read-only files due to the use of shell.cp('-f', ...). The only reason this code dealing with image files had a problem was because it deleted the files before re-copying them.