### PR TITLE
CB-10430 Allow to modify events source

### DIFF
--- a/cordova-common/cordova-common.js
+++ b/cordova-common/cordova-common.js
@@ -19,9 +19,10 @@
 
 /* jshint node:true */
 
+var events = require('./src/events');
+
 // For now expose plugman and cordova just as they were in the old repos
 exports = module.exports = {
-    events: require('./src/events'),
     superspawn: require('./src/superspawn'),
 
     ActionStack: require('./src/ActionStack'),
@@ -40,3 +41,12 @@ exports = module.exports = {
 
     xmlHelpers: require('./src/util/xml-helpers')
 };
+
+Object.defineProperty(module.exports, 'events', {
+    get: function () {
+        return events.get();
+    },
+    set: function (value) {
+        return events.set(value);
+    }
+});

--- a/cordova-common/spec/events.spec.js
+++ b/cordova-common/spec/events.spec.js
@@ -1,0 +1,76 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var EventEmitter = require('events').EventEmitter;
+var common = require('../cordova-common');
+var events = require('../src/events');
+
+var fakeEmitter = new EventEmitter();
+fakeEmitter.FAKE_PROPERTY = 'fake_property';
+
+describe('events module', function() {
+    it('should be exposed as module\'s property', function () {
+        expect(common.events).toBeDefined();
+        expect(common.events).toEqual(jasmine.any(EventEmitter));
+    });
+
+    it('should be exposed via get method when required internally', function () {
+        expect(events).toBeDefined();
+        expect(events.get()).toEqual(jasmine.any(EventEmitter));
+    });
+
+    it('should not be exposed as module\'s exports when required internally', function () {
+        expect(events).not.toEqual(jasmine.any(EventEmitter));
+        expect(function () { events.emit('fake_event', 'fake_message'); }).toThrow();
+    });
+
+    it('should be settable via module\'s property', function () {
+        var originalEmitter = common.events;
+        common.events = fakeEmitter;
+
+        expect(common.events.FAKE_PROPERTY).toBe('fake_property');
+
+        common.events = originalEmitter;
+    });
+
+    it('should be settable via set method, when required internally', function () {
+        var originalEmitter = events.get();
+        events.set(fakeEmitter);
+
+        expect(events.get().FAKE_PROPERTY).toBe('fake_property');
+
+        events.set(originalEmitter);
+    });
+
+    it('should throw if set to non-EventEmitter\'s instance', function () {
+        expect(function () { common.events = {}; }).toThrow();
+    });
+
+    it('get method should return new instance when set via module\' property', function () {
+        var originalEmitter = common.events;
+        common.events = fakeEmitter;
+
+        expect(common.events.FAKE_PROPERTY).toBe('fake_property');
+        expect(events.get().FAKE_PROPERTY).toBe('fake_property');
+        expect(events.get()).toBe(common.events);
+
+        common.events = originalEmitter;
+    });
+
+});

--- a/cordova-common/src/ActionStack.js
+++ b/cordova-common/src/ActionStack.js
@@ -45,7 +45,7 @@ ActionStack.prototype = {
     },
     // Returns a promise.
     process:function(platform) {
-        events.emit('verbose', 'Beginning processing of action stack for ' + platform + ' project...');
+        events.get().emit('verbose', 'Beginning processing of action stack for ' + platform + ' project...');
 
         while (this.stack.length) {
             var action = this.stack.shift();
@@ -55,7 +55,7 @@ ActionStack.prototype = {
             try {
                 handler.apply(null, action_params);
             } catch(e) {
-                events.emit('warn', 'Error during processing of action! Attempting to revert...');
+                events.get().emit('warn', 'Error during processing of action! Attempting to revert...');
                 this.stack.unshift(action);
                 var issue = 'Uh oh!\n';
                 // revert completed tasks
@@ -67,7 +67,7 @@ ActionStack.prototype = {
                     try {
                         revert.apply(null, revert_params);
                     } catch(err) {
-                        events.emit('warn', 'Error during reversion of action! We probably really messed up your project now, sorry! D:');
+                        events.get().emit('warn', 'Error during reversion of action! We probably really messed up your project now, sorry! D:');
                         issue += 'A reversion action failed: ' + err.message + '\n';
                     }
                 }
@@ -76,7 +76,7 @@ ActionStack.prototype = {
             }
             this.completed.push(action);
         }
-        events.emit('verbose', 'Action stack processing complete.');
+        events.get().emit('verbose', 'Action stack processing complete.');
 
         return Q();
     }

--- a/cordova-common/src/ConfigChanges/ConfigChanges.js
+++ b/cordova-common/src/ConfigChanges/ConfigChanges.js
@@ -103,6 +103,7 @@ function remove_plugin_changes(pluginInfo, is_top_level) {
     var munge = mungeutil.decrement_munge(global_munge, config_munge);
 
     for (var file in munge.files) {
+        events.get().emit('verbose', 'Applying munge to ' + file);
         // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
         if (self.platform == 'windows' && file == 'package.appxmanifest' &&
             !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
@@ -110,7 +111,7 @@ function remove_plugin_changes(pluginInfo, is_top_level) {
             var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest', 'package.windows10.appxmanifest'];
             /* jshint loopfunc:true */
             substs.forEach(function(subst) {
-                events.emit('verbose', 'Applying munge to ' + subst);
+                events.get().emit('verbose', 'Applying munge to ' + subst);
                 self.apply_file_munge(subst, munge.files[file], true);
             });
             /* jshint loopfunc:false */
@@ -146,13 +147,14 @@ function add_plugin_changes(pluginInfo, plugin_vars, is_top_level, should_increm
     }
 
     for (var file in munge.files) {
+        events.get().emit('verbose', 'Applying munge to ' + file);
         // CB-6976 Windows Universal Apps. Compatibility fix for existing plugins.
         if (self.platform == 'windows' && file == 'package.appxmanifest' &&
             !fs.existsSync(path.join(self.project_dir, 'package.appxmanifest'))) {
             var substs = ['package.phone.appxmanifest', 'package.windows.appxmanifest', 'package.windows80.appxmanifest', 'package.windows10.appxmanifest'];
             /* jshint loopfunc:true */
             substs.forEach(function(subst) {
-                events.emit('verbose', 'Applying munge to ' + subst);
+                events.get().emit('verbose', 'Applying munge to ' + subst);
                 self.apply_file_munge(subst, munge.files[file]);
             });
             /* jshint loopfunc:false */

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -347,7 +347,7 @@ ConfigParser.prototype = {
         if (null === pluginElement) {
             var legacyFeature =  this.doc.find('./feature/param[@name="id"][@value="' + id + '"]/..');
             if(legacyFeature){
-                 events.emit('log', 'Found deprecated feature entry for ' + id +' in config.xml.');
+                events.get().emit('log', 'Found deprecated feature entry for ' + id +' in config.xml.');
                 return featureToPlugin(legacyFeature);
             }
             return undefined;

--- a/cordova-common/src/PluginInfo/PluginInfoProvider.js
+++ b/cordova-common/src/PluginInfo/PluginInfoProvider.js
@@ -72,7 +72,7 @@ function getAllHelper(absPath, provider) {
             try {
                 plugins.push(provider.get(d));
             } catch (e) {
-                events.emit('warn', 'Error parsing ' + path.join(d, 'plugin.xml.\n' + e.stack));
+                events.get().emit('warn', 'Error parsing ' + path.join(d, 'plugin.xml.\n' + e.stack));
             }
         }
     });

--- a/cordova-common/src/events.js
+++ b/cordova-common/src/events.js
@@ -16,4 +16,22 @@
     specific language governing permissions and limitations
     under the License.
 */
-module.exports = new (require('events').EventEmitter)();
+
+var EventEmitter = require('events').EventEmitter;
+var INSTANCE;
+
+function get () {
+    return INSTANCE || (INSTANCE = new EventEmitter());
+}
+
+function set (value) {
+    if (!(value instanceof EventEmitter))
+        throw new Error('EventEmitter instance must be used to override events');
+
+    INSTANCE = value;
+
+    return module.exports;
+}
+
+module.exports.get = get;
+module.exports.set = set;

--- a/cordova-common/src/superspawn.js
+++ b/cordova-common/src/superspawn.js
@@ -103,7 +103,7 @@ exports.spawn = function(cmd, args, opts) {
         }
     }
 
-    events.emit(opts.printCommand ? 'log' : 'verbose', 'Running command: ' + maybeQuote(cmd) + ' ' + args.map(maybeQuote).join(' '));
+    events.get().emit(opts.printCommand ? 'log' : 'verbose', 'Running command: ' + maybeQuote(cmd) + ' ' + args.map(maybeQuote).join(' '));
 
     var child = child_process.spawn(cmd, args, spawnOpts);
     var capturedOut = '';
@@ -128,7 +128,7 @@ exports.spawn = function(cmd, args, opts) {
         child.removeListener('error', whenDone);
         var code = typeof arg == 'number' ? arg : arg && arg.code;
 
-        events.emit('verbose', 'Command finished with error code ' + code + ': ' + cmd + ' ' + args);
+        events.get().emit('verbose', 'Command finished with error code ' + code + ': ' + cmd + ' ' + args);
         if (code === 0) {
             d.resolve(capturedOut.trim());
         } else {


### PR DESCRIPTION
This fixes [CB-10430](https://issues.apache.org/jira/browse/CB-10430).

This change is needed to allow other tools to replace default `EventEmitter` instance (e.g. platform might to replace default `EventEmitter` with another one, provided by caller, in order to pass these events to upstream code)