### PR TITLE
CB-10961 Error when adding ios platform and plugin declare in config.xml

### DIFF
--- a/cordova-lib/spec-cordova/platform.spec.js
+++ b/cordova-lib/spec-cordova/platform.spec.js
@@ -145,7 +145,7 @@ describe('platform end-to-end', function () {
         .fin(done);
     });
 
-    it('should call prepare after plugins were installed into platform', function(done) {
+    it('should call prepare before and after plugins were installed into platform', function(done) {
         var order = '';
         var fail = jasmine.createSpy(fail);
         spyOn(plugman.raw, 'install').andCallFake(function() { order += 'I'; });
@@ -157,7 +157,7 @@ describe('platform end-to-end', function () {
         })
         .fail(fail)
         .fin(function() {
-            expect(order).toBe('IP'); // Install first, then prepare
+            expect(order).toBe('PIP'); // Install first, then prepare
             expect(fail).not.toHaveBeenCalled();
             done();
         });


### PR DESCRIPTION
@vladimir-kotikov can you review 
This other commit https://github.com/apache/cordova-lib/commit/3b9face5187857d354d85f3e3f4316cbace100db 
changing the order to run prepare after plugin install cause the problem. I added a prepare before, and left the prepare on after plugin install.
I don't think there is harm on running prepare twice on platform add
