### PR TITLE
CB-10193 Add deprecation notice about pre_package removal

### DIFF
--- a/cordova-lib/src/hooks/HooksRunner.js
+++ b/cordova-lib/src/hooks/HooksRunner.js
@@ -50,10 +50,18 @@ HooksRunner.prototype.fire = function fire(hook, opts) {
     }
     opts = this.prepareOptions(opts);
 
+    var handlers = events.listeners(hook);
+    var scripts = scriptsFinder.getHookScripts(hook, opts);
+
+    // CB-10193 Emit warning if there is any handlers subscribed to 'pre_package'
+    if (hook === 'pre_package' && (handlers.length > 0 || scripts.length > 0)) {
+        events.emit('warn', '"pre_package" hook is deprecated and will be removed in next Windows platform versions. ' +
+            'Please use "after_prepare" if you want to manipulate files in www before app will be packaged.');
+    }
+
     // execute hook event listeners first
     return executeEventHandlersSerially(hook, opts).then(function() {
         // then execute hook script files
-        var scripts = scriptsFinder.getHookScripts(hook, opts);
         var context = new Context(hook, opts);
         return runScriptsSerially(scripts, context);
     });


### PR DESCRIPTION
This PR adds an temporary polyfill for windows 'pre_package' event to keep compatibility with plugins, which uses this hook. It also adds a notice about 'pre_package' hook removal in next windows platform versions.

For more details on this see [corresponding mailing list discussion](http://apache.markmail.org/thread/enzm34cktoeqh4ss)