### PR TITLE
CB-10986: Adding support for scoped npm package plugins

### DIFF
--- a/cordova-lib/spec-cordova/plugin.spec.js
+++ b/cordova-lib/spec-cordova/plugin.spec.js
@@ -190,4 +190,39 @@ describe('plugin end-to-end', function() {
         .fail(errorHandler.errorCallback)
         .fin(done);
     });
+
+    it('should handle scoped npm packages', function(done) {
+        var scopedPackage = '@testscope/' + npmInfoTestPlugin;
+        mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
+
+        spyOn(registry, 'info').andReturn(Q({}));
+        addPlugin(scopedPackage, npmInfoTestPlugin, {}, done)
+        .then(function() {
+            // Check to make sure that we are at least trying to get the correct package.
+            // This package is not published to npm, so we can't truly do end-to-end tests
+
+            expect(registry.info).toHaveBeenCalledWith([scopedPackage]);
+
+            var fetchTarget = plugman.raw.fetch.mostRecentCall.args[0];
+            expect(fetchTarget).toEqual(scopedPackage);
+        })
+        .fail(errorHandler.errorCallback)
+        .fin(done);
+    });
+
+    it('should handle scoped npm packages with given version tags', function(done) {
+        var scopedPackage = '@testscope/' + npmInfoTestPlugin + '@latest';
+        mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
+
+        spyOn(registry, 'info');
+        addPlugin(scopedPackage, npmInfoTestPlugin, {}, done)
+        .then(function() {
+            expect(registry.info).not.toHaveBeenCalled();
+
+            var fetchTarget = plugman.raw.fetch.mostRecentCall.args[0];
+            expect(fetchTarget).toEqual(scopedPackage);
+        })
+        .fail(errorHandler.errorCallback)
+        .fin(done);
+    });
 });

--- a/cordova-lib/spec-cordova/plugin_package_parse.spec.js
+++ b/cordova-lib/spec-cordova/plugin_package_parse.spec.js
@@ -1,0 +1,59 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var pluginSpec = require('../src/cordova/plugin_spec_parser');
+
+describe('methods for parsing npm plugin packages', function() {
+
+    function checkPluginSpecParsing(testString, scope, id, version) {
+        var parsedSpec = pluginSpec.parse(testString);
+        expect(parsedSpec.scope).toEqual(scope);
+        expect(parsedSpec.id).toEqual(id || testString);
+        expect(parsedSpec.version).toEqual(version);
+        expect(parsedSpec.package).toEqual(scope ? scope + id : id);
+    }
+
+    it('should handle package names with no scope or version', function() {
+        checkPluginSpecParsing('test-plugin', null, 'test-plugin', null);
+    });
+    it('should handle package names with a version', function() {
+        checkPluginSpecParsing('test-plugin@1.0.0', null, 'test-plugin', '1.0.0');
+        checkPluginSpecParsing('test-plugin@latest', null, 'test-plugin', 'latest');
+    });
+    it('should handle package names with a scope', function() {
+        checkPluginSpecParsing('@test/test-plugin', '@test/', 'test-plugin', null);
+    });
+    it('should handle package names with a scope and a version', function() {
+        checkPluginSpecParsing('@test/test-plugin@1.0.0', '@test/', 'test-plugin', '1.0.0');
+        checkPluginSpecParsing('@test/test-plugin@latest', '@test/', 'test-plugin', 'latest');
+    });
+    it('should handle invalid package specs', function() {
+        checkPluginSpecParsing('@nonsense', null, null, null);
+        checkPluginSpecParsing('@/nonsense', null, null, null);
+        checkPluginSpecParsing('@', null, null, null);
+        checkPluginSpecParsing('@nonsense@latest', null, null, null);
+        checkPluginSpecParsing('@/@', null, null, null);
+        checkPluginSpecParsing('/', null, null, null);
+        checkPluginSpecParsing('../../@directory', null, null, null);
+        checkPluginSpecParsing('@directory/../@directory', null, null, null);
+        checkPluginSpecParsing('./directory', null, null, null);
+        checkPluginSpecParsing('directory/directory', null, null, null);
+        checkPluginSpecParsing('http://cordova.apache.org', null, null, null);
+    });
+});

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -204,6 +204,44 @@ describe('util module', function() {
             expect(res.indexOf('CVS')).toEqual(-1);
         });
     });
