### PR TITLE
CB-10567 Bubble up `cordova.raw.run()` error to the caller

### DIFF
--- a/cordova-lib/src/cordova/run.js
+++ b/cordova-lib/src/cordova/run.js
@@ -45,5 +45,8 @@ module.exports = function run(options) {
         return hooksRunner.fire('after_run', options);
     }, function(error) {
         events.emit('log', 'ERROR running one or more of the platforms: ' + error + '\nYou may not have the required environment or OS to run this project');
+
+        // CB-10567 bubble up `run` error, so the caller still could get rejected promise
+        return Q.reject(error);
     });
 };


### PR DESCRIPTION
JIRA [CB-10567](https://issues.apache.org/jira/browse/CB-10567)

This PR fixes the case when `cordova.raw.run()` promise always being resolved, event if run itself fails due to some reason.