### PR TITLE
CB-10430 Adds forwardEvents method to easily connect two EventEmitters

### DIFF
--- a/cordova-common/src/events.js
+++ b/cordova-common/src/events.js
@@ -16,4 +16,50 @@
     specific language governing permissions and limitations
     under the License.
 */
-module.exports = new (require('events').EventEmitter)();
+
+var EventEmitter = require('events').EventEmitter;
+
+var INSTANCE = new EventEmitter();
+var EVENTS_RECEIVER;
+
+module.exports = INSTANCE;
+
+/**
+ * Sets up current instance to forward emitted events to another EventEmitter
+ *   instance.
+ *
+ * @param   {EventEmitter}  [eventEmitter]  The emitter instance to forward
+ *   events to. Falsy value, when passed, disables forwarding.
+ */
+module.exports.forwardEventsTo = function (eventEmitter) {
+
+    // If no argument is specified disable events forwarding
+    if (!eventEmitter) {
+        EVENTS_RECEIVER = undefined;
+        return;
+    }
+
+    if (!(eventEmitter instanceof EventEmitter))
+        throw new Error('Cordova events could be redirected to another EventEmitter instance only');
+
+    EVENTS_RECEIVER = eventEmitter;
+};
+
+var emit = INSTANCE.emit;
+
+/**
+ * This method replaces original 'emit' method to allow events forwarding.
+ *
+ * @return  {eventEmitter}  Current instance to allow calls chaining, as
+ *   original 'emit' does
+ */
+module.exports.emit = function () {
+
+    var args = Array.prototype.slice.call(arguments);
+
+    if (EVENTS_RECEIVER) {
+        EVENTS_RECEIVER.emit.apply(EVENTS_RECEIVER, args);
+    }
+
+    return emit.apply(this, args);
+};


### PR DESCRIPTION
This fixes CB-10430.

This change is needed to allow platform connect own `events` instance to another, provided by caller (`cordova-lib` in most cases)

This PR is a replacement for #370 

A usage sample:
```javascript
function Api(platform, platformRootDir, eventEmitter) {
    ...
    if (eventEmitter) {
        events.forwardEventsTo(eventEmitter);
    } else {
        CordovaLogger.get().subscribe(events);
    }
    ...
```