### PR TITLE
CB-10662 Use project's config.xml as a fallback for package name

### DIFF
--- a/cordova-lib/src/plugman/platforms/browser.js
+++ b/cordova-lib/src/plugman/platforms/browser.js
@@ -20,10 +20,8 @@
 /* jshint laxcomma:true, sub:true */
 
 var path = require('path')
-    , fs = require('fs')
     , common = require('./common')
     , events = require('cordova-common').events
-    , xml_helpers = require('cordova-common').xmlHelpers
     ;
 
 module.exports = {
@@ -31,25 +29,7 @@ module.exports = {
         return path.join(project_dir, 'www');
     },
     package_name:function(project_dir) {
-        // preferred location if cordova >= 3.4
-        var preferred_path = path.join(project_dir, 'config.xml');
-        var config_path;
-
-        if (!fs.existsSync(preferred_path)) {
-            // older location
-            var old_config_path = path.join(module.exports.www_dir(project_dir), 'config.xml');
-            if (!fs.existsSync(old_config_path)) {
-                // output newer location and fail reading
-                config_path = preferred_path;
-                events.emit('verbose', 'unable to find '+config_path);
-            } else {
-                config_path = old_config_path;
-            }
-        } else {
-            config_path = preferred_path;
-        }
-        var widget_doc = xml_helpers.parseElementtreeSync(config_path);
-        return widget_doc._root.attrib['id'];
+        return common.package_name(project_dir, this.www_dir(project_dir));
     },
     'source-file':{
         install:function(obj, plugin_dir, project_dir, plugin_id, options) {

--- a/cordova-lib/src/plugman/platforms/common.js
+++ b/cordova-lib/src/plugman/platforms/common.js
@@ -22,7 +22,39 @@ var shell = require('shelljs'),
     fs    = require('fs'),
     common;
 
+var cordovaUtil = require('../../cordova/util');
+var CordovaError = require('cordova-common').CordovaError;
+var xmlHelpers = require('cordova-common').xmlHelpers;
+
 module.exports = common = {
+    package_name: function(project_dir, www_dir) {
+
+        var configPaths = [
+            // preferred location if cordova >= 3.4
+            path.join(project_dir, 'config.xml'),
+            // older location
+            path.join(www_dir || path.join(project_dir, 'www'), 'config.xml'),
+        ];
+
+        var cordovaRoot = cordovaUtil.isCordova();
+        if (cordovaRoot) {
+            // CB-10662 If we're in cli project then add project's config as a fallback
+            configPaths.push(path.join(cordovaRoot, 'config.xml'));
+        }
+
+        for (var i = 0; i < configPaths.length; i++) {
+            var configPath = configPaths[i];
+            // If no config there try next path
+            if (!fs.existsSync(configPath)) continue;
+
+            var widget_doc = xmlHelpers.parseElementtreeSync(configPath);
+            return widget_doc._root.attrib.id;
+        }
+
+        // No configs found - fail with meaningful error message
+        throw new CordovaError('Unable to find project\'s config in any of ' +
+            'the following directories:\n\t' + configPaths.join('\n\t'));
+    },
     // helper for resolving source paths from plugin.xml
     resolveSrcPath:function(plugin_dir, relative_path) {
         var full_path = path.resolve(plugin_dir, relative_path);

--- a/cordova-lib/src/plugman/platforms/firefoxos.js
+++ b/cordova-lib/src/plugman/platforms/firefoxos.js
@@ -20,10 +20,8 @@
 /* jshint laxcomma:true, sub:true */
 
 var path = require('path')
-    , fs = require('fs')
     , common = require('./common')
     , events = require('cordova-common').events
-    , xml_helpers = require('cordova-common').xmlHelpers
     ;
 
 module.exports = {
@@ -31,25 +29,7 @@ module.exports = {
         return path.join(project_dir, 'www');
     },
     package_name:function(project_dir) {
-        // preferred location if cordova >= 3.4
-        var preferred_path = path.join(project_dir, 'config.xml');
-        var config_path;
-
-        if (!fs.existsSync(preferred_path)) {
-            // older location
-            var old_config_path = path.join(module.exports.www_dir(project_dir), 'config.xml');
-            if (!fs.existsSync(old_config_path)) {
-                // output newer location and fail reading
-                config_path = preferred_path;
-                events.emit('verbose', 'unable to find '+config_path);
-            } else {
-                config_path = old_config_path;
-            }
-        } else {
-            config_path = preferred_path;
-        }
-        var widget_doc = xml_helpers.parseElementtreeSync(config_path);
-        return widget_doc._root.attrib['id'];
+        return common.package_name(project_dir, this.www_dir(project_dir));
     },
     'source-file':{
         install:function(obj, plugin_dir, project_dir, plugin_id, options) {

--- a/cordova-lib/src/plugman/platforms/webos.js
+++ b/cordova-lib/src/plugman/platforms/webos.js
@@ -23,10 +23,8 @@
 */
 
 var path = require('path')
-    , fs = require('fs')
     , common = require('./common')
     , events = require('cordova-common').events
-    , xml_helpers = require('cordova-common').xmlHelpers
     ;
 
 module.exports = {
@@ -34,25 +32,7 @@ module.exports = {
         return path.join(project_dir, 'www');
     },
     package_name:function(project_dir) {
-        // preferred location if cordova >= 3.4
-        var preferred_path = path.join(project_dir, 'config.xml');
-        var config_path;
-
-        if (!fs.existsSync(preferred_path)) {
-            // older location
-            var old_config_path = path.join(module.exports.www_dir(project_dir), 'config.xml');
-            if (!fs.existsSync(old_config_path)) {
-                // output newer location and fail reading
-                config_path = preferred_path;
-                events.emit('verbose', 'unable to find '+config_path);
-            } else {
-                config_path = old_config_path;
-            }
-        } else {
-            config_path = preferred_path;
-        }
-        var widget_doc = xml_helpers.parseElementtreeSync(config_path);
-        return widget_doc._root.attrib['id'];
+        return common.package_name(project_dir, this.www_dir(project_dir));
     },
     'source-file':{
         install:function(obj, plugin_dir, project_dir, plugin_id, options) {


### PR DESCRIPTION
JIRA: [CB-10662](https://issues.apache.org/jira/browse/CB-10662)

This change is needed because some platforms (`browser` in particular)  doesn't contain own `config.xml` and rely on cordova, which generates one from defaults during `prepare`. However, prepare now called after plugin installation (after b04db5feaf5516836c8a157cc3331b75d6dca0eb) and hence fails due to abscence of config.