+
+    describe('methods for parsing scoped plugin packages', function() {
+
+        function checkPluginSpecParsing(testString, scope, package, version) {
+            expect(util.parseRegistryPluginSpec(testString)).toEqual([scope ? scope + package : package, version]);
+            expect(util.extractPluginId(testString)).toEqual(package || testString);
+            expect(util.isScopedRegistryPluginSpec(testString)).toEqual(!!(scope && package));
+        }
+
+        it('should handle package names with no scope or version', function() {
+            checkPluginSpecParsing('test-plugin', null, 'test-plugin', null);
+        });
+        it('should handle package names with a version', function() {
+            checkPluginSpecParsing('test-plugin@1.0.0', null, 'test-plugin', '1.0.0');
+            checkPluginSpecParsing('test-plugin@latest', null, 'test-plugin', 'latest');
+        });
+        it('should handle package names with a scope', function() {
+            checkPluginSpecParsing('@test/test-plugin', '@test/', 'test-plugin', null);
+        });
+        it('should handle package names with a scope and a version', function() {
+            checkPluginSpecParsing('@test/test-plugin@1.0.0', '@test/', 'test-plugin', '1.0.0');
+            checkPluginSpecParsing('@test/test-plugin@latest', '@test/', 'test-plugin', 'latest');
+        });
+        it('should handle invalid package specs', function() {
+            checkPluginSpecParsing('@nonsense', null, null, null);
+            checkPluginSpecParsing('@/nonsense', null, null, null);
+            checkPluginSpecParsing('@', null, null, null);
+            checkPluginSpecParsing('@nonsense@latest', null, null, null);
+            checkPluginSpecParsing('@/@', null, null, null);
+            checkPluginSpecParsing('/', null, null, null);
+            checkPluginSpecParsing('../../@directory', null, null, null);
+            checkPluginSpecParsing('@directory/../@directory', null, null, null);
+            checkPluginSpecParsing('./directory', null, null, null);
+            checkPluginSpecParsing('directory/directory', null, null, null);
+            checkPluginSpecParsing('http://cordova.apache.org', null, null, null);
+        });
+    });
+
     describe('preprocessOptions method', function() {
 
         var isCordova, listPlatforms;

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -205,43 +205,6 @@ describe('util module', function() {
         });
     });
 
