### PR TITLE
CB-10981 Remove cordova-common from bundled dependencies

### DIFF
--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -42,9 +42,6 @@
         "valid-identifier": "0.0.1",
         "xcode": "0.8.0"
     },
-    "bundledDependencies": [
-        "cordova-common"
-    ],
     "devDependencies": {
         "codecov": "^1.0.1",
         "istanbul": "^0.3.4",


### PR DESCRIPTION
Since cordova-common has been released to NPM we do not need to bundle it into cordova-lib release packages. See [CB-10981](https://issues.apache.org/jira/browse/CB-10981)