### PR TITLE
CB-10531 Enable coverage reports for cordova-lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,13 @@ node_js:
   - "0.12"
   - "4.2"
 install:
-  - cd ..
   - git clone https://github.com/apache/cordova-js --depth 10
-  - cd cordova-js
+  - cd cordova-lib
+  - npm link ../cordova-js
+  - npm link ../cordova-common
+  - npm link ../cordova-serve
   - npm install
-  - npm link
-  - cd ../cordova-lib/cordova-common
-  - npm install
-  - npm test
-  - npm link
-  - cd ../cordova-serve
-  - npm install
-  - npm link
-  - cd ../cordova-lib
-  - npm link cordova-js
-  - npm link cordova-common
-  - npm link cordova-serve
-  - npm install
+
+script:
+  - "(cd ../cordova-common && npm test)"
+  - "npm run ci"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/q9s459ssqvs1t7j6/branch/master)](https://ci.appveyor.com/project/Humbedooh/cordova-lib)
 [![Build Status](https://travis-ci.org/apache/cordova-lib.svg?branch=master)](https://travis-ci.org/apache/cordova-lib)
+[![Code coverage](https://codecov.io/github/apache/cordova-lib/coverage.svg?branch=master)](https://codecov.io/github/apache/cordova-lib?branch=master)
 [![NPM](https://nodei.co/npm/cordova.png)](https://nodei.co/npm/cordova/)
 
 [BuildBot waterfall](http://ci.cordova.io/) with [cordova-mobile-spec](https://github.com/apache/cordova-mobile-spec) running on real Android and iOS devices.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,11 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
 install:
-  - cd ..
   - git clone https://github.com/apache/cordova-js --depth 10
-  - cd cordova-js
-  - npm install
-  - npm link
-  - cd ..\cordova-lib\cordova-common
-  - npm install
-  - npm test
-  - npm link
-  - cd ..\cordova-serve
-  - npm install
-  - npm link
-  - cd ..\cordova-lib
-  - npm link cordova-js
-  - npm link cordova-common
-  - npm link cordova-serve
+  - cd cordova-lib
+  - npm link ../cordova-js
+  - npm link ../cordova-common
+  - npm link ../cordova-serve
   - npm install
 
 build: off
@@ -25,4 +14,5 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - "cd ../cordova-common && npm test"
+  - "cd ../cordova-lib && npm test"

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -16,7 +16,7 @@
     "node": ">=0.9.9"
   },
   "engineStrict": true,
-  "cordovaPlugins" : {
+  "cordovaPlugins": {
     "cordova-plugin-battery-status": "~1.1.1",
     "cordova-plugin-camera": "~2.1.0",
     "cordova-plugin-console": "~1.0.2",
@@ -71,6 +71,7 @@
     "cordova-common"
   ],
   "devDependencies": {
+    "codecov": "^1.0.1",
     "istanbul": "^0.3.4",
     "jasmine-node": "1.14.5",
     "jshint": "2.5.8",
@@ -78,9 +79,10 @@
   },
   "scripts": {
     "test": "npm run jshint && npm run jasmine",
-    "jshint": "node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint spec-cordova && node node_modules/jshint/bin/jshint spec-plugman",
-    "jasmine": "node node_modules/jasmine-node/bin/jasmine-node --captureExceptions --color spec-plugman spec-cordova",
-    "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
+    "ci": "npm run jshint && npm run cover && codecov",
+    "jshint": "jshint src spec-cordova spec-plugman",
+    "jasmine": "jasmine-node --captureExceptions --color spec-plugman spec-cordova",
+    "cover": "istanbul cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
   },
   "contributors": [
     {


### PR DESCRIPTION
This PR adds integration with codecov.io

There is also a few improvements for Travis and Appveyor configs and npm tasks:
  * Simplify Travis and Appveyor configs by using relative `npm link`s
  * Run `cordova-common` tests as a part of `test_script` (was the part of `install`)
  * Shorten `npm run` scripts specification by assuming that tools are already in `PATH`(proof: https://docs.npmjs.com/cli/run-script)