### PR TITLE
CB-10611 fixed the before_plugin_install hook not disabled with --noh…

### DIFF
--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -188,7 +188,8 @@ module.exports = function plugin(command, targets, opts) {
                                 // instead of <platform>/www. This is required since on each prepare platform's www dir is changed
                                 // and files from 'platform_www' merged into 'www'. Thus we need to persist these
                                 // files platform_www directory, so they'll be applied to www on each prepare.
-                                usePlatformWww: true
+                                usePlatformWww: true,
+                                nohooks: opts.nohooks
                             };
 
                             events.emit('verbose', 'Calling plugman.install on plugin "' + pluginInfo.dir + '" for platform "' + platform);

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -381,7 +381,8 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
                         pluginInfo: pluginInfo,
                         platform: install.platform,
                         dir: install.top_plugin_dir
-                    }
+                    },
+                    nohooks: options.nohooks
                 };
 
                 var hooksRunner = new HooksRunner(projectRoot);


### PR DESCRIPTION
…ooks

The fix is to pass the command line option to the plugman when adding a plugin.