### PR TITLE
CB-10519 Wrap all sync calls inside of `cordova.raw` methods into promises

### DIFF
--- a/cordova-lib/spec-cordova/build.spec.js
+++ b/cordova-lib/spec-cordova/build.spec.js
@@ -40,7 +40,8 @@ describe('build command', function() {
     describe('failure', function() {
         it('should not run inside a project with no platforms', function(done) {
             list_platforms.andReturn([]);
-            Q().then(cordova.raw.build).then(function() {
+            cordova.raw.build()
+            .then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
                 expect(err.message).toEqual(
@@ -52,7 +53,8 @@ describe('build command', function() {
         it('should not run outside of a Cordova-based project', function(done) {
             is_cordova.andReturn(false);
 
-            Q().then(cordova.raw.build).then(function() {
+            cordova.raw.build()
+            .then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
                 expect(err.message).toEqual(

--- a/cordova-lib/spec-cordova/prepare.spec.js
+++ b/cordova-lib/spec-cordova/prepare.spec.js
@@ -95,7 +95,7 @@ describe('prepare command', function() {
         it('should not run outside of a cordova-based project by calling util.isCordova', function(done) {
             is_cordova.andReturn(false);
             cd_project_root.andCallThrough();  // undo spy here because prepare depends on cdprojectRoot for isCordova check
-            Q().then(prepare).then(function() {
+            prepare().then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
                 expect('' + err).toContain('Current working directory is not a Cordova-based project.');
@@ -103,7 +103,7 @@ describe('prepare command', function() {
         });
         it('should not run inside a cordova-based project with no platforms', function(done) {
             list_platforms.andReturn([]);
-            Q().then(prepare).then(function() {
+            prepare().then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
                 expect('' + err).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.');

--- a/cordova-lib/src/cordova/build.js
+++ b/cordova-lib/src/cordova/build.js
@@ -17,22 +17,25 @@
     under the License.
 */
 
-var cordovaUtil      = require('./util'),
-    HooksRunner           = require('../hooks/HooksRunner');
+var Q = require('q'),
+    cordovaUtil = require('./util'),
+    HooksRunner = require('../hooks/HooksRunner');
 
 // Returns a promise.
 module.exports = function build(options) {
-    var projectRoot = cordovaUtil.cdProjectRoot();
-    options = cordovaUtil.preProcessOptions(options);
+    return Q().then(function() {
+        var projectRoot = cordovaUtil.cdProjectRoot();
+        options = cordovaUtil.preProcessOptions(options);
 
-    // fire build hooks
-    var hooksRunner = new HooksRunner(projectRoot);
-    return hooksRunner.fire('before_build', options)
-    .then(function() {
-        return require('./cordova').raw.prepare(options);
-    }).then(function() {
-        return require('./cordova').raw.compile(options);
-    }).then(function() {
-        return hooksRunner.fire('after_build', options);
+        // fire build hooks
+        var hooksRunner = new HooksRunner(projectRoot);
+        return hooksRunner.fire('before_build', options)
+        .then(function() {
+            return require('./cordova').raw.prepare(options);
+        }).then(function() {
+            return require('./cordova').raw.compile(options);
+        }).then(function() {
+            return hooksRunner.fire('after_build', options);
+        });
     });
 };

--- a/cordova-lib/src/cordova/compile.js
+++ b/cordova-lib/src/cordova/compile.js
@@ -24,16 +24,23 @@ var cordova_util = require('./util'),
 
 // Returns a promise.
 module.exports = function compile(options) {
-    var projectRoot = cordova_util.cdProjectRoot();
-    options = cordova_util.preProcessOptions(options);
+    return Q().then(function() {
+        var projectRoot = cordova_util.cdProjectRoot();
+        options = cordova_util.preProcessOptions(options);
 
-    var hooksRunner = new HooksRunner(projectRoot);
-    return hooksRunner.fire('before_compile', options)
-    .then(function () {
-        return promiseUtil.Q_chainmap(options.platforms, function (platform) {
-            return platform_lib
-                .getPlatformApi(platform)
-                .build(options.options);
+        var hooksRunner = new HooksRunner(projectRoot);
+        return hooksRunner.fire('before_compile', options)
+        .then(function () {
+            return promiseUtil.Q_chainmap(options.platforms, function (platform) {
+                return platform_lib
+                    .getPlatformApi(platform)
+                    .build(options.options);
+            });
+        }).then(function() {
+            return hooksRunner.fire('after_compile', options);
+        }, function(error) {
+            events.emit('log', 'ERROR building one of the platforms: ' + error + '\nYou may not have the required environment or OS to build this project');
+            return Q.reject(error);
         });
     }).then(function() {
         return hooksRunner.fire('after_compile', options);

--- a/cordova-lib/src/cordova/emulate.js
+++ b/cordova-lib/src/cordova/emulate.js
@@ -24,24 +24,26 @@ var cordova_util = require('./util'),
 
 // Returns a promise.
 module.exports = function emulate(options) {
-    var projectRoot = cordova_util.cdProjectRoot();
-    options = cordova_util.preProcessOptions(options);
-    options.options.device = false;
-    options.options.emulator = true;
+    return Q().then(function() {
+        var projectRoot = cordova_util.cdProjectRoot();
+        options = cordova_util.preProcessOptions(options);
+        options.options.device = false;
+        options.options.emulator = true;
 
-    var hooksRunner = new HooksRunner(projectRoot);
-    return hooksRunner.fire('before_emulate', options)
-    .then(function() {
-        // Run a prepare first!
-        return require('./cordova').raw.prepare(options);
-    }).then(function() {
-        // Deploy in parallel (output gets intermixed though...)
-        return Q.all(options.platforms.map(function(platform) {
-            return platform_lib
-                .getPlatformApi(platform)
-                .run(options.options);
-        }));
-    }).then(function() {
-        return hooksRunner.fire('after_emulate', options);
+        var hooksRunner = new HooksRunner(projectRoot);
+        return hooksRunner.fire('before_emulate', options)
+        .then(function() {
+            // Run a prepare first!
+            return require('./cordova').raw.prepare(options);
+        }).then(function() {
+            // Deploy in parallel (output gets intermixed though...)
+            return Q.all(options.platforms.map(function(platform) {
+                return platform_lib
+                    .getPlatformApi(platform)
+                    .run(options.options);
+            }));
+        }).then(function() {
+            return hooksRunner.fire('after_emulate', options);
+        });
     });
 };

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -34,34 +34,36 @@ var cordova_util      = require('./util'),
 // Returns a promise.
 exports = module.exports = prepare;
 function prepare(options) {
-    var projectRoot = cordova_util.cdProjectRoot();
-    var config_json = config.read(projectRoot);
-    options = options || { verbose: false, platforms: [], options: {} };
+    return Q().then(function() {
+        var projectRoot = cordova_util.cdProjectRoot();
+        var config_json = config.read(projectRoot);
+        options = options || { verbose: false, platforms: [], options: {} };
 
-    var hooksRunner = new HooksRunner(projectRoot);
-    return hooksRunner.fire('before_prepare', options)
-    .then(function(){
-        return restore.installPlatformsFromConfigXML(options.platforms, { searchpath : options.searchpath });
-    })
-    .then(function(){
-        options = cordova_util.preProcessOptions(options);
-        var paths = options.platforms.map(function(p) {
-            var platform_path = path.join(projectRoot, 'platforms', p);
-            return platforms.getPlatformApi(p, platform_path).getPlatformInfo().locations.www;
+        var hooksRunner = new HooksRunner(projectRoot);
+        return hooksRunner.fire('before_prepare', options)
+        .then(function(){
+            return restore.installPlatformsFromConfigXML(options.platforms, { searchpath : options.searchpath });
+        })
+        .then(function(){
+            options = cordova_util.preProcessOptions(options);
+            var paths = options.platforms.map(function(p) {
+                var platform_path = path.join(projectRoot, 'platforms', p);
+                return platforms.getPlatformApi(p, platform_path).getPlatformInfo().locations.www;
+            });
+            options.paths = paths;
+        }).then(function() {
+            options = cordova_util.preProcessOptions(options);
+            options.searchpath = options.searchpath || config_json.plugin_search_path;
+            // Iterate over each added platform
+            return preparePlatforms(options.platforms, projectRoot, options);
+        }).then(function() {
+            options.paths = options.platforms.map(function(platform) {
+                return platforms.getPlatformApi(platform).getPlatformInfo().locations.www;
+            });
+            return hooksRunner.fire('after_prepare', options);
+        }).then(function () {
+            return restore.installPluginsFromConfigXML(options);
         });
-        options.paths = paths;
-    }).then(function() {
-        options = cordova_util.preProcessOptions(options);
-        options.searchpath = options.searchpath || config_json.plugin_search_path;
-        // Iterate over each added platform
-        return preparePlatforms(options.platforms, projectRoot, options);
-    }).then(function() {
-        options.paths = options.platforms.map(function(platform) {
-            return platforms.getPlatformApi(platform).getPlatformInfo().locations.www;
-        });
-        return hooksRunner.fire('after_prepare', options);
-    }).then(function () {
-        return restore.installPluginsFromConfigXML(options);
     });
 }
 

--- a/cordova-lib/src/cordova/requirements.js
+++ b/cordova-lib/src/cordova/requirements.js
@@ -32,20 +32,22 @@ var knownPlatforms = require('../platforms/platforms');
  *   requirements check results for each platform.
  */
 module.exports = function check_reqs(platforms) {
-    platforms = cordova_util.preProcessOptions(platforms).platforms;
+    return Q().then(function() {
+        var platforms = cordova_util.preProcessOptions(platforms).platforms;
 
-    return Q.allSettled(platforms.map(function (platform) {
-        return knownPlatforms.getPlatformApi(platform).requirements();
-    }))
-    .then(function (settledChecks) {
-        var res = {};
-        settledChecks.reduce(function (result, settledCheck, idx) {
-            var platformName = platforms[idx];
-            result[platformName] = settledCheck.state === 'fulfilled' ?
-                settledCheck.value :
-                new CordovaError(settledCheck.reason);
-            return result;
-        }, res);
-        return res;
+        return Q.allSettled(platforms.map(function (platform) {
+            return knownPlatforms.getPlatformApi(platform).requirements();
+        }))
+        .then(function (settledChecks) {
+            var res = {};
+            settledChecks.reduce(function (result, settledCheck, idx) {
+                var platformName = platforms[idx];
+                result[platformName] = settledCheck.state === 'fulfilled' ?
+                    settledCheck.value :
+                    new CordovaError(settledCheck.reason);
+                return result;
+            }, res);
+            return res;
+        });
     });
 };

--- a/cordova-lib/src/cordova/run.js
+++ b/cordova-lib/src/cordova/run.js
@@ -25,22 +25,29 @@ var cordova_util = require('./util'),
 
 // Returns a promise.
 module.exports = function run(options) {
-    var projectRoot = cordova_util.cdProjectRoot();
-    options = cordova_util.preProcessOptions(options);
+    return Q().then(function() {
+        var projectRoot = cordova_util.cdProjectRoot();
+        options = cordova_util.preProcessOptions(options);
 
-    var hooksRunner = new HooksRunner(projectRoot);
-    return hooksRunner.fire('before_run', options)
-    .then(function() {
-        // Run a prepare first, then shell out to run
-        return require('./cordova').raw.prepare(options);
-    }).then(function() {
-        // Deploy in parallel (output gets intermixed though...)
-        return Q.all(options.platforms.map(function(platform) {
-            return platform_lib
-                .getPlatformApi(platform)
-                .run(options.options);
-        }));
-    }).then(function() {
-        return hooksRunner.fire('after_run', options);
+        var hooksRunner = new HooksRunner(projectRoot);
+        return hooksRunner.fire('before_run', options)
+        .then(function() {
+            // Run a prepare first, then shell out to run
+            return require('./cordova').raw.prepare(options);
+        }).then(function() {
+            // Deploy in parallel (output gets intermixed though...)
+            return Q.all(options.platforms.map(function(platform) {
+                return platform_lib
+                    .getPlatformApi(platform)
+                    .run(options.options);
+            }));
+        }).then(function() {
+            return hooksRunner.fire('after_run', options);
+        }, function(error) {
+            events.emit('log', 'ERROR running one or more of the platforms: ' + error + '\nYou may not have the required environment or OS to run this project');
+
+            // CB-10567 bubble up `run` error, so the caller still could get rejected promise
+            return Q.reject(error);
+        });
     });
 };


### PR DESCRIPTION
This is a fix for [CB-10519](https://issues.apache.org/jira/browse/CB-10519)

This PR fixes the issue when promise returned from `cordova.raw` API would never be rejected if command is ran outside of cordova project. Instead synchronous exception will be thrown (by `util.preProcessOptions`), which is definitely unexpected for promise based API.

There are many indentation changes in this PR, so it's more convenient to review with [`?w=1`](https://github.com/apache/cordova-lib/pull/384?w=1) option