### PR TITLE
CB-10553 Fix framework tag handler for Android

### DIFF
--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -608,7 +608,7 @@ function handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, 
             .save();
 
         if (platform == 'android' && semver.gte(options.platformVersion, '4.0.0-dev') &&
-                pluginInfo.getFrameworks('platform').length > 0) {
+                pluginInfo.getFrameworks(platform).length > 0) {
 
             events.emit('verbose', 'Updating build files since android plugin contained <framework>');
             var buildModule;


### PR DESCRIPTION
The framework tag was not being handled during plugin-install for Android. In the conditional check, it checks for the string literal 'platform' instead of just the platform. 