-    describe('methods for parsing scoped plugin packages', function() {
-
-        function checkPluginSpecParsing(testString, scope, package, version) {
-            expect(util.parseRegistryPluginSpec(testString)).toEqual([scope ? scope + package : package, version]);
-            expect(util.extractPluginId(testString)).toEqual(package || testString);
-            expect(util.isScopedRegistryPluginSpec(testString)).toEqual(!!(scope && package));
-        }
-
-        it('should handle package names with no scope or version', function() {
-            checkPluginSpecParsing('test-plugin', null, 'test-plugin', null);
-        });
-        it('should handle package names with a version', function() {
-            checkPluginSpecParsing('test-plugin@1.0.0', null, 'test-plugin', '1.0.0');
-            checkPluginSpecParsing('test-plugin@latest', null, 'test-plugin', 'latest');
-        });
-        it('should handle package names with a scope', function() {
-            checkPluginSpecParsing('@test/test-plugin', '@test/', 'test-plugin', null);
-        });
-        it('should handle package names with a scope and a version', function() {
-            checkPluginSpecParsing('@test/test-plugin@1.0.0', '@test/', 'test-plugin', '1.0.0');
-            checkPluginSpecParsing('@test/test-plugin@latest', '@test/', 'test-plugin', 'latest');
-        });
-        it('should handle invalid package specs', function() {
-            checkPluginSpecParsing('@nonsense', null, null, null);
-            checkPluginSpecParsing('@/nonsense', null, null, null);
-            checkPluginSpecParsing('@', null, null, null);
-            checkPluginSpecParsing('@nonsense@latest', null, null, null);
-            checkPluginSpecParsing('@/@', null, null, null);
-            checkPluginSpecParsing('/', null, null, null);
-            checkPluginSpecParsing('../../@directory', null, null, null);
-            checkPluginSpecParsing('@directory/../@directory', null, null, null);
-            checkPluginSpecParsing('./directory', null, null, null);
-            checkPluginSpecParsing('directory/directory', null, null, null);
-            checkPluginSpecParsing('http://cordova.apache.org', null, null, null);
-        });
-    });
-
     describe('preprocessOptions method', function() {
 
         var isCordova, listPlatforms;

--- a/cordova-lib/spec-plugman/fetch.spec.js
+++ b/cordova-lib/spec-plugman/fetch.spec.js
@@ -44,7 +44,7 @@ describe('fetch', function() {
         }).fin(done);
     }
     /*
-     * Taking out the following test. Fetch has a copyPlugin method that uses existsSync to see if a plugin already exists in the plugins folder. If the plugin exists in the plugins directory for the cordova project, it won't be copied over. This test fails now due it always returning true for existsSync. 
+     * Taking out the following test. Fetch has a copyPlugin method that uses existsSync to see if a plugin already exists in the plugins folder. If the plugin exists in the plugins directory for the cordova project, it won't be copied over. This test fails now due it always returning true for existsSync.
     describe('plugin in a dir with spaces', function() {
         it('should copy locally-available plugin to plugins directory when spaces in path', function(done) {
             // XXX: added this because plugman tries to fetch from registry when plugin folder does not exist
@@ -251,7 +251,7 @@ describe('fetch', function() {
 
         var srcDir = path.join(__dirname, 'plugins/recursivePlug');
         var appDir = path.join(__dirname, 'plugins/recursivePlug/demo');
-        
+
         if(/^win/.test(process.platform)) {
             it('should copy all but the /demo/ folder',function(done) {
                 var cp = spyOn(shell, 'cp');
@@ -310,6 +310,18 @@ describe('fetch', function() {
         it('should succeed when the plugin version specified is correct', function(done) {
             wrapper(fetch(pluginId, temp, { expected_id: test_plugin_id + '@' + test_plugin_version }), done, function() {
                 expect(1).toBe(1);
+            });
+        });
+        it('should fetch plugins that are scoped packages', function(done) {
+            var scopedPackage = '@testcope/dummy-plugin';
+            wrapper(fetch(scopedPackage, temp, { expected_id: test_plugin_id }), done, function() {
+                expect(sFetch).toHaveBeenCalledWith([scopedPackage]);
+            });
+        });
+        it('should fetch plugins that are scoped packages and have versions specified', function(done) {
+            var scopedPackage = '@testcope/dummy-plugin@latest';
+            wrapper(fetch(scopedPackage, temp, { expected_id: test_plugin_id }), done, function() {
+                expect(sFetch).toHaveBeenCalledWith([scopedPackage]);
             });
         });
     });

--- a/cordova-lib/src/cordova/plugin_spec_parser.js
+++ b/cordova-lib/src/cordova/plugin_spec_parser.js
@@ -1,0 +1,61 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+// npm packages follow the pattern of (@scope/)?package(@spec)? where scope and tag are optional
+var NPM_SPEC_REGEX = /^(@[^\/]+\/)?([^@\/]+)(?:@(.+))?$/;
+
+module.exports.parse = parse;
+
+/**
+ * Represents a parsed specification for a plugin
+ * @class
+ * @param {String} raw      The raw specification (i.e. provided by the user)
+ * @param {String} scope    The scope of the package if this is an npm package
+ * @param {String} id       The id of the package if this is an npm package
+ * @param {String} version  The version specified for the package if this is an npm package
+ */
+function PluginSpec(raw, scope, id, version) {
+    /** @member {String|null} The npm scope of the plugin spec or null if it does not have one */
+    this.scope = scope || null;
+
+    /** @member {String|null} The id of the plugin or the raw plugin spec if it is not an npm package */
+    this.id = id || raw;
+
+    /** @member {String|null} The specified version of the plugin or null if no version was specified */
+    this.version = version || null;
+
+    /** @member {String|null} The npm package of the plugin (with scope) or null if this is not a spec for an npm package */
+    this.package = (scope ? scope + id : id) || null;
+}
+
+/**
+ * Tries to parse the given string as an npm-style package specification of
+ * the form (@scope/)?package(@version)? and return the various parts.
+ *
+ * @param {String} raw  The string to be parsed
+ * @param {PluginSpec}  The parsed plugin spec
+ */
+function parse(raw) {
+    var split = NPM_SPEC_REGEX.exec(raw);
+    if (split) {
+        return new PluginSpec(raw, split[1], split[2], split[3]);
+    } else {
+        return new PluginSpec(raw);
+    }
+}

--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -30,9 +30,6 @@ var fs            = require('fs'),
     semver        = require('semver'),
     superspawn    = require('cordova-common').superspawn;
 
-// npm packages follow the pattern of (@scope/)?package(@spec)? where scope and tag are optional
-var NPM_SPEC_REGEX = /^((?:@[^\/]+\/)?)([^@\/]+)(?:@(.+))?$/;
-
 // Global configuration paths
 var global_config_path = process.env['CORDOVA_HOME'];
 if (!global_config_path) {
@@ -68,9 +65,6 @@ exports.isUrl = isUrl;
 exports.getLatestMatchingNpmVersion = getLatestMatchingNpmVersion;
 exports.getAvailableNpmVersions = getAvailableNpmVersions;
 exports.getInstalledPlatformsWithVersions = getInstalledPlatformsWithVersions;
-exports.parseRegistryPluginSpec = parseRegistryPluginSpec;
-exports.extractPluginId = extractPluginId;
-exports.isScopedRegistryPluginSpec = isScopedRegistryPluginSpec;
 
 function isUrl(value) {
     var u = value && url.parse(value);
@@ -406,49 +400,4 @@ function getAvailableNpmVersions(module_name) {
             return result[Object.keys(result)[0]].versions;
         });
     });
