### PR TITLE
CB-10550 Fixed the issue of plugin id mapper not enforced when a vers…

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -132,10 +132,14 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 ));
             }
             // If not found in local search path, fetch from the registry.
-            var newID = pluginMapperotn[plugin_src];
+            var splitVersion = plugin_src.split('@');
+            var newID = pluginMapperotn[splitVersion[0]];
             if(newID) {
                 events.emit('warn', 'Notice: ' + plugin_src + ' has been automatically converted to ' + newID + ' to be fetched from npm. This is due to our old plugins registry shutting down.');                
                 plugin_src = newID;
+                if (splitVersion[1]) {
+                    plugin_src += '@'+splitVersion[1];
+                }
             } 
             return registry.fetch([plugin_src])
             .fail(function (error) {

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -135,7 +135,7 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
             var splitVersion = plugin_src.split('@');
             var newID = pluginMapperotn[splitVersion[0]];
             if(newID) {
-                events.emit('warn', 'Notice: ' + plugin_src + ' has been automatically converted to ' + newID + ' to be fetched from npm. This is due to our old plugins registry shutting down.');                
+                events.emit('warn', 'Notice: ' + splitVersion[0] + ' has been automatically converted to ' + newID + ' to be fetched from npm. This is due to our old plugins registry shutting down.');
                 plugin_src = newID;
                 if (splitVersion[1]) {
                     plugin_src += '@'+splitVersion[1];


### PR DESCRIPTION
…ion is specified

The issue is described in https://issues.apache.org/jira/browse/CB-10550
The fix is to inspect the given plugin_src if it contains the '@'version_number' before it tries to find the mapper database.