### PR TITLE
CB-10770 Remove cache-min when adding platforms

### DIFF
--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -147,10 +147,7 @@ function cordova_npm(platform) {
 // Returns a promise that resolves to directory containing the package.
 function npm_cache_add(pkg) {
     var npm_cache_dir = path.join(util.libDirectory, 'npm_cache');
-    // 'cache-min' is the time in seconds npm considers the files fresh and
-    // does not ask the registry if it got a fresher version.
     var platformNpmConfig = {
-        'cache-min': 3600*24,
         cache: npm_cache_dir
     };
 

--- a/cordova-lib/src/cordova/remote_load.js
+++ b/cordova-lib/src/cordova/remote_load.js
@@ -72,7 +72,6 @@ function npmCacheAdd(npmPackage) {
     cacheDir = path.join(util.libDirectory, 'npm_cache');
 
     npmConfig = {
-        'cache-min': 3600 * 24,
         'cache': cacheDir
     };
 


### PR DESCRIPTION
When we release platforms it takes a day for people to be able to use them. This is sub-optimal and removing the timeout to keep the cache fresh makes sense.