-}
-
-/**
- * Extracts the name and spec from an npm style package spec that follows the
- * format of (@scope/)?package(@spec)?
- * @param {String} raw  The raw npm style package spec
- * @returns {String[]}  An array containing the package name with optional scope
- *                      followed by the plugin spec (either value may be null
- *                      if not matched)
- */
-function parseRegistryPluginSpec(raw) {
-    var split = NPM_SPEC_REGEX.exec(raw);
-    if (split) {
-        var package = split[1] ? split[1] + split[2] : split[2];
-        var version = split[3] || null;
-        return [package, version];
-    } else {
-        return [null, null];
-    }
-}
-
-/**
- * Extracts the package name from an npm style package spec of the format
- * (@scope/)?package(@spec)?. Useful for getting the id used for directories
- * created for install
- * @param {String} raw  The raw npm style package spec
- * @returns {String}    The package name without scope or version or the original
- *                      string if it isn't an npm package spec
- */
-function extractPluginId(raw) {
-    var split = NPM_SPEC_REGEX.exec(raw);
-    return split ? split[2] : raw;
-}
-
-
-/**
- * Determines if a string is a package spec of the format @scope/package(@spec)?
- * or not
- * @param {String} raw  The raw npm style package spec
- * @returns {boolean}   True if the given string follows the format of an npm style
- *                      package spec or false otherwise
- */
-function isScopedRegistryPluginSpec(raw) {
-    var split = NPM_SPEC_REGEX.exec(raw);
-    return split ? !!(split[1] && split[2]) : false;
 }

--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -30,6 +30,9 @@ var fs            = require('fs'),
     semver        = require('semver'),
     superspawn    = require('cordova-common').superspawn;
 
