### PR TITLE
CB-11022 Improve performance of `cordova plugin add` command

### DIFF
--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -234,7 +234,7 @@ function runUninstallPlatform(actions, platform, project_dir, plugin_dir, plugin
     var pluginInfoProvider = options.pluginInfoProvider;
     // If this plugin is not really installed, return (CB-7004).
     if (!fs.existsSync(plugin_dir)) {
-        return Q();
+        return Q(true);
     }
 
     var pluginInfo = pluginInfoProvider.get(plugin_dir);
@@ -332,7 +332,7 @@ function handleUninstall(actions, platform, pluginInfo, project_dir, www_dir, pl
     options.usePlatformWww = true;
     return platform_modules.getPlatformApi(platform, project_dir)
     .removePlugin(pluginInfo, options)
-    .then(function() {
+    .then(function(result) {
         // Remove plugin from installed list. This already done in platform,
         // but need to be duplicated here to remove plugin entry from project's
         // plugin list to manage dependencies properly.
@@ -359,5 +359,8 @@ function handleUninstall(actions, platform, pluginInfo, project_dir, www_dir, pl
                 buildModule.prepBuildFiles();
             }
         }
+
+        // CB-11022 propagate `removePlugin` result to the caller
+        return Q(result);
     });
 }


### PR DESCRIPTION
This addresses [CB-11022](https://issues.apache.org/jira/browse/CB-11022) and dramaticaly reduces time required for plugin installation (especially for the projects with a lot of www assets) by skipping prepare after each plugin install.

This change also requires a corresponding update for the platforms that implement PlatformApi contract (see https://github.com/apache/cordova-android/pull/289) - they have to take care of installing (or removing) their js and www files into both `www` and `platform_www` directories and return any non-falsy value as a result of `addPlugin`/`removePlugin` methods

Also a side note: this fix is an interim solution and ideally we should not running `prepare` after plugin installation at all, despite of what platform has reported. Unfortunately this might break some usage scenarios and would put application into broken state when platform is not updated in a proper way (as in https://github.com/apache/cordova-android/pull/289) - just as described in [CB-9617](https://issues.apache.org/jira/browse/CB-9617). I think that `prepare` removal is a good candidate for major release, when some breaking changes are expected.

UPDATE: to test this change i used modified version of `vs-tac` to be able to use custom android platform version instead of pinned one. To do this you need to modify `vs-tac/app.js` and change `return cordova.raw.platform('add', 'android');` -> `return cordova.raw.platform('add', 'local/android/platform');`