### PR TITLE
CB-11117: Add FileUpdater module to cordova-common

### DIFF
--- a/cordova-common/cordova-common.js
+++ b/cordova-common/cordova-common.js
@@ -27,10 +27,11 @@ exports = module.exports = {
     CordovaExternalToolErrorContext: require('./src/CordovaError/CordovaExternalToolErrorContext'),
     PlatformJson: require('./src/PlatformJson'),
     ConfigParser: require('./src/ConfigParser/ConfigParser.js'),
+    FileUpdater: require('./src/FileUpdater'),
 
     PluginInfo: require('./src/PluginInfo/PluginInfo.js'),
     PluginInfoProvider: require('./src/PluginInfo/PluginInfoProvider.js'),
-    
+
     PluginManager: require('./src/PluginManager'),
 
     ConfigChanges: require('./src/ConfigChanges/ConfigChanges.js'),

--- a/cordova-common/package.json
+++ b/cordova-common/package.json
@@ -29,6 +29,7 @@
     "cordova-registry-mapper": "^1.1.8",
     "elementtree": "^0.1.6",
     "glob": "^5.0.13",
+    "minimatch": "^3.0.0",
     "osenv": "^0.1.3",
     "plist": "^1.2.0",
     "q": "^1.4.1",

--- a/cordova-common/package.json
+++ b/cordova-common/package.json
@@ -3,7 +3,7 @@
   "name": "cordova-common",
   "description": "Apache Cordova tools and platforms shared routines",
   "license": "Apache-2.0",
-  "version": "1.2.1-dev",
+  "version": "1.3.0-dev",
   "repository": {
     "type": "git",
     "url": "git://git-wip-us.apache.org/repos/asf/cordova-common.git"

--- a/cordova-common/spec/FileUpdater.spec.js
+++ b/cordova-common/spec/FileUpdater.spec.js
@@ -1,0 +1,666 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var path = require('path');
+var rewire = require('rewire');
+var FileUpdater = rewire('../src/FileUpdater');
+
+// Normally these are internal to the module; these lines use rewire to expose them for testing.
+FileUpdater.mapDirectory = FileUpdater.__get__('mapDirectory');
+FileUpdater.mergePathMaps = FileUpdater.__get__('mergePathMaps');
+FileUpdater.updatePathWithStats = FileUpdater.__get__('updatePathWithStats');
+
+// Intercept calls to the internal updatePathWithStats function,
+// so calling methods can be tested in isolation.
+FileUpdater.updatePathWithStatsCalls = [];
+FileUpdater.updatePathWithStatsResult = true;
+FileUpdater.__set__('updatePathWithStats', function () {
+    FileUpdater.updatePathWithStatsCalls.push(arguments);
+    return FileUpdater.updatePathWithStatsResult;
+});
+
+// Create mock fs.Stats to simulate file or directory attributes.
+function mockFileStats(modified) {
+    return {
+        isFile: function () { return true; },
+        isDirectory: function () { return false; },
+        mtime: modified,
+    };
+}
+function mockDirStats() {
+    return {
+        isFile: function () { return false; },
+        isDirectory: function () { return true; },
+        mtime: null,
+    };
+}
+
+// Create a mock to replace the fs and shelljs modules used by the FileUpdater,
+// so the tests don't have to actually touch the filesystem.
+var mockFs = {
+    mkdirPaths: [],
+    cpPaths: [],
+    rmPaths: [],
+    dirMap: {},
+    statMap: {},
+
+    reset: function () {
+        this.mkdirPaths = [];
+        this.cpPaths = [];
+        this.rmPaths = [];
+        this.dirMap = {};
+        this.statMap = {};
+    },
+
+    existsSync: function (fileOrDirPath) {
+        return typeof(this.statMap[fileOrDirPath]) !== 'undefined';
+    },
+
+    readdirSync: function(dirPath) {
+        var result = this.dirMap[dirPath];
+        if (!result) throw new Error('Directory path not found: ' + dirPath);
+        return result;
+    },
+
+    statSync: function (fileOrDirPath) {
+        var result = this.statMap[fileOrDirPath];
+        if (!result) throw new Error('File or directory path not found: ' + fileOrDirPath);
+        return result;
+    },
+
+    mkdir: function (flags, path) {
+        this.mkdirPaths.push(path);
+    },
+
+    cp: function (flags, sourcePath, targetPath) {
+        this.cpPaths.push([sourcePath, targetPath]);
+    },
+
+    rm: function(flags, path) {
+        this.rmPaths.push(path);
+    },
+};
+FileUpdater.__set__('fs', mockFs);
+FileUpdater.__set__('shell', mockFs);
+
+// Define some constants used in the test cases.
+var testRootDir = 'testRootDir';
+var testSourceDir = 'testSourceDir';
+var testSourceDir2 = 'testSourceDir2';
+var testSourceDir3 = 'testSourceDir3';
+var testTargetDir = 'testTargetDir';
+var testSourceFile = 'testSourceFile';
+var testSourceFile2 = 'testSourceFile2';
+var testTargetFile = 'testTargetFile';
+var testTargetFile2 = 'testTargetFile2';
+var testSubDir = 'testSubDir';
+var now = new Date();
+var oneHourAgo = new Date(now.getTime() - 1*60*60*1000);
+var testDirStats = mockDirStats();
+var testFileStats = mockFileStats(now);
+var testFileStats2 = mockFileStats(now);
+var testFileStats3 = mockFileStats(now);
+
+describe('FileUpdater class', function() {
+
+    beforeEach(function () {
+        FileUpdater.updatePathWithStatsCalls = [];
+        FileUpdater.updatePathWithStatsResult = true;
+        mockFs.reset();
+    });
+
+    describe('updatePathWithStats method', function () {
+        it('should do nothing when a directory exists at source and target', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetDir, mockDirStats(), testSourceDir, mockDirStats());
+            expect(updated).toBe(false);
+            expect(mockFs.mkdirPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(0);
+        });
+        it('should create a directory that exists at source and not at target', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetDir, null, testSourceDir, mockDirStats());
+            expect(updated).toBe(true);
+            expect(mockFs.mkdirPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
+        });
+        it('should remove a directory that exists at target and not at source', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetDir, mockDirStats(), testSourceDir, null);
+            expect(updated).toBe(true);
+            expect(mockFs.mkdirPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(1);
+            expect(mockFs.rmPaths[0]).toBe(testTargetDir);
+        });
+
+        it('should do nothing when a file exists at source and target and times are the same',
+                function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(now), testSourceFile, mockFileStats(now));
+            expect(updated).toBe(false);
+            expect(mockFs.cpPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(0);
+        });
+        it('should do nothing when a file exists at source and target and target is newer',
+                function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(now),
+                testSourceFile, mockFileStats(oneHourAgo));
+            expect(updated).toBe(false);
+            expect(mockFs.cpPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(0);
+        });
+        it('should copy when a file exists at source and target and forcing update', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(now),
+                testSourceFile, mockFileStats(now), true);
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should copy when a file exists at source and target and target is newer ' +
+                'and forcuing update', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(now),
+                testSourceFile, mockFileStats(oneHourAgo), true);
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should copy when a file exists at source and target and source is newer', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(oneHourAgo),
+                testSourceFile, mockFileStats(now));
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should copy when a file exists at source and not at target', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, null, testSourceFile, mockFileStats(now));
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should remove when a file exists at target and not at source', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockFileStats(now), testSourceFile, null);
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(1);
+            expect(mockFs.rmPaths[0]).toBe(testTargetFile);
+        });
+
+        it('should remove and mkdir when source is a directory and target is a file', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetDir, mockFileStats(now), testSourceDir, mockDirStats());
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(0);
+            expect(mockFs.rmPaths.length).toBe(1);
+            expect(mockFs.mkdirPaths.length).toBe(1);
+            expect(mockFs.rmPaths[0]).toBe(testTargetDir);
+            expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
+        });
+        it('should remove and copy when source is a file and target is a directory', function () {
+            var updated = FileUpdater.updatePathWithStats(
+                null, testTargetFile, mockDirStats(), testSourceFile, mockFileStats(now));
+            expect(updated).toBe(true);
+            expect(mockFs.rmPaths.length).toBe(1);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.mkdirPaths.length).toBe(0);
+            expect(mockFs.rmPaths[0]).toBe(testTargetFile);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+
+        it('should join the paths when a rootDir is specified', function () {
+            FileUpdater.updatePathWithStats(
+                testRootDir, testTargetFile, null, testSourceFile, mockFileStats(now));
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual(
+                [path.join(testRootDir, testSourceFile), path.join(testRootDir, testTargetFile)]);
+        });
+
+        it('should log dir creation', function () {
+            var loggedSource = 0;
+            var loggedTarget = 0;
+            var loggedRoot = 0;
+            FileUpdater.updatePathWithStats(testRootDir, testTargetDir, null,
+                    testSourceDir, mockDirStats(now), false, function (message) {
+                loggedSource += new RegExp(testSourceDir).test(message) ? 1 : 0;
+                loggedTarget += new RegExp(testTargetDir).test(message) ? 1 : 0;
+                loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
+            });
+            expect(loggedSource).toBe(0);
+            expect(loggedTarget).toBe(1);
+            expect(loggedRoot).toBe(0);
+        });
+        it('should log dir removal', function () {
+            var loggedSource = 0;
+            var loggedTarget = 0;
+            var loggedRoot = 0;
+            FileUpdater.updatePathWithStats(testRootDir, testTargetDir, mockDirStats(now),
+                    testSourceDir, null, false, function (message) {
+                loggedSource += new RegExp(testSourceDir).test(message) ? 1 : 0;
+                loggedTarget += new RegExp(testTargetDir).test(message) ? 1 : 0;
+                loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
+            });
+            expect(loggedSource).toBe(0);
+            expect(loggedTarget).toBe(1);
+            expect(loggedRoot).toBe(0);
+        });
+        it('should log file copy', function () {
+            var loggedSource = 0;
+            var loggedTarget = 0;
+            var loggedRoot = 0;
+            FileUpdater.updatePathWithStats(testRootDir, testTargetFile, null,
+                    testSourceFile, mockFileStats(now), false, function (message) {
+                loggedSource += new RegExp(testSourceFile).test(message) ? 1 : 0;
+                loggedTarget += new RegExp(testTargetFile).test(message) ? 1 : 0;
+                loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
+            });
+            expect(loggedSource).toBe(1);
+            expect(loggedTarget).toBe(1);
+            expect(loggedRoot).toBe(0);
+        });
+        it('should log file removal', function () {
+            var loggedSource = 0;
+            var loggedTarget = 0;
+            var loggedRoot = 0;
+            var messages = [];
+            FileUpdater.updatePathWithStats(testRootDir, testTargetFile, mockFileStats(now),
+                    testSourceFile, null, false, function (message) {
+                loggedSource += new RegExp(testSourceFile).test(message) ? 1 : 0;
+                loggedTarget += new RegExp(testTargetFile).test(message) ? 1 : 0;
+                loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
+            });
+            expect(messages).toEqual([]);
+            expect(loggedSource).toBe(0);
+            expect(loggedTarget).toBe(1);
+            expect(loggedRoot).toBe(0);
+        });
+    });
+
+    describe('mapDirectory method', function () {
+        it('should map an empty directory', function () {
+            mockFs.statMap[path.join(testRootDir, testSourceDir)] = testDirStats;
+            mockFs.dirMap[path.join(testRootDir, testSourceDir)] = [];
+            var dirMap = FileUpdater.mapDirectory(testRootDir, testSourceDir, ['**'], []);
+            expect(Object.keys(dirMap)).toEqual(['']);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+        });
+        it('should map a directory with a file', function () {
+            mockFs.statMap[path.join(testRootDir, testSourceDir)] = testDirStats;
+            mockFs.dirMap[path.join(testRootDir, testSourceDir)] = [testSourceFile];
+            mockFs.statMap[path.join(testRootDir, testSourceDir, testSourceFile)] = testFileStats;
+            var dirMap = FileUpdater.mapDirectory(testRootDir, testSourceDir, ['**'], []);
+            expect(Object.keys(dirMap).sort()).toEqual(['', testSourceFile]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
+            expect(dirMap[testSourceFile].stats).toBe(testFileStats);
+        });
+        it('should map a directory with a subdirectory', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir)] = [];
+            var dirMap = FileUpdater.mapDirectory('', testSourceDir, ['**'], []);
+            expect(Object.keys(dirMap).sort()).toEqual(['', testSubDir]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[testSubDir].subDir).toBe(testSourceDir);
+            expect(dirMap[testSubDir].stats).toBe(testDirStats);
+        });
+        it('should map a directory with a file in a nested subdirectory', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir)] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir, testSubDir)] = [testSourceFile];
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSubDir, testSourceFile)] =
+                testFileStats;
+            var dirMap = FileUpdater.mapDirectory('', testSourceDir, ['**'], []);
+            expect(Object.keys(dirMap).sort()).toEqual([
+                '',
+                testSubDir,
+                path.join(testSubDir, testSubDir),
+                path.join(testSubDir, testSubDir, testSourceFile)]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[testSubDir].subDir).toBe(testSourceDir);
+            expect(dirMap[testSubDir].stats).toBe(testDirStats);
+            expect(dirMap[path.join(testSubDir, testSubDir)].subDir).toBe(testSourceDir);
+            expect(dirMap[path.join(testSubDir, testSubDir)].stats).toBe(testDirStats);
+            expect(dirMap[path.join(testSubDir, testSubDir, testSourceFile)].subDir).toBe(
+                testSourceDir);
+            expect(dirMap[path.join(testSubDir, testSubDir, testSourceFile)].stats).toBe(
+                testFileStats);
+        });
+
+        it('should include files that match include globs', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSourceFile, testSourceFile2];
+            mockFs.statMap[path.join(testSourceDir, testSourceFile)] = testFileStats;
+            mockFs.statMap[path.join(testSourceDir, testSourceFile2)] = testFileStats;
+            var dirMap = FileUpdater.mapDirectory('', testSourceDir, [testSourceFile], []);
+            expect(Object.keys(dirMap).sort()).toEqual(['', testSourceFile]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
+            expect(dirMap[testSourceFile].stats).toBe(testFileStats);
+        });
+        it('should include files in a subdirectory that match include globs', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir)] =
+                [testSourceFile, testSourceFile2];
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSourceFile)] = testFileStats;
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSourceFile2)] = testFileStats;
+            var dirMap = FileUpdater.mapDirectory('', testSourceDir, ['**/' + testSourceFile], []);
+            expect(Object.keys(dirMap).sort()).toEqual([
+                '',
+                testSubDir,
+                path.join(testSubDir, testSourceFile)]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[path.join(testSubDir, testSourceFile)].subDir).toBe(testSourceDir);
+            expect(dirMap[path.join(testSubDir, testSourceFile)].stats).toBe(testFileStats);
+        });
+        it('should exclude paths that match exclude globs', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSourceFile, testSourceFile2];
+            mockFs.statMap[path.join(testSourceDir, testSourceFile)] = testFileStats;
+            mockFs.statMap[path.join(testSourceDir, testSourceFile2)] = testFileStats;
+            var dirMap = FileUpdater.mapDirectory('', testSourceDir, ['**'], [testSourceFile2]);
+            expect(Object.keys(dirMap).sort()).toEqual(['', testSourceFile]);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+            expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
+            expect(dirMap[testSourceFile].stats).toBe(testFileStats);
+        });
+        it('should exclude paths that match both exclude and include globs', function () {
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir)] =
+                [testSourceFile, testSourceFile2];
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSourceFile)] = testFileStats;
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSourceFile2)] = testFileStats;
+            var dirMap = FileUpdater.mapDirectory(
+                '', testSourceDir, ['**/' + testSourceFile], [testSubDir]);
+            expect(Object.keys(dirMap).sort()).toEqual(['']);
+            expect(dirMap[''].subDir).toBe(testSourceDir);
+            expect(dirMap[''].stats).toBe(testDirStats);
+        });
+    });
+
+    describe('mergePathMaps method', function () {
+        var testTargetFileStats = mockFileStats(oneHourAgo);
+        var testSourceFileStats = mockFileStats(now);
+        var testSourceFileStats2 = mockFileStats(now);
+        var testSourceFileStats3 = mockFileStats(now);
+        it('should prepend the target directory on target paths', function () {
+            var mergedPathMap = FileUpdater.mergePathMaps(
+                testTargetDir,
+                {
+                    '': { subDir: testTargetDir, stats: testDirStats },
+                    testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
+                },
+                [{
+                    '': { subDir: testSourceDir, stats: testDirStats },
+                    testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
+                }]);
+            expect(Object.keys(mergedPathMap).sort()).toEqual(['', testTargetFile]);
+            expect(mergedPathMap[''].targetPath).toBe(testTargetDir);
+            expect(mergedPathMap[''].targetStats).toBe(testDirStats);
+            expect(mergedPathMap[''].sourcePath).toBe(testSourceDir);
+            expect(mergedPathMap[''].sourceStats).toBe(testDirStats);
+            expect(mergedPathMap[testTargetFile].targetPath).toBe(
+                path.join(testTargetDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].targetStats).toBe(testTargetFileStats);
+            expect(mergedPathMap[testTargetFile].sourcePath).toBe(
+                path.join(testSourceDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].sourceStats).toBe(testSourceFileStats);
+        });
+        it('should handle missing source files', function () {
+            var mergedPathMap = FileUpdater.mergePathMaps(
+                testTargetDir,
+                {
+                    testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
+                },
+                [{}]);
+            expect(Object.keys(mergedPathMap).sort()).toEqual([testTargetFile]);
+            expect(mergedPathMap[testTargetFile].targetPath).toBe(
+                path.join(testTargetDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].targetStats).toBe(testTargetFileStats);
+            expect(mergedPathMap[testTargetFile].sourcePath).toBeNull();
+            expect(mergedPathMap[testTargetFile].sourceStats).toBeNull();
+        });
+        it('should handle missing target files', function () {
+            var mergedPathMap = FileUpdater.mergePathMaps(
+                testTargetDir,
+                {},
+                [{
+                    testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
+                }]);
+            expect(Object.keys(mergedPathMap).sort()).toEqual([testTargetFile]);
+            expect(mergedPathMap[testTargetFile].targetPath).toBe(
+                path.join(testTargetDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].targetStats).toBeNull();
+            expect(mergedPathMap[testTargetFile].sourcePath).toBe(
+                path.join(testSourceDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].sourceStats).toBe(testSourceFileStats);
+        });
+        it('should merge three source maps', function () {
+            var mergedPathMap = FileUpdater.mergePathMaps(
+                testTargetDir,
+                {
+                    '': { subDir: testTargetDir, stats: testDirStats },
+                    testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
+                },
+                [
+                    {
+                        '': { subDir: testSourceDir, stats: testDirStats },
+                        testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
+                    },
+                    {
+                        '': { subDir: testSourceDir2, stats: testDirStats },
+                        testTargetFile: { subDir: testSourceDir2, stats: testSourceFileStats2 },
+                        testTargetFile2: { subDir: testSourceDir2, stats: testSourceFileStats2 },
+                    },
+                    {
+                        '': { subDir: testSourceDir3, stats: testDirStats },
+                        testTargetFile2: { subDir: testSourceDir3, stats: testSourceFileStats3 },
+                    },
+                ]);
+            expect(Object.keys(mergedPathMap).sort()).toEqual(
+                ['', testTargetFile, testTargetFile2]);
+            expect(mergedPathMap[''].targetPath).toBe(testTargetDir);
+            expect(mergedPathMap[''].targetStats).toBe(testDirStats);
+            expect(mergedPathMap[''].sourcePath).toBe(testSourceDir3);
+            expect(mergedPathMap[''].sourceStats).toBe(testDirStats);
+            expect(mergedPathMap[testTargetFile].targetPath).toBe(
+                path.join(testTargetDir, testTargetFile));
+            expect(mergedPathMap[testTargetFile].targetStats).toBe(testTargetFileStats);
+            expect(mergedPathMap[testTargetFile].sourcePath).toBe(
+                path.join(testSourceDir2, testTargetFile));
+            expect(mergedPathMap[testTargetFile].sourceStats).toBe(testSourceFileStats2);
+            expect(mergedPathMap[testTargetFile2].targetPath).toBe(
+                path.join(testTargetDir, testTargetFile2));
+            expect(mergedPathMap[testTargetFile2].targetStats).toBeNull();
+            expect(mergedPathMap[testTargetFile2].sourcePath).toBe(
+                path.join(testSourceDir3, testTargetFile2));
+            expect(mergedPathMap[testTargetFile2].sourceStats).toBe(testSourceFileStats3);
+        });
+    });
+
+    describe('updatePath method', function () {
+        it('should update a path', function () {
+            mockFs.statMap[testRootDir] = testDirStats;
+            mockFs.statMap[path.join(testRootDir, testTargetFile)] = testFileStats;
+            mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
+            var updated = FileUpdater.updatePath(
+                testRootDir, testTargetFile, testSourceFile, true);
+            expect(updated).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testRootDir);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBe(true);
+        });
+        it('should update a path without a separate root directory', function () {
+            mockFs.statMap[testTargetFile] = testFileStats;
+            mockFs.statMap[testSourceFile] = testFileStats2;
+            FileUpdater.updatePathWithStatsResult = false;
+            var updated = FileUpdater.updatePath(null, testTargetFile, testSourceFile);
+            expect(updated).toBe(false);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+        });
+        it('should update a path when the source doesn\'t exist', function () {
+            mockFs.statMap[testTargetFile] = testFileStats;
+            var updated = FileUpdater.updatePath(null, testTargetFile, null);
+            expect(updated).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+        });
+        it('should update a path when the target doesn\'t exist', function () {
+            mockFs.statMap[testSourceFile] = testFileStats2;
+            var updated = FileUpdater.updatePath(null, testTargetFile, testSourceFile);
+            expect(updated).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+        });
+        it('should create the target\'s parent directory if it doesn\'t exist',
+                function () {
+            mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
+            var updated = FileUpdater.updatePath(testRootDir, testTargetFile, testSourceFile);
+            expect(updated).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testRootDir);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+            expect(mockFs.mkdirPaths.length).toBe(1);
+            expect(mockFs.mkdirPaths[0]).toBe(testRootDir);
+        });
+    });
+
+    describe('mergeAndUpdateDir method', function () {
+        it('should update files from merged source directories', function () {
+            mockFs.statMap[testTargetDir] = testDirStats;
+            mockFs.dirMap[testTargetDir] = [testSubDir];
+            mockFs.statMap[path.join(testTargetDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testTargetDir, testSubDir)] = [testSourceFile];
+            mockFs.statMap[path.join(testTargetDir, testSubDir, testSourceFile)] =
+                testFileStats;
+
+            mockFs.statMap[testSourceDir] = testDirStats;
+            mockFs.dirMap[testSourceDir] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir, testSubDir)] = [testSourceFile];
+            mockFs.statMap[path.join(testSourceDir, testSubDir, testSourceFile)] =
+                testFileStats2;
+
+            mockFs.statMap[testSourceDir2] = testDirStats;
+            mockFs.dirMap[testSourceDir2] = [testSubDir];
+            mockFs.statMap[path.join(testSourceDir2, testSubDir)] = testDirStats;
+            mockFs.dirMap[path.join(testSourceDir2, testSubDir)] = [testSourceFile2];
+            mockFs.statMap[path.join(testSourceDir2, testSubDir, testSourceFile2)] =
+                testFileStats3;
+
+            var updated = FileUpdater.mergeAndUpdateDir(
+                null, testTargetDir, [testSourceDir, testSourceDir2]);
+            expect(updated).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls.length).toBe(4);
+
+            function validateUpdatePathWithStatsCall(
+                    index, targetDir, sourceDir, subPath, targetStats, sourceStats) {
+                var args = FileUpdater.updatePathWithStatsCalls[index];
+                expect(args[0]).toBe('');
+                expect(args[1]).toBe(path.join(targetDir, subPath));
+                expect(args[2]).toEqual(targetStats);
+                expect(args[3]).toBe(path.join(sourceDir, subPath));
+                expect(args[4]).toEqual(sourceStats);
+                expect(args[5]).toBeFalsy();
+            }
+
+            // Update the root directory.
+            validateUpdatePathWithStatsCall(
+                0,
+                testTargetDir,
+                testSourceDir2,
+                '',
+                testDirStats,
+                testDirStats);
+            // Update the subdirectory.
+           validateUpdatePathWithStatsCall(
+                1,
+                testTargetDir,
+                testSourceDir2,
+                testSubDir,
+                testDirStats,
+                testDirStats);
+            // Update the first file, from the first source.
+            validateUpdatePathWithStatsCall(
+                2,
+                testTargetDir,
+                testSourceDir,
+                path.join(testSubDir, testSourceFile),
+                testFileStats,
+                testFileStats2);
+            // Update the second file, from the second source.
+            validateUpdatePathWithStatsCall(
+                3,
+                testTargetDir,
+                testSourceDir2,
+                path.join(testSubDir, testSourceFile2),
+                null,
+                testFileStats3);
+        });
+    });
+});