+// npm packages follow the pattern of (@scope/)?package(@spec)? where scope and tag are optional
+var NPM_SPEC_REGEX = /^((?:@[^\/]+\/)?)([^@\/]+)(?:@(.+))?$/;
+
 // Global configuration paths
 var global_config_path = process.env['CORDOVA_HOME'];
 if (!global_config_path) {
@@ -65,6 +68,9 @@ exports.isUrl = isUrl;
 exports.getLatestMatchingNpmVersion = getLatestMatchingNpmVersion;
 exports.getAvailableNpmVersions = getAvailableNpmVersions;
 exports.getInstalledPlatformsWithVersions = getInstalledPlatformsWithVersions;
+exports.parseRegistryPluginSpec = parseRegistryPluginSpec;
+exports.extractPluginId = extractPluginId;
+exports.isScopedRegistryPluginSpec = isScopedRegistryPluginSpec;
 
 function isUrl(value) {
     var u = value && url.parse(value);
@@ -400,4 +406,49 @@ function getAvailableNpmVersions(module_name) {
             return result[Object.keys(result)[0]].versions;
         });
     });
+}
+
+/**
+ * Extracts the name and spec from an npm style package spec that follows the
+ * format of (@scope/)?package(@spec)?
+ * @param {String} raw  The raw npm style package spec
+ * @returns {String[]}  An array containing the package name with optional scope
+ *                      followed by the plugin spec (either value may be null
+ *                      if not matched)
+ */
+function parseRegistryPluginSpec(raw) {
+    var split = NPM_SPEC_REGEX.exec(raw);
+    if (split) {
+        var package = split[1] ? split[1] + split[2] : split[2];
+        var version = split[3] || null;
+        return [package, version];
+    } else {
+        return [null, null];
+    }
+}
+
+/**
+ * Extracts the package name from an npm style package spec of the format
+ * (@scope/)?package(@spec)?. Useful for getting the id used for directories
+ * created for install
+ * @param {String} raw  The raw npm style package spec
+ * @returns {String}    The package name without scope or version or the original
+ *                      string if it isn't an npm package spec
+ */
+function extractPluginId(raw) {
+    var split = NPM_SPEC_REGEX.exec(raw);
+    return split ? split[2] : raw;
+}
+
+
+/**
+ * Determines if a string is a package spec of the format @scope/package(@spec)?
+ * or not
+ * @param {String} raw  The raw npm style package spec
+ * @returns {boolean}   True if the given string follows the format of an npm style
+ *                      package spec or false otherwise
+ */
+function isScopedRegistryPluginSpec(raw) {
+    var split = NPM_SPEC_REGEX.exec(raw);
+    return split ? !!(split[1] && split[2]) : false;
 }

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -132,8 +132,9 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 ));
             }
             // If not found in local search path, fetch from the registry.
