### PR TITLE
CB-10641 Run prepare _after_ plugins were installed

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -180,18 +180,21 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     PlatformApi.createPlatform.bind(null, destination, cfg, options, events) :
                     PlatformApi.updatePlatform.bind(null, destination, options, events);
 
-                return promise().then(function () {
+                return promise()
+                .then(function() {
+                    if (cmd == 'add') {
+                        return installPluginsForNewPlatform(platform, projectRoot, opts);
+                    }
+                })
+                .then(function () {
                     // Call prepare for the current platform.
                     var prepOpts = {
                         platforms :[platform],
                         searchpath :opts.searchpath
                     };
                     return require('./cordova').raw.prepare(prepOpts);
-                }).then(function() {
-                    if (cmd == 'add') {
-                        return installPluginsForNewPlatform(platform, projectRoot, opts);
-                    }
-                }).then(function() {
+                })
+                .then(function() {
                     var saveVersion = !spec || semver.validRange(spec, true);
 
                     // Save platform@spec into platforms.json, where 'spec' is a version or a soure location. If a


### PR DESCRIPTION
This is a fix for [CB-10641](https://issues.apache.org/jira/browse/CB-10641) and [CB-10586](https://issues.apache.org/jira/browse/CB-10586)
 
This PR changes order of operations in `cordova.raw.platform('add', ...)` method so `cordova.raw.prepare` is called after all plugins installed into platform. Also apart from resolving the issue above, the new flow (`platform_add -> install_plugins -> prepare`) looks semantically more correct.