### PR TITLE
CB-10658: Downgrade error to warning

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -199,8 +199,8 @@ function loadLocalPlugins(searchpath, pluginInfoProvider) {
         if ( !underscore.isEqual(localPlugins.searchpath, searchpath) ) {
             var msg =
                 'loadLocalPlugins called twice with different search paths.' +
-                'Support for this is not implemented.';
-            throw new Error(msg);
+                'Support for this is not implemented.  Using previously cached path.';
+            events.emit('warn', msg);
         }
         return;
     }


### PR DESCRIPTION
Replace error with warning message if search paths differ.
(which does happen with `cca` tool from the MobileChromeApps project)

Generally, if the `localPlugins` cache variable has been previously set, 
(e.g. via programmatically calling plugin add), then subsequent calls with
differing paths will cause the process to exit, which seems a bit extreme.
As the comments suggest, this is simply not implemented, not a failure 
state, and can be safely passed.
