### PR TITLE
CB-10673 added --force-copying-src option

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -654,7 +654,8 @@ function installPluginsForNewPlatform(platform, projectRoot, opts) {
                 // NOTE: there is another code path for plugin installation (see CB-10274 and the
                 // related PR: https://github.com/apache/cordova-lib/pull/360) so we need to
                 // specify the option below in both places
-                usePlatformWww: true
+                usePlatformWww: true,
+                forceCopyingSrc: opts.forceCopyingSrc
             };
 
             // Get plugin variables from fetch.json if have any and pass them as cli_variables to plugman

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -655,7 +655,7 @@ function installPluginsForNewPlatform(platform, projectRoot, opts) {
                 // related PR: https://github.com/apache/cordova-lib/pull/360) so we need to
                 // specify the option below in both places
                 usePlatformWww: true,
-                forceCopyingSrc: opts.forceCopyingSrc
+                force: opts.force
             };
 
             // Get plugin variables from fetch.json if have any and pass them as cli_variables to plugman

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -193,7 +193,7 @@ module.exports = function plugin(command, targets, opts) {
                                     // files platform_www directory, so they'll be applied to www on each prepare.
                                     usePlatformWww: true,
                                     nohooks: opts.nohooks,
-                                    forceCopyingSrc: opts.forceCopyingSrc
+                                    force: opts.force
                                 };
 
                                 events.emit('verbose', 'Calling plugman.install on plugin "' + pluginInfo.dir + '" for platform "' + platform);

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -192,7 +192,8 @@ module.exports = function plugin(command, targets, opts) {
                                     // and files from 'platform_www' merged into 'www'. Thus we need to persist these
                                     // files platform_www directory, so they'll be applied to www on each prepare.
                                     usePlatformWww: true,
-                                    nohooks: opts.nohooks
+                                    nohooks: opts.nohooks,
+                                    forceCopyingSrc: opts.forceCopyingSrc
                                 };
 
                                 events.emit('verbose', 'Calling plugman.install on plugin "' + pluginInfo.dir + '" for platform "' + platform);


### PR DESCRIPTION
This option is need to rescue some Cordova users who has trouble installing two conflicting plugins that use the same source-file target.