### PR TITLE
CB-10328 set top-level property of plugins when adding new platforms

### DIFF
--- a/cordova-lib/spec-cordova/platform.spec.js
+++ b/cordova-lib/spec-cordova/platform.spec.js
@@ -201,3 +201,50 @@ describe('add function', function () {
         });
     });
 });
+
+describe('platform add plugin rm end-to-end', function () {
+
+    var tmpDir = helpers.tmpDir('plugin_rm_test');
+    var project = path.join(tmpDir, 'hello');
+    var pluginsDir = path.join(project, 'plugins');
+    
+    beforeEach(function() {
+        process.chdir(tmpDir);
+    });
+    
+    afterEach(function() {
+        process.chdir(path.join(__dirname, '..'));  // Needed to rm the dir on Windows.
+        shell.rm('-rf', tmpDir);
+    });
+
+    it('should remove dependency when removing parent plugin', function(done) {
+        
+        cordova.raw.create('hello')
+        .then(function() {
+            process.chdir(project);
+            return cordova.raw.platform('add', 'ios');
+        })
+        .then(function() {
+            return cordova.raw.plugin('add', 'cordova-plugin-media');
+        })
+        .then(function() {
+            expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
+            expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
+            return cordova.raw.platform('add', 'android');
+        })
+        .then(function() {
+            expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
+            expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
+            return cordova.raw.plugin('rm', 'cordova-plugin-media');
+        })
+        .then(function() {
+            expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
+            expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
+        })
+        .fail(function(err) {
+            console.error(err);
+            expect(err).toBeUndefined();
+        })
+        .fin(done);
+    }, 20000);
+});

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -644,6 +644,9 @@ function installPluginsForNewPlatform(platform, projectRoot, opts) {
             events.emit('verbose', 'Installing plugin "' + plugin + '" following successful platform add of ' + platform);
             plugin = path.basename(plugin);
 
+            // Get plugin variables from fetch.json if have any and pass them as cli_variables to plugman
+            var pluginMetadata = fetchMetadata.get_fetch_metadata(path.join(plugins_dir, plugin));
+
             var options = {
                 searchpath: opts.searchpath,
                 // Set up platform to install asset files/js modules to <platform>/platform_www dir
@@ -654,11 +657,10 @@ function installPluginsForNewPlatform(platform, projectRoot, opts) {
                 // NOTE: there is another code path for plugin installation (see CB-10274 and the
                 // related PR: https://github.com/apache/cordova-lib/pull/360) so we need to
                 // specify the option below in both places
-                usePlatformWww: true
+                usePlatformWww: true,
+                is_top_level: pluginMetadata.is_top_level
             };
 
-            // Get plugin variables from fetch.json if have any and pass them as cli_variables to plugman
-            var pluginMetadata = fetchMetadata.get_fetch_metadata(path.join(plugins_dir, plugin));
             var variables = pluginMetadata && pluginMetadata.variables;
             if (variables) {
                 events.emit('verbose', 'Found variables for "' + plugin + '". Processing as cli_variables.');

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -71,7 +71,8 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
     project_dir = cordovaUtil.convertToRealPathSafe(project_dir);
     plugins_dir = cordovaUtil.convertToRealPathSafe(plugins_dir);
     options = options || {};
-    options.is_top_level = true;
+    if (options.is_top_level === undefined)
+        options.is_top_level = true;
     plugins_dir = plugins_dir || path.join(project_dir, 'cordova', 'plugins');
 
     if (!platform_modules[platform]) {

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -71,7 +71,7 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
     project_dir = cordovaUtil.convertToRealPathSafe(project_dir);
     plugins_dir = cordovaUtil.convertToRealPathSafe(plugins_dir);
     options = options || {};
-    if (options.is_top_level === undefined)
+  if (options.hasOwnProperty('is_top_level') === false)
         options.is_top_level = true;
     plugins_dir = plugins_dir || path.join(project_dir, 'cordova', 'plugins');
 


### PR DESCRIPTION
The problem is caused by not setting the top-level property of plugins from cordova/platform.js-installPluginsForNewPlatform() function and by always setting is_top_level to true in plugman/install.js-installPlugin.
This caused all plugins that exist in the plugins directory to be set top-level in plugins/<platform>.json files.
The uninstallation process relies on this metadata file to see if there is any dependency plugin was installed when removing a top-level plugin.
By setting the top-level correctly in <platform>.json files, this uninstallation process worked correctly.

After this fix is applied, here is how the behavior is changed:
```
[CB-10328] cordova plugin
cordova-plugin-file 4.1.1 "File"
cordova-plugin-media 2.1.0 "Media"
cordova-plugin-whitelist 1.2.1 "Whitelist"
[CB-10328] cordova plugin rm cordova-plugin-media
Uninstalling 1 dependent plugins.
Uninstalling cordova-plugin-file from android
Uninstalling cordova-plugin-media from android
Uninstalling 1 dependent plugins.
Uninstalling cordova-plugin-file from ios
Uninstalling cordova-plugin-media from ios
Removing "cordova-plugin-media"
[CB-10328] cordova plugin
cordova-plugin-whitelist 1.2.1 "Whitelist"
```