### PR TITLE
CB-10423 Recursive error in plugin add ( windows )

### DIFF
--- a/cordova-lib/spec-plugman/fetch.spec.js
+++ b/cordova-lib/spec-plugman/fetch.spec.js
@@ -251,15 +251,26 @@ describe('fetch', function() {
 
         var srcDir = path.join(__dirname, 'plugins/recursivePlug');
         var appDir = path.join(__dirname, 'plugins/recursivePlug/demo');
-
-        it('should skip copy to avoid recursive error', function(done) {
-
-            var cp = spyOn(shell, 'cp').andCallFake(function(){});
-
-            wrapper(fetch(srcDir, appDir),done, function() {
-                expect(cp).not.toHaveBeenCalled();
+        
+        if(/^win/.test(process.platform)) {
+            it('should copy all but the /demo/ folder',function(done) {
+                var cp = spyOn(shell, 'cp');
+                wrapper(fetch(srcDir, appDir),done, function() {
+                    expect(cp).toHaveBeenCalledWith('-R',path.join(srcDir,'asset.txt'),path.join(appDir,'test-recursive'));
+                    expect(cp).not.toHaveBeenCalledWith('-R',srcDir,path.join(appDir,'test-recursive'));
+                });
             });
-        });
+        }
+        else {
+            it('should skip copy to avoid recursive error', function(done) {
+
+                var cp = spyOn(shell, 'cp').andCallFake(function(){});
+
+                wrapper(fetch(srcDir, appDir),done, function() {
+                    expect(cp).not.toHaveBeenCalled();
+                });
+            });
+        }
 
     });
 

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -277,12 +277,38 @@ function copyPlugin(pinfo, plugins_dir, link) {
         return altDest;
     }
 
+    shell.rm('-rf', dest);
+
     if(!link && dest.indexOf(path.resolve(plugin_dir)) === 0) {
-        events.emit('verbose', 'Copy plugin destination is child of src. Forcing --link mode.');
-        link = true;
+        
+        if(/^win/.test(process.platform)) {
+            /*
+                [CB-10423]
+                This is a special case. On windows we cannot create a symlink unless we are run as admin
+                The error that we have is because src contains dest, so we end up with a recursive folder explosion
+                This code avoids copy the one folder that will explode, and allows plugins to contain a demo project
+                and to install the plugin via `cordova plugin add ../`
+            */
+            var resolvedSrcPath = path.resolve(plugin_dir);
+            var filenames = fs.readdirSync(resolvedSrcPath);
+            var relPath = path.relative(resolvedSrcPath,dest);
+            var relativeRootFolder = relPath.split('\\')[0];
+            filenames.splice(filenames.indexOf(relativeRootFolder),1);
+            shell.mkdir('-p', dest);
+            events.emit('verbose', 'Copying plugin "' + resolvedSrcPath + '" => "' + dest + '"');
+            events.emit('verbose', 'Skipping folder "' + relativeRootFolder + '"');
+            
+            filenames.forEach(function(elem) {
+                shell.cp('-R', path.join(resolvedSrcPath,elem) , dest);
+            });
+            return dest;
+        }
+        else {
+            events.emit('verbose', 'Copy plugin destination is child of src. Forcing --link mode.');
+            link = true;
+        }
     }
 
-    shell.rm('-rf', dest);
     if (link) {
         var isRelativePath = plugin_dir.charAt(1) != ':' && plugin_dir.charAt(0) != path.sep;
         var fixedPath = isRelativePath ? path.join(path.relative(plugins_dir, process.env.PWD || process.cwd()), plugin_dir) : plugin_dir;


### PR DESCRIPTION
repro steps ;
in a plugin repo that has a demo project, you may want to do something like this to allow other developers to run the demo:
cd demo
cordova plugin add ../ 

windows does not allow symlink unless the shell is run with administrator privileges, which means the fix for [CB-8809] will still fail in most cases.

The root of the problem is that we are attempting to copy src->dest when src contains dest, so we CAN proceed as long as we skip the destination folder from source.
