### PR TITLE
CB-10921 Emit warning in case of plugin restoration failure

### DIFF
--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -156,8 +156,8 @@ module.exports = function plugin(command, targets, opts) {
                             });
 
                             if (missingVariables.length) {
-                                shell.rm('-rf', pluginInfo.dir);
                                 events.emit('verbose', 'Removing ' + pluginInfo.dir + ' due to installation failure');
+                                shell.rm('-rf', pluginInfo.dir);
                                 var msg = 'Variable(s) missing (use: --variable ' + missingVariables.join('=value --variable ') + '=value).';
                                 return Q.reject(new CordovaError(msg));
                             }

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -157,6 +157,7 @@ module.exports = function plugin(command, targets, opts) {
 
                             if (missingVariables.length) {
                                 shell.rm('-rf', pluginInfo.dir);
+                                events.emit('verbose', 'Removing ' + pluginInfo.dir + ' due to installation failure');
                                 var msg = 'Variable(s) missing (use: --variable ' + missingVariables.join('=value --variable ') + '=value).';
                                 return Q.reject(new CordovaError(msg));
                             }


### PR DESCRIPTION
This PR adds a warning if plugin restore failed due to some reason. See [CB-10921](https://issues.apache.org/jira/browse/CB-10921)