### PR TITLE
Add cli_variables to plugman before_plugin_install hook params

### DIFF
--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -450,6 +450,14 @@ describe('HooksRunner', function() {
                                 delete call.args[1].plugin.pluginInfo._et;
                             }
 
+                            if(call.args[0] == 'before_plugin_install' ||
+                                call.args[0] == 'after_plugin_install') {
+                                // before_plugin_install and after_plugin_install include cli_variables
+                                androidPluginOpts.plugin.variables = {
+                                    'PACKAGE_NAME': 'io.cordova.hellocordova'
+                                };
+                            }
+
                             if(call.args[0] == 'before_plugin_uninstall' ||
                                 call.args[0] == 'before_plugin_install' ||
                                 call.args[0] == 'after_plugin_install') {

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -375,7 +375,8 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
                         id: pluginInfo.id,
                         pluginInfo: pluginInfo,
                         platform: install.platform,
-                        dir: install.top_plugin_dir
+                        dir: install.top_plugin_dir,
+                        variables: filtered_variables
                     }
                 };
 


### PR DESCRIPTION
Currently the context provided to the `before_plugin_install` hook does not include plugin variables/parameters. This is problematic for my use case, where I bundle a hook with the plugin that performs string manipulation based on plugin variables a user defines.

It's possible to get default values (if they are defined) in a hook using the `context.opts.plugin.pluginInfo.getPreferences()`, but this does not account for `cli_options`, or those defined in an plugin through `config.xml` in the `<variable>` element.

This change adds a `variables` key to the hook's context, which contains the CLI (or default) plugin variables. A hook could access them through the `context.opts.plugin.variables` object.
