### PR TITLE
CB-10235 Added clearer error message for info command

### DIFF
--- a/cordova-lib/src/cordova/info.js
+++ b/cordova-lib/src/cordova/info.js
@@ -43,7 +43,7 @@ function getPlatformInfo(platform, projectRoot) {
     case 'ios':
         return execSpawn('xcodebuild', ['-version'], 'iOS platform:\n\n', 'Error retrieving iOS platform information: ');
     case 'android':
-        return execSpawn('android', ['list', 'target'], 'Android platform:\n\n', 'Error retrieving Android platform information: ');
+        return execSpawn('android', ['list', 'target'], 'Android platform:\n\n', 'Error retrieving Android platform information: \nAndroid SDK is not set up properly. Make sure that the Android SDK \'tools\' and \'platform-tools\' directories are in the PATH variable. \n\n');
     }
 }
 


### PR DESCRIPTION
When using the cordova info command, if Android isn't set up properly, then the error message printed out isn't too helpful. I added to the error message to tell users to make sure they have the path of Android SDK tools and platform-tools in their PATH environment variable. 