### PR TITLE
CB-10618 Do not call prepBuildFiles for cordova-android@>=5.2.0

### DIFF
--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -83,7 +83,7 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
     // Split @Version from the plugin id if it exists.
     var splitVersion = id.split('@');
     //Check if a mapping exists for the plugin id
-    //if it does, convert id to new name id 
+    //if it does, convert id to new name id
     var newId = pluginMapper[splitVersion[0]];
     if(newId) {
         events.emit('warn', 'Notice: ' + id + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
@@ -92,7 +92,7 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
         } else {
             id = newId;
         }
-     }     
+     }
     return possiblyFetch(id, plugins_dir, options)
     .then(function(plugin_dir) {
         return runInstall(current_stack, platform, project_dir, plugin_dir, plugins_dir, options);
@@ -397,7 +397,7 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
         }
     ).fail(
         function (error) {
-            
+
             if(error === 'skip') {
                 events.emit('warn', 'Skipping \'' + pluginInfo.id + '\' for ' + platform);
             } else {
@@ -429,7 +429,7 @@ function installDependencies(install, dependencies, options) {
                 // Split @Version from the plugin id if it exists.
                 var splitVersion = dep.id.split('@');
                 //Check if a mapping exists for the plugin id
-                //if it does, convert id to new name id 
+                //if it does, convert id to new name id
                 var newId = pluginMapper[splitVersion[0]];
                 if(newId) {
                     events.emit('warn', 'Notice: ' + dep.id + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
@@ -612,7 +612,12 @@ function handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, 
             .addPlugin(pluginInfo.id, filtered_variables, options.is_top_level)
             .save();
 
-        if (platform == 'android' && semver.gte(options.platformVersion, '4.0.0-dev') &&
+        if (platform == 'android' &&
+                semver.gte(options.platformVersion, '4.0.0-dev') &&
+                // CB-10533 since 5.2.0-dev prepBuildFiles is now called internally by android platform and
+                // no more exported from build module
+                // TODO: This might be removed once we deprecate non-PlatformApi compatible platforms support
+                semver.lte(options.platformVersion, '5.2.0-dev') &&
                 pluginInfo.getFrameworks(platform).length > 0) {
 
             events.emit('verbose', 'Updating build files since android plugin contained <framework>');

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -267,7 +267,7 @@ function runUninstallPlatform(actions, platform, project_dir, plugin_dir, plugin
         promise = promiseutil.Q_chainmap(danglers, function(dangler) {
             var dependent_path = path.join(plugins_dir, dangler);
 
-            //try to convert ID if old-id path doesn't exist. 
+            //try to convert ID if old-id path doesn't exist.
             if (!fs.existsSync(dependent_path)) {
                 var splitVersion = dangler.split('@');
                 var newId = pluginMapper[splitVersion[0]];
@@ -334,8 +334,14 @@ function handleUninstall(actions, platform, pluginInfo, project_dir, www_dir, pl
             .removePlugin(pluginInfo.id, is_top_level)
             .save();
 
-        if (platform == 'android' && semver.gte(options.platformVersion, '4.0.0-dev') &&
+        if (platform == 'android' &&
+                semver.gte(options.platformVersion, '4.0.0-dev') &&
+                // CB-10533 since 5.2.0-dev prepBuildFiles is now called internally by android platform and
+                // no more exported from build module
+                // TODO: This might be removed once we deprecate non-PlatformApi compatible platforms support
+                semver.lte(options.platformVersion, '5.2.0-dev') &&
                 pluginInfo.getFrameworks(platform).length > 0) {
+
             events.emit('verbose', 'Updating build files since android plugin contained <framework>');
             var buildModule;
             try {


### PR DESCRIPTION
An implementation for [CB-10618](https://issues.apache.org/jira/browse/CB-10618)
This PR disables calling `prepBuildFiles` as since android@5.2.0 it is called from platform's code