### PR TITLE
CB-10034 Addresses Embedded/Linked/Signed Custom Frameworks via updated node-xcode

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -305,6 +305,8 @@ function PluginInfo(dirname) {
                 type: el.attrib.type,
                 parent: el.attrib.parent,
                 custom: isStrTrue(el.attrib.custom),
+                embed: el.attrib.embed === undefined ? undefined : isStrTrue(el.attrib.embed),
+                link: el.attrib.link === undefined ? undefined : isStrTrue(el.attrib.link),
                 src: el.attrib.src,
                 weak: isStrTrue(el.attrib.weak),
                 versions: el.attrib.versions,

--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -309,6 +309,7 @@ function PluginInfo(dirname) {
                 link: el.attrib.link === undefined ? undefined : isStrTrue(el.attrib.link),
                 src: el.attrib.src,
                 weak: isStrTrue(el.attrib.weak),
+                sign: isStrTrue(el.attrib.sign),
                 versions: el.attrib.versions,
                 targetDir: el.attrib['target-dir'],
                 deviceTarget: el.attrib['device-target'] || el.attrib.target,

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -65,7 +65,7 @@
     "underscore": "1.7.0",
     "unorm": "1.3.3",
     "valid-identifier": "0.0.1",
-    "xcode": "0.8.4"
+    "xcode": "0.8.6"
   },
   "bundledDependencies": [
     "cordova-common"

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -65,7 +65,7 @@
     "underscore": "1.7.0",
     "unorm": "1.3.3",
     "valid-identifier": "0.0.1",
-    "xcode": "0.8.0"
+    "xcode": "0.8.4"
   },
   "bundledDependencies": [
     "cordova-common"

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -269,7 +269,7 @@ describe('ios project handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), {customFramework:true});
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), {customFramework:true, embed:true, link:undefined});
             });
 
             // TODO: Add more tests to cover the cases:
@@ -299,6 +299,21 @@ describe('ios project handler', function() {
                                                      path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin'));
                 });
             });
+
+            it('with embed="false" attribute should call into xcodeproj\'s addFramework accordingly', function() {
+                var frameworks = copyArray(valid_custom_frameworks);
+                var spy = spyOn(proj_files.xcode, 'addFramework');
+                ios['framework'].install(frameworks[1], dummyplugin, temp, dummy_id, null, proj_files);
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/NonEmbeddable.framework'), {customFramework:true, embed:false, link:undefined});
+            });
+
+            it('with link="false" attribute should call into xcodeproj\'s addFramework accordingly', function() {
+                var frameworks = copyArray(valid_custom_frameworks);
+                var spy = spyOn(proj_files.xcode, 'addFramework');
+                ios['framework'].install(frameworks[2], dummyplugin, temp, dummy_id, null, proj_files);
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Unlinkable.framework'), {customFramework:true, embed:false, link:false});
+            });
+
         });
         it('of two plugins should apply xcode file changes from both', function(){
             runs(function() {

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -269,7 +269,7 @@ describe('ios project handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), {customFramework:true, embed:true, link:undefined});
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), {customFramework:true, embed:true, link:undefined, sign:false});
             });
 
             // TODO: Add more tests to cover the cases:
@@ -304,16 +304,22 @@ describe('ios project handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[1], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/NonEmbeddable.framework'), {customFramework:true, embed:false, link:undefined});
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/NonEmbeddable.framework'), {customFramework:true, embed:false, link:undefined, sign:false});
             });
 
             it('with link="false" attribute should call into xcodeproj\'s addFramework accordingly', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[2], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Unlinkable.framework'), {customFramework:true, embed:false, link:false});
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Unlinkable.framework'), {customFramework:true, embed:false, link:false, sign:false});
             });
 
