### PR TITLE
CB-10497 Prefer .bat over .cmd on windows platform

### DIFF
--- a/cordova-common/src/superspawn.js
+++ b/cordova-common/src/superspawn.js
@@ -28,7 +28,7 @@ var iswin32 = process.platform == 'win32';
 
 // On Windows, spawn() for batch files requires absolute path & having the extension.
 function resolveWindowsExe(cmd) {
-    var winExtensions = ['.exe', '.cmd', '.bat', '.js', '.vbs'];
+    var winExtensions = ['.exe', '.bat', '.cmd', '.js', '.vbs'];
     function isValidExe(c) {
         return winExtensions.indexOf(path.extname(c)) !== -1 && fs.existsSync(c);
     }


### PR DESCRIPTION
Fixes ant-running issue on windows platform.

Originally I wanted to build android platform with ant:

```
cordova build android -- --ant
```

The downloadable Ant distribution package contains `ant.bat` and `ant.cmd` files in the `bin` directory.

The `resolveWindowsExe()` function resolves `ant` to `%ANT_HOME%\\bin\\ant.cmd`.

In case of ant this is not correct because `ant.cmd` is made for OS/2 platform ( see: https://ant.apache.org/manual/running.html )

`child_process.spawn()` should run `ant.bat` file instead of `ant.cmd`.
