### PR TITLE
CB-10654 make hooks fire when platforms added from repo or dir

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -84,7 +84,7 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
         var parts = target.split('@');
         var platform = parts[0];
         var spec = parts[1];
-        var platDetails = "";
+        var platDetails = '';
 
         return Q.when().then(function() {
             if (!(platform in platforms)) {
@@ -118,7 +118,6 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
             return downloadPlatform(projectRoot, platform, spec, opts);
         }).then(function(platformDetails) {
             platDetails = platformDetails;
-            console.log(JSON.stringify(opts));
             var hookOpts = {
                 platforms :[platDetails.platform],
                 nohooks :[opts.nohooks]


### PR DESCRIPTION
JIRA [CB-10654](https://issues.apache.org/jira/browse/CB-10654)
move `hooksRunner.fire('before_platform_'...)` till after platform has been resolved, pass resolved platform instead of target.
move `hooksRunner.fire('after_platform_'...)` into platform loop, pass resolved platform instead of target.