+            it('with sign="true" attribute should call into xcodeproj\'s addFramework accordingly', function() {
+                var frameworks = copyArray(valid_custom_frameworks);
+                var spy = spyOn(proj_files.xcode, 'addFramework');
+                ios['framework'].install(frameworks[3], dummyplugin, temp, dummy_id, null, proj_files);
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Signable.framework'), {customFramework:true, embed:true, link:undefined, sign:true});
+            });
         });
         it('of two plugins should apply xcode file changes from both', function(){
             runs(function() {
@@ -325,19 +331,18 @@ describe('ios project handler', function() {
             waitsFor(function() { return done; }, 'install promise never resolved', 200);
             runs(function() {
                 var xcode = ios.parseProjectFile(temp).xcode;
-                // from org.test.plugins.dummyplugin
-                expect(xcode.hasFile(slashJoin('Resources', 'DummyPlugin.bundle'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin', 'DummyPluginCommand.h'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin', 'DummyPluginCommand.m'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.h'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.m'))).toBe(true);
-                expect(xcode.hasFile('usr/lib/src/ios/libsqlite3.dylib')).toBe(true);
-                expect(xcode.hasFile(slashJoin('SampleApp','Plugins','org.test.plugins.dummyplugin','Custom.framework'))).toBe(true);
+                expect(xcode.hasFile(slashJoin('Resources', 'DummyPlugin.bundle'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin', 'DummyPluginCommand.h'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin', 'DummyPluginCommand.m'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.h'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.m'))).toBeTruthy();
+                expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('SampleApp','Plugins','org.test.plugins.dummyplugin','Custom.framework'))).toBeTruthy();
                 // from org.test.plugins.weblessplugin
-                expect(xcode.hasFile(slashJoin('Resources', 'WeblessPluginViewController.xib'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.h'))).toBe(true);
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.m'))).toBe(true);
-                expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBe(true);
+                expect(xcode.hasFile(slashJoin('Resources', 'WeblessPluginViewController.xib'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.h'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.m'))).toBeTruthy();
+                expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBeTruthy();
             });
         });
     });

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
@@ -133,10 +133,11 @@
 
         <!-- framework for testing (not actual dependency of org.test.plugins.dummyplugin -->
         <framework src="src/ios/libsqlite3.dylib" />
-        <framework src="src/ios/libsqlite3.dylib" weak="true" />
+        <framework src="src/ios/weaklibsqlite3.dylib" weak="true" />
         <framework src="src/ios/Custom.framework" custom="true" />
         <framework src="src/ios/NonEmbeddable.framework" custom="true" embed="false" />
         <framework src="src/ios/Unlinkable.framework" custom="true" embed="false" link="false" />
+        <framework src="src/ios/Signable.framework" custom="true" embed="true" sign="true" />
     </platform>
 
     <!-- wp8 -->

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
@@ -135,6 +135,8 @@
         <framework src="src/ios/libsqlite3.dylib" />
         <framework src="src/ios/libsqlite3.dylib" weak="true" />
         <framework src="src/ios/Custom.framework" custom="true" />
+        <framework src="src/ios/NonEmbeddable.framework" custom="true" embed="false" />
+        <framework src="src/ios/Unlinkable.framework" custom="true" embed="false" link="false" />
     </platform>
 
     <!-- wp8 -->

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/someFheader.h
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/someFheader.h
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/someFheader.h

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/somebinlib
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/somebinlib
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/NonEmbeddable.framework/somebinlib

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Signable.framework/someFheader.h
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Signable.framework/someFheader.h
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/Signable.framework/someFheader.h

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Signable.framework/somebinlib
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Signable.framework/somebinlib
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/Signable.framework/somebinlib

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Unlinkable.framework/someFheader.h
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/Unlinkable.framework/someFheader.h
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/Unlinkable.framework/someFheader.h

--- a/cordova-lib/src/plugman/platforms/ios.js
+++ b/cordova-lib/src/plugman/platforms/ios.js
@@ -147,7 +147,8 @@ module.exports = {
             var src = obj.src,
                 custom = obj.custom,
                 embed = obj.embed === undefined || obj.embed, /*defaults to true if not specified to keep behavior from CB-9517*/
-                link = obj.link;
+                link = obj.link,
+                sign = obj.sign;
 
             if (!custom) {
                 var keepFrameworks = keep_these_frameworks;
@@ -169,7 +170,7 @@ module.exports = {
             shell.mkdir('-p', path.dirname(targetDir));
             shell.cp('-R', srcFile, path.dirname(targetDir)); // frameworks are directories
             var project_relative = path.relative(project_dir, targetDir);
-            project.xcode.addFramework(project_relative, {customFramework: true, embed: embed, link: link});
+            project.xcode.addFramework(project_relative, {customFramework: true, embed: embed, link: link, sign:sign});
         },
         uninstall:function(obj, project_dir, plugin_id, options, project) {
             var src = obj.src;

--- a/cordova-lib/src/plugman/platforms/ios.js
+++ b/cordova-lib/src/plugman/platforms/ios.js
@@ -94,39 +94,6 @@ function uninstallHelper(type, obj, project_dir, plugin_id, options, project) {
     }
 }
 
-// special handlers to add frameworks to the 'Embed Frameworks' build phase, needed for custom frameworks
-// see CB-9517. should probably be moved to node-xcode.
-var util = require('util');
-function pbxBuildPhaseObj(file) {
-    var obj = Object.create(null);
-    obj.value = file.uuid;
-    obj.comment = longComment(file);
-    return obj;
-}
-
-function longComment(file) {
-    return util.format('%s in %s', file.basename, file.group);
-}
-
-xcode.project.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
-};
-
-xcode.project.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
-    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
-    if (sources) {
-        sources.files.push(pbxBuildPhaseObj(file));
-    }
-};
-xcode.project.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
-    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
-    if (sources) {
-        sources.files = _.reject(sources.files, function(file){
-            return file.comment === longComment(file);
-        });
-    }
-};
-
 // These frameworks are required by cordova-ios by default. We should never add/remove them.
 var keep_these_frameworks = [
     'MobileCoreServices.framework',
@@ -178,7 +145,9 @@ module.exports = {
     'framework':{ // CB-5238 custom frameworks only
         install:function(obj, plugin_dir, project_dir, plugin_id, options, project) {
             var src = obj.src,
-                custom = obj.custom;
+                custom = obj.custom,
+                embed = obj.embed === undefined || obj.embed, /*defaults to true if not specified to keep behavior from CB-9517*/
+                link = obj.link;
 
             if (!custom) {
                 var keepFrameworks = keep_these_frameworks;
@@ -200,10 +169,7 @@ module.exports = {
             shell.mkdir('-p', path.dirname(targetDir));
             shell.cp('-R', srcFile, path.dirname(targetDir)); // frameworks are directories
             var project_relative = path.relative(project_dir, targetDir);
-            var pbxFile = project.xcode.addFramework(project_relative, {customFramework: true});
-            if (pbxFile) {
-                project.xcode.addToPbxEmbedFrameworksBuildPhase(pbxFile);
-            }
+            project.xcode.addFramework(project_relative, {customFramework: true, embed: embed, link: link});
         },
         uninstall:function(obj, project_dir, plugin_id, options, project) {
             var src = obj.src;
@@ -226,11 +192,8 @@ module.exports = {
                 return;
             }
 
-            var targetDir = path.resolve(project.plugins_dir, plugin_id, path.basename(src)),
-                pbxFile = project.xcode.removeFramework(targetDir, {customFramework: true});
-            if (pbxFile) {
-                project.xcode.removeFromPbxEmbedFrameworksBuildPhase(pbxFile);
-            }
+            var targetDir = path.resolve(project.plugins_dir, plugin_id, path.basename(src));
+            project.xcode.removeFramework(targetDir, {customFramework: true});
             shell.rm('-rf', targetDir);
         }
     },


### PR DESCRIPTION
- Moved previously committed node-xcode extension to that project. Waiting PR: https://github.com/alunny/node-xcode/pull/79 and https://github.com/alunny/node-xcode/pull/88
- Added options and tests for iOS frameworks to not be optionally "embedded" or "linked" depending on the use cases.
