### PR TITLE
CB-10314 avoid fetching plugins when oldId is already fetched

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -150,6 +150,7 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 // if the plugin alias has already been fetched, use it.
                 var alias = pluginMappernto[splitVersion[0]] || newID;
                 if (alias && fs.existsSync(path.join(plugins_dir, alias))) {
+                    events.emit('warn', 'Found '+alias+' is already fetched. Skipped fetching '+splitVersion[0]);
                     P = Q(path.join(plugins_dir, alias));
                     skipCopyingPlugin = true;
                 } else {

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -36,7 +36,7 @@ var path = require('path'),
     plugman = require('./plugman'),
     HooksRunner = require('../hooks/HooksRunner'),
     isWindows = (os.platform().substr(0,3) === 'win'),
-    pluginMapper = require('cordova-registry-mapper').oldToNew,
+    pluginMapper = require('cordova-registry-mapper'),
     cordovaUtil = require('../cordova/util');
 
 var superspawn = require('cordova-common').superspawn;
@@ -79,21 +79,36 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
     }
 
     var current_stack = new action_stack();
-
     // Split @Version from the plugin id if it exists.
     var splitVersion = id.split('@');
     //Check if a mapping exists for the plugin id
     //if it does, convert id to new name id
-    var newId = pluginMapper[splitVersion[0]];
+    var newId = pluginMapper.oldToNew[splitVersion[0]];
     if(newId) {
-        events.emit('warn', 'Notice: ' + id + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
         if(splitVersion[1]) {
             id = newId +'@'+splitVersion[1];
         } else {
             id = newId;
         }
-     }
-    return possiblyFetch(id, plugins_dir, options)
+    }
+    var P;
+    var plugin_dir = path.join(plugins_dir, splitVersion[0]);
+    // if the plugin has already been fetched, use it.
+    if (fs.existsSync(plugin_dir)) {
+        P = Q(plugin_dir);
+    } else {
+        var alias = pluginMapper.newToOld[splitVersion[0]] || newId;
+        // if the plugin alias has already been fetched, use it.
+        if (alias && fs.existsSync(path.join(plugins_dir, alias))) {
+            P = Q(path.join(plugins_dir, alias));
+        } else {
+            if (newId) {
+                events.emit('warn', 'Notice: ' + splitVersion[0] + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
+            }
+            P = possiblyFetch(id, plugins_dir, options);
+        }
+    }
+    return P
     .then(function(plugin_dir) {
         return runInstall(current_stack, platform, project_dir, plugin_dir, plugins_dir, options);
     });
@@ -105,17 +120,16 @@ function possiblyFetch(id, plugins_dir, options) {
 
     // if plugin is a relative path, check if it already exists
     var plugin_src_dir = isAbsolutePath(id) ? id : path.join(plugins_dir, id);
-
     // Check that the plugin has already been fetched.
     if (fs.existsSync(plugin_src_dir)) {
         return Q(plugin_src_dir);
     }
 
+    // if plugin doesnt exist, use fetch to get it.
     var opts = underscore.extend({}, options, {
         client: 'plugman'
     });
 
-    // if plugin doesnt exist, use fetch to get it.
     return plugman.raw.fetch(id, plugins_dir, opts);
 }
 
@@ -291,7 +305,6 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
     var pluginInfoProvider = options.pluginInfoProvider;
     var pluginInfo   = pluginInfoProvider.get(plugin_dir);
     var filtered_variables = {};
-
     var platformJson = PlatformJson.load(plugins_dir, platform);
 
     if (platformJson.isPluginInstalled(pluginInfo.id)) {
@@ -431,7 +444,7 @@ function installDependencies(install, dependencies, options) {
                 var splitVersion = dep.id.split('@');
                 //Check if a mapping exists for the plugin id
                 //if it does, convert id to new name id
-                var newId = pluginMapper[splitVersion[0]];
+                var newId = pluginMapper.oldToNew[splitVersion[0]];
                 if(newId) {
                     events.emit('warn', 'Notice: ' + dep.id + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
                     if(splitVersion[1]) {


### PR DESCRIPTION
implement the fix to the issue in CB-10314.
Before start fetching the plugin, first check if the plugin with alias id is already fetched in the project.
Otherwise, it is a waste of time fetching the plugin with newId and then decide not to install.
This pull request also includes a fix to the issue of reporting the bogus mismatched id error which is caused by fetching the new-Id when old-Id is renamed to fetch. (checkID function in fetch.js)
After the fix, the plugin add is changed as follows:
```
[CB-10314] cordova plugin
cordova-plugin-whitelist 1.2.1 "Whitelist"
org.apache.cordova.device 0.3.0 "Device"
[CB-10314] cordova plugin add org.apache.cordova.device
Plugin "org.apache.cordova.device" already installed on ios.
```