### PR TITLE
CB-11023 Add attribute through config-file tag

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -227,6 +227,10 @@ describe('config.xml parser', function () {
                 var navigations = cfg.getAllowNavigations();
                 expect(navigations.length).not.toEqual(0);
             });
+            it('it should read <config-file> tag entries', function(){
+                var configFile = cfg.getConfigFiles('android');
+                expect(configFile.length).not.toEqual(0);
+            });
         });
         describe('static resources', function() {
             var hasPlatformPropertyDefined = function (e) { return !!e.platform; };

--- a/cordova-common/spec/fixtures/plugins/org.test.xmlattributestest/plugin.xml
+++ b/cordova-common/spec/fixtures/plugins/org.test.xmlattributestest/plugin.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.xmlattributestest"
+    version="1.0.0">
+
+    <name>Adding attributes through config-file</name>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="AndroidManifest.xml" parent="application" attr="true">
+            <activity android:hardwareAccelerated="true" />
+            <activity android:configChanges="orientation" />
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest" attr="true">
+            <uses-sdk android:targetSdkVersion="23" />
+            <uses-sdk android:minSdkVersion="14" />
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/*/application" attr="true">
+            <activity android:hardwareAccelerated="true" />
+            <activity android:configChanges="orientation" />
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest/application" attr="true">
+            <poop android:poop="poop" />
+        </config-file>
+    </platform>
+
+</plugin>

--- a/cordova-common/spec/fixtures/test-config.xml
+++ b/cordova-common/spec/fixtures/test-config.xml
@@ -85,6 +85,15 @@
         <icon cdv:density="mdpi" height="255" src="logo-android-cdv.png" width="255" />
         <preference name="android-minSdkVersion" value="10" />
         <preference name="orientation" value="landscape" />
+        <!-- add new tag -->
+        <config-file target="AndroidManifest.xml" parent="application" >
+            <activity android:name="NewActivity" />
+        </config-file>
+        <!-- add new attribute and overwrite attribute -->
+        <config-file target="AndroidManifest.xml" parent="/manifest" attr="true">
+            <application android:name="MyApplication"/>
+            <uses-sdk android:minSdkVersion="15"/>
+        </config-file>
     </platform>
     <platform name="windows">
         <icon src="res/windows/logo.scale-200.png" target="logo.png"/>

--- a/cordova-common/src/ConfigChanges/ConfigChanges.js
+++ b/cordova-common/src/ConfigChanges/ConfigChanges.js
@@ -291,7 +291,7 @@ function generate_plugin_config_munge(pluginInfo, vars) {
                 });
             }
             // 2. add into munge
-            mungeutil.deep_add(munge, change.target, change.parent, { xml: stringified, count: 1, after: change.after });
+            mungeutil.deep_add(munge, change.target, change.parent, { xml: stringified, count: 1, after: change.after, attr: change.attr });
         });
     });
     return munge;

--- a/cordova-common/src/ConfigChanges/ConfigFile.js
+++ b/cordova-common/src/ConfigChanges/ConfigFile.js
@@ -103,7 +103,12 @@ ConfigFile.prototype.graft_child = function ConfigFile_graft_child(selector, xml
     var result;
     if (self.type === 'xml') {
         var xml_to_graft = [modules.et.XML(xml_child.xml)];
-        result = modules.xml_helpers.graftXML(self.data, xml_to_graft, selector, xml_child.after);
+        if (xml_child.attr) {
+            result = modules.xml_helpers.graftXMLAttr(self.data, xml_to_graft, selector, xml_child.after);
+        }
+        else {
+            result = modules.xml_helpers.graftXML(self.data, xml_to_graft, selector, xml_child.after);
+        }
         if ( !result) {
             throw new Error('grafting xml at selector "' + selector + '" from "' + filepath + '" during config install went bad :(');
         }
@@ -123,7 +128,12 @@ ConfigFile.prototype.prune_child = function ConfigFile_prune_child(selector, xml
     var result;
     if (self.type === 'xml') {
         var xml_to_graft = [modules.et.XML(xml_child.xml)];
-        result = modules.xml_helpers.pruneXML(self.data, xml_to_graft, selector);
+        if (xml_child.attr) {
+            result = modules.xml_helpers.pruneXMLAttr(self.data, xml_to_graft, selector);
+        }
+        else {
+            result = modules.xml_helpers.pruneXML(self.data, xml_to_graft, selector);
+        }
     } else {
         // plist file
         result = modules.plist_helpers.prunePLIST(self.data, xml_child.xml, selector);

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -100,7 +100,7 @@ ConfigParser.prototype = {
         return this.doc.getroot().attrib['android-packageName'];
     },
     android_activityName: function() {
-	return this.doc.getroot().attrib['android-activityName'];
+        return this.doc.getroot().attrib['android-activityName'];
     },
     ios_CFBundleIdentifier: function() {
         return this.doc.getroot().attrib['ios-CFBundleIdentifier'];
@@ -462,6 +462,28 @@ ConfigParser.prototype = {
                 'minimum_tls_version': minimum_tls_version,
                 'requires_forward_secrecy' : requires_forward_secrecy
             };
+        });
+    },
+    /* Get all config-file tags */
+    getConfigFiles: function(platform) {
+        var platform_tag = this.doc.find('./platform[@name="' + platform + '"]');
+        var platform_config_files = platform_tag ? platform_tag.findall('config-file') : [];
+
+        var config_files = this.doc.findall('config-file').concat(platform_config_files);
+
+        return config_files.map(function(tag) {
+            var configFile =
+                {
+                    target : tag.attrib['target'],
+                    parent : tag.attrib['parent'],
+                    after : tag.attrib['after'],
+                    attr : tag.attrib['attr'],
+                    xmls : tag.getchildren(),
+                    // To support demuxing via versions
+                    versions : tag.attrib['versions'],
+                    deviceTarget: tag.attrib['device-target']
+                };
+            return configFile;
         });
     },
     write:function() {

--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -138,6 +138,7 @@ function PluginInfo(dirname) {
             { target : tag.attrib['target']
             , parent : tag.attrib['parent']
             , after : tag.attrib['after']
+            , attr : tag.attrib['attr']
             , xmls : tag.getchildren()
             // To support demuxing via versions
             , versions : tag.attrib['versions']

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -21,6 +21,7 @@ var cordova_util      = require('./util'),
     ConfigParser      = require('cordova-common').ConfigParser,
     PlatformJson      = require('cordova-common').PlatformJson,
     PluginInfoProvider = require('cordova-common').PluginInfoProvider,
+    PlatformMunger    = require('cordova-common').ConfigChanges.PlatformMunger,
     events            = require('cordova-common').events,
     platforms         = require('../platforms/platforms'),
     PlatformApiPoly = require('../platforms/PlatformApiPoly'),
@@ -116,6 +117,13 @@ function preparePlatforms (platformList, projectRoot, options) {
                     var browserify = require('../plugman/browserify');
                     return browserify(project, platformApi);
                 }
+            })
+            .then(function () {
+                // Handle config-file in config.xml
+                var platformRoot = path.join(projectRoot, 'platforms', platform);
+                var platformJson = PlatformJson.load(platformRoot, platform);
+                var munger = new PlatformMunger(platform, platformRoot, platformJson);
+                munger.add_config_changes(project.projectConfig, /*should_increment=*/true).save_all();
             });
         });
     }));


### PR DESCRIPTION
Add functionality to be able to add attributes to xml files through config-file tag. 

Syntax:
Able to add multiple attributes to multiple elements at once (only to direct children of the parent). 
```
<config-file target="AndroidManifest.xml" parent="/manifest" attr="true">
        <application android:name="MyApplication" android:isGame="true" />
        <uses-sdk android:maxSdkVersion="22" />
</config-file>
```