### PR TITLE
CB-11062 Add --recursive option to git clone command

### DIFF
--- a/cordova-lib/src/gitclone.js
+++ b/cordova-lib/src/gitclone.js
@@ -44,7 +44,7 @@ function clone(git_url, git_ref, clone_dir){
     shell.rm('-rf', tmp_dir);
     shell.mkdir('-p', tmp_dir);
     
-    var cloneArgs = ['clone'];
+    var cloneArgs = ['clone', '--recursive'];
     if(!needsGitCheckout) {
         // only get depth of 1 if there is no branch/commit specified
         cloneArgs.push('--depth=1');


### PR DESCRIPTION
Support cordova plugins that make use of git submodules.

ref: https://issues.apache.org/jira/browse/CB-11062
