### PR TITLE
CB-11174 Resolve symlinked path before getting PlatformApi instance

### DIFF
--- a/cordova-lib/src/platforms/platforms.js
+++ b/cordova-lib/src/platforms/platforms.js
@@ -40,6 +40,9 @@ function getPlatformApi(platform, platformRootDir) {
         throw new Error('Current location is not a Cordova project');
     }
 
+    // CB-11174 Resolve symlinks first before working with root directory
+    platformRootDir = util.convertToRealPathSafe(platformRootDir);
+
     var cached = cachedApis[platformRootDir];
     if (cached && cached.platform == platform) return cached;
 


### PR DESCRIPTION
This PR the issue when `getPlatformApi` method in cordova-lib returns a different instances for two paths pointing to the same destination, This also fixes 'npm test' failures on OS X.

See JIRA [CB-11174](https://issues.apache.org/jira/browse/CB-11174) for background and details.