### PR TITLE
CB-10708 Install/uninstall plugins correctly into CLI project using plugman

### DIFF
--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -385,6 +385,11 @@ function runInstall(actions, platform, project_dir, plugin_dir, plugins_dir, opt
                     nohooks: options.nohooks
                 };
 
+                // CB-10708 This is the case when we're trying to install plugin using plugman to specific
+                // platform inside of the existing CLI project. In this case we need to put plugin's files
+                // into platform_www but plugman CLI doesn't allow us to do that, so we set it here
+                options.usePlatformWww = true;
+
                 var hooksRunner = new HooksRunner(projectRoot);
 
                 return hooksRunner.fire('before_plugin_install', hookOptions).then(function() {

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -303,6 +303,11 @@ function runUninstallPlatform(actions, platform, project_dir, plugin_dir, plugin
             }
         };
 
+        // CB-10708 This is the case when we're trying to uninstall plugin using plugman from specific
+        // platform inside of the existing CLI project. This option is usually set by cordova-lib for CLI projects
+        // but since we're running this code through plugman, we need to set it here implicitly
+        options.usePlatformWww = true;
+
         var hooksRunner = new HooksRunner(projectRoot);
 
         return promise.then(function() {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CB-10708

This forces plugman to install plugin's www files to `platform_www` directory instead of `www` (see also https://github.com/apache/cordova-lib/pull/360 for background) when cordova CLI project detected. This allows to install plugins for each platform separately.