-            var splitVersion = plugin_src.split('@');
-            var newID = pluginMapperotn[splitVersion[0]];
+            var splitVersion = cordovaUtil.parseRegistryPluginSpec(plugin_src);
+            var oldId = splitVersion[0] || plugin_src;
+            var newID = pluginMapperotn[oldId];
             if(newID) {
                 plugin_src = newID;
                 if (splitVersion[1]) {
@@ -205,8 +206,9 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
 // Helper function for checking expected plugin IDs against reality.
 function checkID(expectedIdAndVersion, pinfo) {
     if (!expectedIdAndVersion) return;
-    var expectedId = expectedIdAndVersion.split('@')[0];
-    var expectedVersion = expectedIdAndVersion.split('@')[1];
+    var parts = cordovaUtil.parseRegistryPluginSpec(expectedIdAndVersion);
+    var expectedId = parts[0] || expectedIdAndVersion;
+    var expectedVersion = parts[1];
     if (expectedId != pinfo.id) {
         var alias = pluginMappernto[expectedId] || pluginMapperotn[expectedId];
         if (alias !== pinfo.id) {
@@ -260,8 +262,8 @@ function findLocalPlugin(plugin_src, searchpath, pluginInfoProvider) {
     loadLocalPlugins(searchpath, pluginInfoProvider);
     var id = plugin_src;
     var versionspec = '*';
-    if (plugin_src.indexOf('@') != -1) {
-        var parts = plugin_src.split('@');
+    var parts = cordovaUtil.parseRegistryPluginSpec(plugin_src);
+    if (parts[0] && parts[1]) {
         id = parts[0];
         versionspec = parts[1];
     }
@@ -313,7 +315,7 @@ function copyPlugin(pinfo, plugins_dir, link) {
     shell.rm('-rf', dest);
 
     if(!link && dest.indexOf(path.resolve(plugin_dir)) === 0) {
-        
+
         if(/^win/.test(process.platform)) {
             /*
                 [CB-10423]
@@ -330,7 +332,7 @@ function copyPlugin(pinfo, plugins_dir, link) {
             shell.mkdir('-p', dest);
             events.emit('verbose', 'Copying plugin "' + resolvedSrcPath + '" => "' + dest + '"');
             events.emit('verbose', 'Skipping folder "' + relativeRootFolder + '"');
-            
+
             filenames.forEach(function(elem) {
                 shell.cp('-R', path.join(resolvedSrcPath,elem) , dest);
             });

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -31,7 +31,8 @@ var shell   = require('shelljs'),
     Q       = require('q'),
     registry = require('./registry/registry'),
     pluginMappernto = require('cordova-registry-mapper').newToOld,
-    pluginMapperotn = require('cordova-registry-mapper').oldToNew;
+    pluginMapperotn = require('cordova-registry-mapper').oldToNew,
+    pluginSpec      = require('../cordova/plugin_spec_parser');
 var cordovaUtil = require('../cordova/util');
 
 // Cache of PluginInfo objects for plugins in search path.
@@ -132,31 +133,30 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 ));
             }
             // If not found in local search path, fetch from the registry.
-            var splitVersion = cordovaUtil.parseRegistryPluginSpec(plugin_src);
-            var oldId = splitVersion[0] || plugin_src;
-            var newID = pluginMapperotn[oldId];
+            var parsedSpec = pluginSpec.parse(plugin_src);
+            var newID = parsedSpec.scope ? null : pluginMapperotn[parsedSpec.id];
             if(newID) {
                 plugin_src = newID;
-                if (splitVersion[1]) {
-                    plugin_src += '@'+splitVersion[1];
+                if (parsedSpec.version) {
+                    plugin_src += '@' + parsedSpec.version;
                 }
             }
             var P, skipCopyingPlugin;
-            plugin_dir = path.join(plugins_dir, splitVersion[0]);
+            plugin_dir = path.join(plugins_dir, parsedSpec.id);
             // if the plugin has already been fetched, use it.
             if (fs.existsSync(plugin_dir)) {
                 P = Q(plugin_dir);
                 skipCopyingPlugin = true;
             } else {
                 // if the plugin alias has already been fetched, use it.
-                var alias = pluginMappernto[splitVersion[0]] || newID;
+                var alias = parsedSpec.scope ? null : pluginMappernto[parsedSpec.id] || newID;
                 if (alias && fs.existsSync(path.join(plugins_dir, alias))) {
-                    events.emit('warn', 'Found '+alias+' is already fetched. Skipped fetching '+splitVersion[0]);
+                    events.emit('warn', 'Found '+alias+' is already fetched. Skipped fetching ' + parsedSpec.id);
                     P = Q(path.join(plugins_dir, alias));
                     skipCopyingPlugin = true;
                 } else {
                     if (newID) {
-                        events.emit('warn', 'Notice: ' + splitVersion[0] + ' has been automatically converted to ' + newID + ' to be fetched from npm. This is due to our old plugins registry shutting down.');
+                        events.emit('warn', 'Notice: ' + parsedSpec.id + ' has been automatically converted to ' + newID + ' to be fetched from npm. This is due to our old plugins registry shutting down.');
                     }
                     P = registry.fetch([plugin_src]);
                     skipCopyingPlugin = false;
@@ -206,17 +206,17 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
 // Helper function for checking expected plugin IDs against reality.
 function checkID(expectedIdAndVersion, pinfo) {
     if (!expectedIdAndVersion) return;
-    var parts = cordovaUtil.parseRegistryPluginSpec(expectedIdAndVersion);
-    var expectedId = parts[0] || expectedIdAndVersion;
-    var expectedVersion = parts[1];
-    if (expectedId != pinfo.id) {
-        var alias = pluginMappernto[expectedId] || pluginMapperotn[expectedId];
+
+    var parsedSpec = pluginSpec.parse(expectedIdAndVersion);
+
+    if (parsedSpec.id != pinfo.id) {
+        var alias = parsedSpec.scope ? null : pluginMappernto[parsedSpec.id] || pluginMapperotn[parsedSpec.id];
         if (alias !== pinfo.id) {
-            throw new Error('Expected plugin to have ID "' + expectedId + '" but got "' + pinfo.id + '".');
+            throw new Error('Expected plugin to have ID "' + parsedSpec.id + '" but got "' + pinfo.id + '".');
         }
     }
-    if (expectedVersion && !semver.satisfies(pinfo.version, expectedVersion)) {
-        throw new Error('Expected plugin ' + pinfo.id + ' to satisfy version "' + expectedVersion + '" but got "' + pinfo.version + '".');
+    if (parsedSpec.version && !semver.satisfies(pinfo.version, parsedSpec.version)) {
+        throw new Error('Expected plugin ' + pinfo.id + ' to satisfy version "' + parsedSpec.version + '" but got "' + pinfo.version + '".');
     }
 }
 
@@ -260,16 +260,11 @@ function loadLocalPlugins(searchpath, pluginInfoProvider) {
 //      org.apache.cordova.file@>=1.2.0
 function findLocalPlugin(plugin_src, searchpath, pluginInfoProvider) {
     loadLocalPlugins(searchpath, pluginInfoProvider);
-    var id = plugin_src;
-    var versionspec = '*';
-    var parts = cordovaUtil.parseRegistryPluginSpec(plugin_src);
-    if (parts[0] && parts[1]) {
-        id = parts[0];
-        versionspec = parts[1];
-    }
+    var parsedSpec = pluginSpec.parse(plugin_src);
+    var versionspec = parsedSpec.version || '*';
 
     var latest = null;
-    var versions = localPlugins.plugins[id];
+    var versions = localPlugins.plugins[parsedSpec.id];
 
     if (!versions) return null;
 

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -72,7 +72,7 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
     plugins_dir = cordovaUtil.convertToRealPathSafe(plugins_dir);
     options = options || {};
     if (!options.hasOwnProperty('is_top_level')) options.is_top_level = true;
-    
+
     plugins_dir = plugins_dir || path.join(project_dir, 'cordova', 'plugins');
 
     if (!platform_modules[platform]) {
@@ -90,35 +90,37 @@ module.exports = function installPlugin(platform, project_dir, id, plugins_dir, 
 // Returns a promise.
 function possiblyFetch(id, plugins_dir, options) {
     // Split @Version from the plugin id if it exists.
-    var splitVersion = id.split('@');
+    var splitVersion = cordovaUtil.parseRegistryPluginSpec(id);
+    var extractedId = splitVersion[0] || id;
     //Check if a mapping exists for the plugin id
     //if it does, convert id to new name id
-    var newId = pluginMapper.oldToNew[splitVersion[0]];
+    var newId = pluginMapper.oldToNew[extractedId];
     if(newId) {
         if(splitVersion[1]) {
-            id = newId +'@'+splitVersion[1];
+            id = newId + '@' +splitVersion[1];
         } else {
             id = newId;
         }
     }
+
     // if plugin is a relative path, check if it already exists
-    var plugin_src_dir = isAbsolutePath(id) ? id : path.join(plugins_dir, splitVersion[0]);
+    var plugin_src_dir = isAbsolutePath(id) ? id : path.join(plugins_dir, cordovaUtil.extractPluginId(id));
 
     // Check that the plugin has already been fetched.
     if (fs.existsSync(plugin_src_dir)) {
         return Q(plugin_src_dir);
     }
 
-    var alias = pluginMapper.newToOld[splitVersion[0]] || newId;
+    var alias = pluginMapper.newToOld[extractedId] || newId;
     // if the plugin alias has already been fetched, use it.
     if (alias && fs.existsSync(path.join(plugins_dir, alias))) {
-        events.emit('warn', 'Found ' + alias + ' is already fetched, so it is installed instead of '+splitVersion[0]);
+        events.emit('warn', 'Found ' + alias + ' is already fetched, so it is installed instead of ' + extractedId);
         return Q(path.join(plugins_dir, alias));
     }
 
     // if plugin doesnt exist, use fetch to get it.
     if (newId) {
-        events.emit('warn', 'Notice: ' + splitVersion[0] + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
+        events.emit('warn', 'Notice: ' + extractedId + ' has been automatically converted to ' + newId + ' and fetched from npm. This is due to our old plugins registry shutting down.');
     }
     var opts = underscore.extend({}, options, {
         client: 'plugman'

--- a/cordova-lib/src/plugman/uninstall.js
+++ b/cordova-lib/src/plugman/uninstall.js
@@ -145,10 +145,9 @@ module.exports.uninstallPlugin = function(id, plugins_dir, options) {
         var deps = pluginInfo.getDependencies();
         var deps_path;
         deps.forEach(function (d) {
-            var splitVersion = d.id.split('@');
-            deps_path = path.join(plugin_dir, '..', splitVersion[0]);
+            deps_path = path.join(plugin_dir, '..', cordovaUtil.extractPluginId(d.id));
             if (!fs.existsSync(deps_path)) {
-                var newId = pluginMapper[splitVersion[0]];
+                var newId = pluginMapper[cordovaUtil.parseRegistryPluginSpec(d.id)[0] || d.id];
                 if (newId && toDelete.indexOf(newId) === -1) {
                    events.emit('verbose', 'Automatically converted ' + d.id + ' to ' + newId + 'for uninstallation.');
                    toDelete.push(newId);
@@ -269,8 +268,8 @@ function runUninstallPlatform(actions, platform, project_dir, plugin_dir, plugin
 
             //try to convert ID if old-id path doesn't exist.
             if (!fs.existsSync(dependent_path)) {
-                var splitVersion = dangler.split('@');
-                var newId = pluginMapper[splitVersion[0]];
+                var oldId = cordovaUtil.parseRegistryPluginSpec(dangler)[0] || dangler;
+                var newId = pluginMapper[oldId];
                 if(newId) {
                     dependent_path = path.join(plugins_dir, newId);
                     events.emit('verbose', 'Automatically converted ' + dangler + ' to ' + newId + 'for uninstallation.');


### PR DESCRIPTION
Apparently pre 6.1.0 versions of the CLI were able to add scoped npm packages, but I don't think we ever supported that feature (if it ever worked, I'm sure it was very error prone). This adds support for npm scoped packages. Some notes about the implementation:

* Scoped npm packages, once installed, should be identified by the plugin ID and not the whole scoped package spec. That means if you run `cordova plugin add @scope/cordova-plugin-camera`, the entry that appears in `cordova plugin ls` will be `cordova-plugin-camera` without the scope. If you wanted to remove the plugin, you would run `cordova plugin remove cordova-plugin-camera` (again without the scope)
* Scoped npm packages cannot be installed side by side with their un-scoped counterparts (but I'm not sure why you would want to do that anyway)
* Scoped plugin entries in `config.xml` populate the spec field in this format: `@scope/plugin-id@version` whereas un-scoped plugins just give the version

I am afraid this may conflict somewhat with cordova-fetch (but I am unsure).