### PR TITLE
CB-11261 Cut out '-nightly' prerelease tag when checking plugin engines

### DIFF
--- a/cordova-lib/spec-plugman/install.spec.js
+++ b/cordova-lib/spec-plugman/install.spec.js
@@ -277,7 +277,7 @@ describe('install', function() {
                 install('android', project, plugins['com.cordova.engine'])
                 .fail(fail)
                 .fin(function () {
-                    expect(satisfies).toHaveBeenCalledWith('2.5.0','>=1.0.0');
+                    expect(satisfies).toHaveBeenCalledWith('2.5.0','>=1.0.0', true);
                     done();
                 });
             });
@@ -286,7 +286,7 @@ describe('install', function() {
                 install('android', project, plugins['com.cordova.engine'])
                 .fail(fail)
                 .fin(function () {
-                    expect(satisfies).toHaveBeenCalledWith('3.0.0-rc1','>=1.0.0');
+                    expect(satisfies).toHaveBeenCalledWith('3.0.0-rc1','>=1.0.0', true);
                     done();
                 });
             });
@@ -295,23 +295,23 @@ describe('install', function() {
                 install('android', project, plugins['com.cordova.engine-android'])
                 .fail(fail)
                 .fin(function() {
-                    expect(satisfies).toHaveBeenCalledWith('3.1.0','>=3.1.0');
+                    expect(satisfies).toHaveBeenCalledWith('3.1.0','>=3.1.0', true);
                     done();
                 });
             });
             it('should check platform sdk version if specified', function(done) {
-                var cordovaVersion = require('../package.json').version.replace('-dev', '');
+                var cordovaVersion = require('../package.json').version.replace(/-dev|-nightly.*$/, '');
                 exec.andCallFake(function(cmd, cb) { cb(null, '18\n'); });
                 install('android', project, plugins['com.cordova.engine-android'])
                 .fail(fail)
                 .fin(function() {
                     expect(satisfies.calls.length).toBe(3);
                     // <engine name="cordova" VERSION=">=3.0.0"/>
-                    expect(satisfies.calls[0].args).toEqual([ cordovaVersion, '>=3.0.0' ]);
+                    expect(satisfies.calls[0].args).toEqual([ cordovaVersion, '>=3.0.0', true ]);
                     // <engine name="cordova-android" VERSION=">=3.1.0"/>
-                    expect(satisfies.calls[1].args).toEqual([ '18.0.0', '>=3.1.0' ]);
+                    expect(satisfies.calls[1].args).toEqual([ '18.0.0', '>=3.1.0', true ]);
                     // <engine name="android-sdk" VERSION=">=18"/>
-                    expect(satisfies.calls[2].args).toEqual([ '18.0.0','>=18' ]);
+                    expect(satisfies.calls[2].args).toEqual([ '18.0.0','>=18', true ]);
                     done();
                 });
             });
@@ -319,17 +319,17 @@ describe('install', function() {
                 install('android', project, plugins['com.cordova.engine'])
                 .fail(fail)
                 .fin(function() {
-                    var plugmanVersion = require('../package.json').version.replace('-dev', '');
-                    var cordovaVersion = require('../package.json').version.replace('-dev', '');
+                    var plugmanVersion = require('../package.json').version.replace(/-dev|-nightly.*$/, '');
+                    var cordovaVersion = require('../package.json').version.replace(/-dev|-nightly.*$/, '');
                     expect(satisfies.calls.length).toBe(4);
                     // <engine name="cordova" version=">=2.3.0"/>
-                    expect(satisfies.calls[0].args).toEqual([ cordovaVersion, '>=2.3.0' ]);
+                    expect(satisfies.calls[0].args).toEqual([ cordovaVersion, '>=2.3.0', true ]);
                     // <engine name="cordova-plugman" version=">=0.10.0" />
-                    expect(satisfies.calls[1].args).toEqual([ plugmanVersion, '>=0.10.0' ]);
+                    expect(satisfies.calls[1].args).toEqual([ plugmanVersion, '>=0.10.0', true ]);
                     // <engine name="mega-fun-plugin" version=">=1.0.0" scriptSrc="megaFunVersion" platform="*" />
-                    expect(satisfies.calls[2].args).toEqual([ null, '>=1.0.0' ]);
+                    expect(satisfies.calls[2].args).toEqual([ null, '>=1.0.0', true ]);
                     // <engine name="mega-boring-plugin" version=">=3.0.0" scriptSrc="megaBoringVersion" platform="ios|android" />
-                    expect(satisfies.calls[3].args).toEqual([ null, '>=3.0.0' ]);
+                    expect(satisfies.calls[3].args).toEqual([ null, '>=3.0.0', true ]);
                     done();
                 });
             });
@@ -337,7 +337,7 @@ describe('install', function() {
                 install('blackberry10', project, plugins['com.cordova.engine'])
                 .then(fail)
                 .fail(function () {
-                    expect(satisfies).not.toHaveBeenCalledWith('','>=3.0.0');
+                    expect(satisfies).not.toHaveBeenCalledWith('','>=3.0.0', true);
                 })
                 .fin(done);
             });

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -134,15 +134,15 @@ function checkEngines(engines) {
         var engine = engines[i];
 
         // This is a hack to allow plugins with <engine> tag to be installed with
-        // engine with '-dev' suffix. It is required due to new semver range logic,
+        // engine with '-dev' or '-nightly' suffixes. It is required due to new semver range logic,
         // introduced in semver@3.x. For more details see https://github.com/npm/node-semver#prerelease-tags.
         //
         // This may lead to false-positive checks, when engine version with dropped
         // suffix is equal to one of range bounds, for example: 5.1.0-dev >= 5.1.0.
         // However this shouldn't be a problem, because this only should happen in dev workflow.
-        engine.currentVersion = engine.currentVersion && engine.currentVersion.replace(/-dev$/, '');
-        if ( semver.satisfies(engine.currentVersion, engine.minVersion) || engine.currentVersion === null ) {
-            // engine ok!
+        engine.currentVersion = engine.currentVersion && engine.currentVersion.replace(/-dev|-nightly.*$/, '');
+        if ( semver.satisfies(engine.currentVersion, engine.minVersion, /*loose=*/true) || engine.currentVersion === null ) {
+            continue; // engine ok!
         } else {
             var msg = 'Plugin doesn\'t support this project\'s ' + engine.name + ' version. ' +
                       engine.name + ': ' + engine.currentVersion +


### PR DESCRIPTION
See the background and explanation at [CB-11261](https://issues.apache.org/jira/browse/CB-11261)

This PR is required for tests to pass on nightly builds