### PR TITLE
CB-11022 Save modulesMetadata to both www and platform_www when necessary

### DIFF
--- a/cordova-common/src/PluginManager.js
+++ b/cordova-common/src/PluginManager.js
@@ -133,9 +133,13 @@ PluginManager.prototype.doOperation = function (operation, plugin, options) {
         // Save everything (munge and plugin/modules metadata)
         self.munger.save_all();
 
-        var targetDir = options.usePlatformWww ? self.locations.platformWww : self.locations.www;
-        fs.writeFileSync(path.join(targetDir, 'cordova_plugins.js'),
-            self.munger.platformJson.generateMetadata(), 'utf-8');
+        var metadata = self.munger.platformJson.generateMetadata();
+        fs.writeFileSync(path.join(self.locations.www, 'cordova_plugins.js'), metadata, 'utf-8');
+
+        // CB-11022 save plugin metadata to both www and platform_www if options.usePlatformWww is specified
+        if (options.usePlatformWww) {
+            fs.writeFileSync(path.join(self.locations.platformWww, 'cordova_plugins.js'), metadata, 'utf-8');
+        }
     });
 };
 


### PR DESCRIPTION
This is a port of corresponding platform changes (see https://github.com/apache/cordova-windows/pull/167, https://github.com/apache/cordova-ios/pull/218 and https://github.com/apache/cordova-android/pull/289) to PluginManager class.