### PR TITLE
CB-10965 xml helper allows multiple instances to be merge in config.xml

### DIFF
--- a/cordova-common/spec/util/xml-helpers.spec.js
+++ b/cordova-common/spec/util/xml-helpers.spec.js
@@ -207,6 +207,16 @@ describe('xml-helpers', function(){
             expect(testElements[0].attrib.email).toEqual('dev@cordova.apache.org');
             expect(testElements[0].text).toContain('Apache Cordova Team');
         });
+        
+        it('should merge singelton name without clobber', function () {
+            var testXml = et.XML('<widget><name>SUPER_NAME</name></widget>');
+
+            xml_helpers.mergeXml(testXml, dstXml);
+            var testElements = dstXml.findall('name');
+            expect(testElements).toBeDefined();
+            expect(testElements.length).toEqual(1);
+            expect(testElements[0].text).toContain('Hello Cordova');
+        });
 
         it('should clobber singelton children with clobber', function () {
             var testXml = et.XML('<widget><author testAttrib="value" href="http://www.nowhere.com">SUPER_AUTHOR</author></widget>');
@@ -219,6 +229,16 @@ describe('xml-helpers', function(){
             expect(testElements[0].attrib.href).toEqual('http://www.nowhere.com');
             expect(testElements[0].attrib.email).toEqual('dev@cordova.apache.org');
             expect(testElements[0].text).toEqual('SUPER_AUTHOR');
+        });
+        
+        it('should merge singelton name with clobber', function () {
+            var testXml = et.XML('<widget><name>SUPER_NAME</name></widget>');
+
+            xml_helpers.mergeXml(testXml, dstXml, '', true);
+            var testElements = dstXml.findall('name');
+            expect(testElements).toBeDefined();
+            expect(testElements.length).toEqual(1);
+            expect(testElements[0].text).toContain('SUPER_NAME');
         });
 
         it('should append non singelton children', function () {

--- a/cordova-common/src/util/xml-helpers.js
+++ b/cordova-common/src/util/xml-helpers.js
@@ -194,7 +194,7 @@ function findInsertIdx(children, after) {
 }
 
 var BLACKLIST = ['platform', 'feature','plugin','engine'];
-var SINGLETONS = ['content', 'author'];
+var SINGLETONS = ['content', 'author', 'name'];
 function mergeXml(src, dest, platform, clobber) {
     // Do nothing for blacklisted tags.
     if (BLACKLIST.indexOf(src.tag) != -1) return;


### PR DESCRIPTION
@vladimir-kotikov I think this is the real fix on duplicate names ending up in final config.xml triggering the unwanted rename of the xcode project in ios
