### PR TITLE
CB-10761 Resore plugins saved without spec attribute

### DIFF
--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -614,6 +614,21 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
+        it('spec.23.2 should restore plugins without spec attribute', function (done) {
+            redirectRegistryCalls(pluginName2);
+            helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
+            helpers.setPluginSpec(appPath, pluginName2/**, do not specify spec here */);
+            prepare()
+            .then(function () {
+                expect(registry.fetch).toHaveBeenCalledWith([pluginName2]);
+                expect(path.join(appPath, 'plugins', pluginName2)).toExist();
+            }).catch(function (err) {
+                expect(true).toBe(false);
+                console.log(err.message);
+            })
+            .fin(done);
+        }, TIMEOUT);
+
         it('spec.24 should restore only specified platform', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
             helpers.setEngineSpec(appPath, otherPlatformName, otherPlatformSpec);

--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -112,7 +112,11 @@ function installPluginsFromConfigXML(args) {
         // assume it is the location to install from.
         var pluginSpec = pluginEntry.spec;
         pluginName = pluginEntry.name;
-        var installFrom = semver.validRange(pluginSpec, true) ? pluginName + '@' + pluginSpec : pluginSpec;
+
+        // CB-10761 If plugin spec is not specified, use plugin name
+        var installFrom = pluginSpec || pluginName;
+        if (pluginSpec && semver.validRange(pluginSpec, true))
+            installFrom = pluginName + '@' + pluginSpec;
 
         // Add feature preferences as CLI variables if have any
         var options = {


### PR DESCRIPTION
This PR updates plugin restore logic to restore plugins that were added to plugin.xml without `spec` attribute. See [CB-10761](https://issues.apache.org/jira/browse/CB-10761) for details