--- a/cordova-common/spec/FileUpdater.spec.js
+++ b/cordova-common/spec/FileUpdater.spec.js
@@ -128,14 +128,14 @@ describe('FileUpdater class', function() {
     describe('updatePathWithStats method', function () {
         it('should do nothing when a directory exists at source and target', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetDir, mockDirStats(), testSourceDir, mockDirStats());
+                testSourceDir, mockDirStats(), testTargetDir, mockDirStats());
             expect(updated).toBe(false);
             expect(mockFs.mkdirPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
         it('should create a directory that exists at source and not at target', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetDir, null, testSourceDir, mockDirStats());
+                testSourceDir, mockDirStats(), testTargetDir, null);
             expect(updated).toBe(true);
             expect(mockFs.mkdirPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -143,7 +143,7 @@ describe('FileUpdater class', function() {
         });
         it('should remove a directory that exists at target and not at source', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetDir, mockDirStats(), testSourceDir, null);
+                testSourceDir, null, testTargetDir, mockDirStats());
             expect(updated).toBe(true);
             expect(mockFs.mkdirPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(1);
@@ -153,7 +153,7 @@ describe('FileUpdater class', function() {
         it('should do nothing when a file exists at source and target and times are the same',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(now), testSourceFile, mockFileStats(now));
+                testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(now));
             expect(updated).toBe(false);
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -161,16 +161,15 @@ describe('FileUpdater class', function() {
         it('should do nothing when a file exists at source and target and target is newer',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(now),
-                testSourceFile, mockFileStats(oneHourAgo));
+                testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now));
             expect(updated).toBe(false);
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
         it('should copy when a file exists at source and target and forcing update', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(now),
-                testSourceFile, mockFileStats(now), true);
+                testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(now),
+                { force: true });
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -179,8 +178,8 @@ describe('FileUpdater class', function() {
         it('should copy when a file exists at source and target and target is newer ' +
                 'and forcuing update', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(now),
-                testSourceFile, mockFileStats(oneHourAgo), true);
+                testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now),
+                { force: true });
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -188,8 +187,7 @@ describe('FileUpdater class', function() {
         });
         it('should copy when a file exists at source and target and source is newer', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(oneHourAgo),
-                testSourceFile, mockFileStats(now));
+                testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(oneHourAgo));
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -197,7 +195,7 @@ describe('FileUpdater class', function() {
         });
         it('should copy when a file exists at source and not at target', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, null, testSourceFile, mockFileStats(now));
+                testSourceFile, mockFileStats(now), testTargetFile, null);
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -205,7 +203,7 @@ describe('FileUpdater class', function() {
         });
         it('should remove when a file exists at target and not at source', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockFileStats(now), testSourceFile, null);
+                testSourceFile, null, testTargetFile, mockFileStats(now));
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(1);
@@ -214,7 +212,7 @@ describe('FileUpdater class', function() {
 
         it('should remove and mkdir when source is a directory and target is a file', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetDir, mockFileStats(now), testSourceDir, mockDirStats());
+                testSourceDir, mockDirStats(), testTargetDir, mockFileStats(now));
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(1);
@@ -224,7 +222,7 @@ describe('FileUpdater class', function() {
         });
         it('should remove and copy when source is a file and target is a directory', function () {
             var updated = FileUpdater.updatePathWithStats(
-                null, testTargetFile, mockDirStats(), testSourceFile, mockFileStats(now));
+                testSourceFile, mockFileStats(now), testTargetFile, mockDirStats());
             expect(updated).toBe(true);
             expect(mockFs.rmPaths.length).toBe(1);
             expect(mockFs.cpPaths.length).toBe(1);
@@ -235,7 +233,8 @@ describe('FileUpdater class', function() {
 
         it('should join the paths when a rootDir is specified', function () {
             FileUpdater.updatePathWithStats(
-                testRootDir, testTargetFile, null, testSourceFile, mockFileStats(now));
+                testSourceFile, mockFileStats(now), testTargetFile, null,
+                { rootDir: testRootDir });
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual(
@@ -246,8 +245,8 @@ describe('FileUpdater class', function() {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
-            FileUpdater.updatePathWithStats(testRootDir, testTargetDir, null,
-                    testSourceDir, mockDirStats(now), false, function (message) {
+            FileUpdater.updatePathWithStats(testSourceDir, mockDirStats(now), testTargetDir, null,
+                { rootDir: testRootDir }, function (message) {
                 loggedSource += new RegExp(testSourceDir).test(message) ? 1 : 0;
                 loggedTarget += new RegExp(testTargetDir).test(message) ? 1 : 0;
                 loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
@@ -260,8 +259,8 @@ describe('FileUpdater class', function() {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
-            FileUpdater.updatePathWithStats(testRootDir, testTargetDir, mockDirStats(now),
-                    testSourceDir, null, false, function (message) {
+            FileUpdater.updatePathWithStats(testSourceDir, null, testTargetDir, mockDirStats(now),
+                    { rootDir: testRootDir }, function (message) {
                 loggedSource += new RegExp(testSourceDir).test(message) ? 1 : 0;
                 loggedTarget += new RegExp(testTargetDir).test(message) ? 1 : 0;
                 loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
@@ -274,8 +273,8 @@ describe('FileUpdater class', function() {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
-            FileUpdater.updatePathWithStats(testRootDir, testTargetFile, null,
-                    testSourceFile, mockFileStats(now), false, function (message) {
+            FileUpdater.updatePathWithStats(testSourceFile, mockFileStats(now),
+                    testTargetFile, null, { rootDir: testRootDir }, function (message) {
                 loggedSource += new RegExp(testSourceFile).test(message) ? 1 : 0;
                 loggedTarget += new RegExp(testTargetFile).test(message) ? 1 : 0;
                 loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
@@ -289,8 +288,9 @@ describe('FileUpdater class', function() {
             var loggedTarget = 0;
             var loggedRoot = 0;
             var messages = [];
-            FileUpdater.updatePathWithStats(testRootDir, testTargetFile, mockFileStats(now),
-                    testSourceFile, null, false, function (message) {
+            FileUpdater.updatePathWithStats(testSourceFile, null,
+                    testTargetFile, mockFileStats(now), { rootDir: testRootDir },
+                    function (message) {
                 loggedSource += new RegExp(testSourceFile).test(message) ? 1 : 0;
                 loggedTarget += new RegExp(testTargetFile).test(message) ? 1 : 0;
                 loggedRoot += new RegExp(testRootDir).test(message) ? 1 : 0;
@@ -426,15 +426,15 @@ describe('FileUpdater class', function() {
         var testSourceFileStats3 = mockFileStats(now);
         it('should prepend the target directory on target paths', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
-                testTargetDir,
+                [{
+                    '': { subDir: testSourceDir, stats: testDirStats },
+                    testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
+                }],
                 {
                     '': { subDir: testTargetDir, stats: testDirStats },
                     testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
                 },
-                [{
-                    '': { subDir: testSourceDir, stats: testDirStats },
-                    testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
-                }]);
+                testTargetDir);
             expect(Object.keys(mergedPathMap).sort()).toEqual(['', testTargetFile]);
             expect(mergedPathMap[''].targetPath).toBe(testTargetDir);
             expect(mergedPathMap[''].targetStats).toBe(testDirStats);
@@ -449,11 +449,11 @@ describe('FileUpdater class', function() {
         });
         it('should handle missing source files', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
-                testTargetDir,
+                [{}],
                 {
                     testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
                 },
-                [{}]);
+                testTargetDir);
             expect(Object.keys(mergedPathMap).sort()).toEqual([testTargetFile]);
             expect(mergedPathMap[testTargetFile].targetPath).toBe(
                 path.join(testTargetDir, testTargetFile));
@@ -463,11 +463,11 @@ describe('FileUpdater class', function() {
         });
         it('should handle missing target files', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
-                testTargetDir,
-                {},
                 [{
                     testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
-                }]);
+                }],
+                {},
+                testTargetDir);
             expect(Object.keys(mergedPathMap).sort()).toEqual([testTargetFile]);
             expect(mergedPathMap[testTargetFile].targetPath).toBe(
                 path.join(testTargetDir, testTargetFile));
@@ -478,11 +478,6 @@ describe('FileUpdater class', function() {
         });
         it('should merge three source maps', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
-                testTargetDir,
-                {
-                    '': { subDir: testTargetDir, stats: testDirStats },
-                    testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
-                },
                 [
                     {
                         '': { subDir: testSourceDir, stats: testDirStats },
@@ -497,7 +492,12 @@ describe('FileUpdater class', function() {
                         '': { subDir: testSourceDir3, stats: testDirStats },
                         testTargetFile2: { subDir: testSourceDir3, stats: testSourceFileStats3 },
                     },
-                ]);
+                ],
+                {
+                    '': { subDir: testTargetDir, stats: testDirStats },
+                    testTargetFile: { subDir: testTargetDir, stats: testTargetFileStats },
+                },
+                testTargetDir);
             expect(Object.keys(mergedPathMap).sort()).toEqual(
                 ['', testTargetFile, testTargetFile2]);
             expect(mergedPathMap[''].targetPath).toBe(testTargetDir);
@@ -525,66 +525,63 @@ describe('FileUpdater class', function() {
             mockFs.statMap[path.join(testRootDir, testTargetFile)] = testFileStats;
             mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
             var updated = FileUpdater.updatePath(
-                testRootDir, testTargetFile, testSourceFile, true);
+                testSourceFile, testTargetFile, { rootDir: testRootDir, force: true });
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
-            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testRootDir);
-            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
-            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
-            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBe(true);
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(
+                {rootDir: testRootDir, force: true });
         });
         it('should update a path without a separate root directory', function () {
             mockFs.statMap[testTargetFile] = testFileStats;
             mockFs.statMap[testSourceFile] = testFileStats2;
             FileUpdater.updatePathWithStatsResult = false;
-            var updated = FileUpdater.updatePath(null, testTargetFile, testSourceFile);
+            var updated = FileUpdater.updatePath(testSourceFile, testTargetFile);
             expect(updated).toBe(false);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
-            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
-            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
-            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
-            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
         it('should update a path when the source doesn\'t exist', function () {
             mockFs.statMap[testTargetFile] = testFileStats;
-            var updated = FileUpdater.updatePath(null, testTargetFile, null);
+            var updated = FileUpdater.updatePath(null, testTargetFile);
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
-            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
-            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toEqual(testFileStats);
-            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBeNull();
-            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeNull();
-            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
         it('should update a path when the target doesn\'t exist', function () {
             mockFs.statMap[testSourceFile] = testFileStats2;
-            var updated = FileUpdater.updatePath(null, testTargetFile, testSourceFile);
+            var updated = FileUpdater.updatePath(testSourceFile, testTargetFile);
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
-            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe('');
-            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBeNull();
-            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
-            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
         it('should create the target\'s parent directory if it doesn\'t exist',
                 function () {
             mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
-            var updated = FileUpdater.updatePath(testRootDir, testTargetFile, testSourceFile);
+            var updated = FileUpdater.updatePath(
+                testSourceFile, testTargetFile, { rootDir: testRootDir });
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
-            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testRootDir);
-            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toBe(testTargetFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBeNull();
-            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBe(testSourceFile);
-            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(testFileStats2);
-            expect(FileUpdater.updatePathWithStatsCalls[0][5]).toBeFalsy();
+            expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testSourceFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][1]).toEqual(testFileStats2);
+            expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
+            expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBeNull();
+            expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual({rootDir: testRootDir });
             expect(mockFs.mkdirPaths.length).toBe(1);
             expect(mockFs.mkdirPaths[0]).toBe(testRootDir);
         });
@@ -614,53 +611,52 @@ describe('FileUpdater class', function() {
                 testFileStats3;
 
             var updated = FileUpdater.mergeAndUpdateDir(
-                null, testTargetDir, [testSourceDir, testSourceDir2]);
+                [testSourceDir, testSourceDir2], testTargetDir);
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(4);
 
             function validateUpdatePathWithStatsCall(
-                    index, targetDir, sourceDir, subPath, targetStats, sourceStats) {
+                    index, subPath, sourceDir, sourceStats, targetDir, targetStats) {
                 var args = FileUpdater.updatePathWithStatsCalls[index];
-                expect(args[0]).toBe('');
-                expect(args[1]).toBe(path.join(targetDir, subPath));
-                expect(args[2]).toEqual(targetStats);
-                expect(args[3]).toBe(path.join(sourceDir, subPath));
-                expect(args[4]).toEqual(sourceStats);
-                expect(args[5]).toBeFalsy();
+                expect(args[0]).toBe(path.join(sourceDir, subPath));
+                expect(args[1]).toEqual(sourceStats);
+                expect(args[2]).toBe(path.join(targetDir, subPath));
+                expect(args[3]).toEqual(targetStats);
+                expect(args[4]).toBeUndefined();
             }
 
             // Update the root directory.
             validateUpdatePathWithStatsCall(
                 0,
-                testTargetDir,
-                testSourceDir2,
                 '',
+                testSourceDir2,
                 testDirStats,
+                testTargetDir,
                 testDirStats);
             // Update the subdirectory.
            validateUpdatePathWithStatsCall(
                 1,
-                testTargetDir,
-                testSourceDir2,
                 testSubDir,
+                testSourceDir2,
                 testDirStats,
+                testTargetDir,
                 testDirStats);
             // Update the first file, from the first source.
             validateUpdatePathWithStatsCall(
                 2,
-                testTargetDir,
-                testSourceDir,
                 path.join(testSubDir, testSourceFile),
-                testFileStats,
-                testFileStats2);
+                testSourceDir,
+                testFileStats2,
+                testTargetDir,
+                testFileStats);
             // Update the second file, from the second source.
             validateUpdatePathWithStatsCall(
                 3,
-                testTargetDir,
-                testSourceDir2,
                 path.join(testSubDir, testSourceFile2),
-                null,
-                testFileStats3);
+                testSourceDir2,
+                testFileStats3,
+                testTargetDir,
+                null);
         });
     });
 });

--- a/cordova-common/spec/FileUpdater.spec.js
+++ b/cordova-common/spec/FileUpdater.spec.js
@@ -158,18 +158,47 @@ describe('FileUpdater class', function() {
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
-        it('should do nothing when a file exists at source and target and target is newer',
+        it('should copy when a file exists at source and target and target is newer',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now));
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should copy when a file exists at source and target and target is older',
+                function () {
+            var updated = FileUpdater.updatePathWithStats(
+                testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(oneHourAgo));
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
+        it('should do nothing when a file exists at source and target and target is newer',
+                function () {
+            var updated = FileUpdater.updatePathWithStats(
+                testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now),
+                { newer: true });
             expect(updated).toBe(false);
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
+        it('should copy when a file exists at source and target and target is older',
+                function () {
+            var updated = FileUpdater.updatePathWithStats(
+                testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(oneHourAgo),
+                { newer: true });
+            expect(updated).toBe(true);
+            expect(mockFs.cpPaths.length).toBe(1);
+            expect(mockFs.rmPaths.length).toBe(0);
+            expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
+        });
         it('should copy when a file exists at source and target and forcing update', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(now),
-                { force: true });
+                { all: true });
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -179,7 +208,7 @@ describe('FileUpdater class', function() {
                 'and forcuing update', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now),
-                { force: true });
+                { all: true });
             expect(updated).toBe(true);
             expect(mockFs.cpPaths.length).toBe(1);
             expect(mockFs.rmPaths.length).toBe(0);
@@ -525,7 +554,7 @@ describe('FileUpdater class', function() {
             mockFs.statMap[path.join(testRootDir, testTargetFile)] = testFileStats;
             mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
             var updated = FileUpdater.updatePath(
-                testSourceFile, testTargetFile, { rootDir: testRootDir, force: true });
+                testSourceFile, testTargetFile, { rootDir: testRootDir, all: true });
             expect(updated).toBe(true);
             expect(FileUpdater.updatePathWithStatsCalls.length).toBe(1);
             expect(FileUpdater.updatePathWithStatsCalls[0][0]).toBe(testSourceFile);
@@ -533,7 +562,7 @@ describe('FileUpdater class', function() {
             expect(FileUpdater.updatePathWithStatsCalls[0][2]).toBe(testTargetFile);
             expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
             expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(
-                {rootDir: testRootDir, force: true });
+                {rootDir: testRootDir, all: true });
         });
         it('should update a path without a separate root directory', function () {
             mockFs.statMap[testTargetFile] = testFileStats;

--- a/cordova-common/src/FileUpdater.js
+++ b/cordova-common/src/FileUpdater.js
@@ -48,8 +48,8 @@ var minimatch = require("minimatch");
  *     and source path parameters are relative; may be omitted if the paths are absolute. The
  *     rootDir is always omitted from any logged paths, to make the logs easier to read.
  * @param {boolean} [options.all] If true, all files are copied regardless of last-modified times.
- *     Otherwise, a file is only copied if the source's last-modified time is greather than or
- *     equal to the target's creation time.
+ *     Otherwise, a file is copied if the source's last-modified time is greather than or
+ *     equal to the target's last-modified time, or if the file sizes are different.
  * @param {loggingCallback} [log] Optional logging callback that takes a string message
  *     describing any file operations that are performed.
  * @return {boolean} true if any changes were made, or false if the force flag is not set
@@ -105,10 +105,8 @@ function updatePathWithStats(sourcePath, sourceStats, targetPath, targetStats, o
                 // the file sizes are different. (The latter catches most cases in which something
                 // was done to the file after copying.) Comparison is >= rather than > to allow
                 // for timestamps lacking sub-second precision in some filesystems.
-                if (sourceStats.mtime.getTime() >= targetStats.birthtime.getTime() ||
-                        sourceStats.size != targetStats.size) {
-                    // Remove the target file before copying to force updated creation time.
-                    shell.rm("-f", targetFullPath);
+                if (sourceStats.mtime.getTime() >= targetStats.mtime.getTime() ||
+                        sourceStats.size !== targetStats.size) {
                     log("copy  " + sourcePath + " " + targetPath + " (updated file)");
                     shell.cp("-f", sourceFullPath, targetFullPath);
                     updated = true;
@@ -172,8 +170,8 @@ function updatePathInternal(sourcePath, targetPath, options, log) {
  *     and source path parameters are relative; may be omitted if the paths are absolute. The
  *     rootDir is always omitted from any logged paths, to make the logs easier to read.
  * @param {boolean} [options.all] If true, all files are copied regardless of last-modified times.
- *     Otherwise, a file is only copied if the source's last-modified time is greather than or
- *     equal to the target's creation time.
+ *     Otherwise, a file is copied if the source's last-modified time is greather than or
+ *     equal to the target's last-modified time, or if the file sizes are different.
  * @param {loggingCallback} [log] Optional logging callback that takes a string message
  *     describing any file operations that are performed.
  * @return {boolean} true if any changes were made, or false if the force flag is not set
@@ -203,8 +201,8 @@ function updatePath(sourcePath, targetPath, options, log) {
  *     and source path parameters are relative; may be omitted if the paths are absolute. The
  *     rootDir is always omitted from any logged paths, to make the logs easier to read.
  * @param {boolean} [options.all] If true, all files are copied regardless of last-modified times.
- *     Otherwise, a file is only copied if the source's last-modified time is greather than or
- *     equal to the target's creation time.
+ *     Otherwise, a file is copied if the source's last-modified time is greather than or
+ *     equal to the target's last-modified time, or if the file sizes are different.
  * @param {loggingCallback} [log] Optional logging callback that takes a string message
  *     describing any file operations that are performed.
  * @return {boolean} true if any changes were made, or false if the force flag is not set
@@ -243,8 +241,8 @@ function updatePaths(pathMap, options, log) {
  *     and source path parameters are relative; may be omitted if the paths are absolute. The
  *     rootDir is always omitted from any logged paths, to make the logs easier to read.
  * @param {boolean} [options.all] If true, all files are copied regardless of last-modified times.
- *     Otherwise, a file is only copied if the source's last-modified time is greather than or
- *     equal to the target's creation time.
+ *     Otherwise, a file is copied if the source's last-modified time is greather than or
+ *     equal to the target's last-modified time, or if the file sizes are different.
  * @param {string|string[]} [options.include] Optional glob string or array of glob strings that
  *     are tested against both target and source relative paths to determine if they are included
  *     in the merge-and-update. If unspecified, all items are included.

--- a/cordova-common/src/FileUpdater.js
+++ b/cordova-common/src/FileUpdater.js
@@ -1,0 +1,389 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var shell = require("shelljs");
+var minimatch = require("minimatch");
+
+/**
+ * Updates a target file or directory with a source file or directory. (Directory updates are
+ * not recursive.) Stats for target and source items must be passed in. This is an internal
+ * helper function used by other methods in this module.
+ *
+ * @param {string|null} rootDir Root directory (such as a project) to which target and source
+ *     path parameters are relative, or null if the paths are absolute. The rootDir is omitted
+ *     from any logged paths, to make the logs easier to read.
+ * @param {string} targetPath Destination file or directory to be updated. If it does not exist,
+ *     it will be created.
+ * @param {fs.Stats|null} targetStats An instance of fs.Stats for the target path, or null if
+ *     the target does not exist.
+ * @param {string|null} sourcePath Source file or directory to be used to update the
+ *     destination. If the source is null, then the destination is deleted if it exists.
+ * @param {fs.Stats|null} sourceStats An instance of fs.Stats for the source path, or null if
+ *     the source does not exist.
+ * @param {boolean} force If target and source are both files, and the force flag is not
+ *     set, then the file will not be copied unless the source is newer than the target.
+ * @param {function} [log] Optional logging callback that takes a string message describing any
+ *     file operations that are performed.
+ * @return {boolean} true if any changes were made, or false if the force flag is not set
+ *     and everything was up to date
+ */
+function updatePathWithStats(
+        rootDir, targetPath, targetStats, sourcePath, sourceStats, force, log) {
+    log = log || function(message) { };
+    var updated = false;
+
+    var targetFullPath = path.join(rootDir || "", targetPath);
+
+    if (sourceStats) {
+        var sourceFullPath = path.join(rootDir || "", sourcePath);
+
+        if (targetStats) {
+            // The target exists. But if the directory status doesn't match the source, delete it.
+            if (targetStats.isDirectory() && !sourceStats.isDirectory()) {
+                log("rmdir " + targetPath + " (source is a file)");
+                shell.rm("-rf", targetFullPath);
+                targetStats = null;
+                updated = true;
+            } else if (!targetStats.isDirectory() && sourceStats.isDirectory()) {
+                log("delete " + targetPath + " (source is a directory)");
+                shell.rm("-f", targetFullPath);
+                targetStats = null;
+                updated = true;
+            }
+        }
+
+        if (!targetStats) {
+            if (sourceStats.isDirectory()) {
+                // The target directory does not exist, so it should be created.
+                log("mkdir " + targetPath);
+                shell.mkdir("-p", targetFullPath);
+                updated = true;
+            } else if (sourceStats.isFile()) {
+                // The target file does not exist, so it should be copied from the source.
+                log("copy " + sourcePath + " " + targetPath +
+                    (!force ? " (new file)" : ""));
+                shell.cp("-f", sourceFullPath, targetFullPath);
+                updated = true;
+            }
+        } else if (sourceStats.isFile() && targetStats.isFile() &&
+                (force || sourceStats.mtime > targetStats.mtime)) {
+            // When the source and target paths both exist and are files, update
+            // the file if the source is newer or if doing a forced update.
+            log("copy " + sourcePath + " " + targetPath +
+                (!force ? " (updated file)" : ""));
+            shell.cp("-f", sourceFullPath, targetFullPath);
+            updated = true;
+        }
+    } else if (targetStats) {
+        // The target exists but the source is null, so the target should be deleted.
+        if (targetStats.isDirectory()) {
+            log("rmdir " + targetPath + " (no source)");
+            shell.rm("-rf", targetFullPath);
+        } else {
+            log("delete " + targetPath + " (no source)");
+            shell.rm("-f", targetFullPath);
+        }
+        updated = true;
+    }
+
+    return updated;
+}
+
+/**
+ * Updates a target file or directory with a source file or directory. (Directory updates are
+ * not recursive.)
+ *
+ * @param {string|null} rootDir Root directory (such as a project) to which target and source
+ *     path parameters are relative, or null if the paths are absolute. The rootDir is omitted
+ *     from any logged paths, to make the logs easier to read.
+ * @param {string} targetPath Destination file or directory to be updated. If it does not exist,
+ *     it will be created.
+ * @param {string|null} sourcePath Source file or directory to be used to update the
+ *     destination. If the source is null, then the destination is deleted if it exists.
+ * @param {boolean} force If target and source are both files, and the force flag is not
+ *     set, then the file will not be copied unless the source is newer than the target.
+ * @param {function} [log] Optional logging callback that takes a string message describing any
+ *     file operations that are performed.
+ * @return {boolean} true if any changes were made, or false if the force flag is not set
+ *     and everything was up to date
+ */
+function updatePath(rootDir, targetPath, sourcePath, force, log) {
+    rootDir = rootDir || "";
+    if (typeof(rootDir) !== "string") {
+        throw new Error("A root directory path is required.");
+    }
+
+    if (!targetPath || typeof(targetPath) !== "string") {
+        throw new Error("A target path is required.");
+    }
+
+    if (sourcePath && typeof(sourcePath) !== "string") {
+        throw new Error("A source path (or null) is required.");
+    }
+
+    log = log || function(message) { };
+
+    var targetFullPath = path.join(rootDir, targetPath);
+    var targetStats = fs.existsSync(targetFullPath) ? fs.statSync(targetFullPath) : null;
+    var sourceStats = null;
+
+    if (sourcePath) {
+        // A non-null source path was specified. It should exist.
+        var sourceFullPath = path.join(rootDir, sourcePath);
+        if (!fs.existsSync(sourceFullPath)) {
+            throw new Error("Source path does not exist: " + sourcePath);
+        }
+
+        sourceStats = fs.statSync(sourceFullPath);
+
+        // Create the target's parent directory if it doesn't exist.
+        var parentDir = path.dirname(targetFullPath);
+        if (!fs.existsSync(parentDir)) {
+            shell.mkdir("-p", parentDir);
+        }
+    }
+
+    return updatePathWithStats(
+        rootDir, targetPath, targetStats, sourcePath, sourceStats, force, log);
+}
+
+/**
+ * Updates files and directories based on a mapping from target paths to source paths. Targets
+ * with null sources in the map are deleted.
+ *
+ * @param {string|null} rootDir Root directory (such as a project) to which target and source
+ *     path parameters are relative, or null if the paths are absolute. The rootDir is omitted
+ *     from any logged paths, to make the logs easier to read.
+ * @param {object} pathMap A dictionary mapping from target paths to source paths.
+ * @param {boolean} force If target and source are both files, and the force flag is not
+ *     set, then the file will not be copied unless the source is newer than the target.
+ * @param {function} [log] Optional logging callback that takes a string message describing any
+ *     file operations that are performed.
+ * @return {boolean} true if any changes were made, or false if the force flag is not set
+ *     and everything was up to date
+ */
+function updatePaths(rootDir, pathMap, force, log) {
+    if (!pathMap || typeof(pathMap) !== "object") {
+        throw new Error("An object mapping from target paths to source paths is required.");
+    }
+
+    var updated = false;
+
+    for (var targetPath in pathMap) {
+        var sourcePath = pathMap[targetPath];
+        updated = updatePath(rootDir, targetPath, sourcePath, force, log) || updated;
+    }
+
+    return updated;
+}
+
+/**
+ * Updates a target directory with merged files and subdirectories from source directories.
+ *
+ * @param {string|null} rootDir Root directory (such as a project) to which target and source
+ *     path parameters are relative, or null if the paths are absolute. The rootDir is omitted
+ *     from any logged paths, to make the logs easier to read.
+ * @param {string} targetDir Destination directory to be updated. If it does not exist, it will be
+ *     created. If it exists, newer files from source directories will be copied over, and files
+ *     missing in the source directories will be deleted.
+ * @param {string|string[]} sourceDirs Source directory or array of source directories to be
+ *     merged into the target. The directories are listed in order of precedence; files in
+ *     directories later in the array supersede files in directories earlier in the array
+ *     (regardless of timestamps).
+ * @param {string|string[]|null} include Optional glob string or array of glob strings that are
+ *     tested against both target and source relative paths to determine if they are include in
+ *     the merge-and-update. If null, all items are included.
+ * @param {string|string[]|null} exclude Optional glob string or array of glob strings that are
+ *     tested against both target and source relative paths to determine if they are excluded
+ *     from the merge-and-update. Exclusions override inclusions. If null, no items are excluded.
+ * @param {boolean} force If target and source are both files, and the force flag is not
+ *     set, then the file will not be copied unless the source is newer than the target.
+ * @param {function} [log] Optional logging callback that takes a string message describing any
+ *     file operations that are performed.
+ * @return {boolean} true if any changes were made, or false if the force flag is not set
+ *     and everything was up to date
+ */
+function mergeAndUpdateDir(rootDir, targetDir, sourceDirs, include, exclude, force, log) {
+    rootDir = rootDir || "";
+    if (typeof(rootDir) !== "string") {
+        throw new Error("A root directory path (or null) is required.");
+    }
+
+    if (!targetDir || typeof(targetDir) !== "string") {
+        throw new Error("A target directory path is required.");
+    }
+
+    if (typeof(sourceDirs) === "string") {
+        sourceDirs = [ sourceDirs ];
+    } else if (!Array.isArray(sourceDirs) || sourceDirs.length === 0) {
+        throw new Error("A source directory path or array of paths is required.");
+    }
+
+    if (!include) {
+        include = [ "**" ];
+    } else if (typeof (include) === "string") {
+        include = [ include ];
+    } else if (!Array.isArray(include)) {
+        throw new Error("Include parameter must be a glob string or array of glob strings.");
+    }
+
+    if (!exclude) {
+        exclude = [];
+    } else if (typeof (exclude) === "string") {
+        exclude = [ exclude ];
+    } else if (!Array.isArray(exclude)) {
+        throw new Error("Exclude parameter must be a glob string or array of glob strings.");
+    }
+
+    // Scan the files in the target directory, if it exists.
+    var targetMap = {};
+    var targetFullPath = path.join(rootDir, targetDir);
+    if (fs.existsSync(targetFullPath)) {
+        targetMap = mapDirectory(rootDir, targetDir, include, exclude);
+    }
+
+    // Scan the files in each of the source directories.
+    var sourceMaps = [];
+    for (var i in sourceDirs) {
+        var sourceFullPath = path.join(rootDir, sourceDirs[i]);
+        if (!fs.existsSync(sourceFullPath)) {
+            throw new Error("Source directory does not exist: " + sourceDirs[i]);
+        }
+        sourceMaps[i] = mapDirectory(rootDir, sourceDirs[i], include, exclude);
+    }
+
+    var pathMap = mergePathMaps(targetDir, targetMap, sourceMaps);
+
+    var updated = false;
+
+    // Iterate in sorted order to ensure directories are created before files under them.
+    Object.keys(pathMap).sort().forEach(function (subPath) {
+        var entry = pathMap[subPath];
+        updated = updatePathWithStats(
+            rootDir,
+            entry.targetPath,
+            entry.targetStats,
+            entry.sourcePath,
+            entry.sourceStats,
+            force,
+            log) || updated;
+    });
+
+    return updated;
+}
+
+/**
+ * Creates a dictionary map of all files and directories under a path.
+ */
+function mapDirectory(rootDir, subDir, include, exclude) {
+    var dirMap = { "": { subDir: subDir, stats: fs.statSync(path.join(rootDir, subDir)) } };
+    mapSubdirectory(rootDir, subDir, "", include, exclude, dirMap);
+    return dirMap;
+
+    function mapSubdirectory(rootDir, subDir, relativeDir, include, exclude, dirMap) {
+        var itemMapped = false;
+        var items = fs.readdirSync(path.join(rootDir, subDir, relativeDir));
+        for (var i in items) {
+            var relativePath = path.join(relativeDir, items[i]);
+
+            // Skip any files or directories (and everything under) that match an exclude glob.
+            if (matchGlobArray(relativePath, exclude)) {
+                continue;
+            }
+
+            // Stats obtained here (required at least to know where to recurse in directories)
+            // are saved for later, where the modified times may also be used. This minimizes
+            // the number of file I/O operations performed.
+            var fullPath = path.join(rootDir, subDir, relativePath);
+            var stats = fs.statSync(fullPath);
+
+            // Directories are included if either something under them is included or they
+            // match an include glob. Files are included only if they match an include glob.
+            if (stats.isDirectory() ?
+                    (mapSubdirectory(rootDir, subDir, relativePath, include, exclude, dirMap) ||
+                        matchGlobArray(relativePath, include)) :
+                    (stats.isFile() && matchGlobArray(relativePath, include))) {
+                dirMap[relativePath] = { subDir: subDir, stats: stats };
+                itemMapped = true;
+            }
+        }
+        return itemMapped;
+    }
+
+    function matchGlobArray(path, globs) {
+        for (var i in globs) {
+            if (minimatch(path, globs[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * Merges together multiple source maps and a target map into a single mapping from
+ * relative paths to objects with target and source paths and stats.
+ */
+function mergePathMaps(targetDir, targetMap, sourceMaps) {
+    // Merge multiple source maps together, along with target path info.
+    // Entries in later source maps override those in earlier source maps.
+    // Target stats will be filled in below for targets that exist.
+    var pathMap = {};
+    for (var i in sourceMaps) {
+        var sourceMap = sourceMaps[i];
+        for (var sourceSubPath in sourceMap) {
+            var sourceEntry = sourceMap[sourceSubPath];
+            pathMap[sourceSubPath] = {
+                targetPath: path.join(targetDir, sourceSubPath),
+                targetStats: null,
+                sourcePath: path.join(sourceEntry.subDir, sourceSubPath),
+                sourceStats: sourceEntry.stats
+            };
+        }
+    }
+
+    // Fill in target stats for targets that exist, and create entries
+    // for targets that don't have any corresponding sources.
+    for (var subPath in targetMap) {
+        var entry = pathMap[subPath];
+        if (entry) {
+            entry.targetStats = targetMap[subPath].stats;
+        } else {
+            pathMap[subPath] = {
+                targetPath: path.join(targetDir, subPath),
+                targetStats: targetMap[subPath].stats,
+                sourcePath: null,
+                sourceStats: null
+            };
+        }
+    }
+
+    return pathMap;
+}
+
+module.exports = {
+    updatePath: updatePath,
+    updatePaths: updatePaths,
+    mergeAndUpdateDir: mergeAndUpdateDir
+};
+


### PR DESCRIPTION
The new FileUpdater module contains a few functions that enable optimized
file copies by comparing timestamps. These functions are primarily
intended to be used by each platform's prepare operation to avoid
redundantly copying files that haven't changed since the last build, thus
greatly speeding up build times after the first build. But the usfulness
isn't necessarily limited to the prepare operation; the functions could
be used for any Cordova file copy operations that benefit from the same
optimization.

In this initial change, the FileUpdater isn't used yet anywhere. Look for
follow-up changes in other repos which make use of the FileUpdater from
platforms' prepare operations, and a CLI change that enables the
timestamp-based optimization via a new --incremental flag.