### PR TITLE
CB-11023 Add edit-config functionality

### DIFF
--- a/cordova-common/spec/fixtures/plugins/org.test.editconfigtest/plugin.xml
+++ b/cordova-common/spec/fixtures/plugins/org.test.editconfigtest/plugin.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.editconfigtest"
+    version="3.0.0">
+
+    <name>Test edit-config</name>
+
+    <!-- android -->
+    <platform name="android">
+        <edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:name='org.test.DroidGap']" mode="merge">
+            <activity android:enabled="true" android:configChanges="keyboardHidden"  />
+        </edit-config>
+        <edit-config file="AndroidManifest.xml" target="/manifest/application/activity" mode="overwrite">
+            <activity android:name="ChildApp" android:label="@string/app_name" android:enabled="true" />
+        </edit-config>
+    </platform>
+</plugin>

--- a/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
+++ b/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.test.editconfigtest_two"
+    version="3.0.0">
+
+    <name>Test edit-config with conflicts</name>
+
+    <!-- android -->
+    <platform name="android">
+        <edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:name='org.test.DroidGap']" mode="merge">
+            <activity android:enabled="true" android:configChanges="orientation|keyboardHidden"  />
+        </edit-config>
+        <edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:name='ChildApp']" mode="overwrite">
+            <activity android:name="ChildApp" android:label="@string/app_name" android:enabled="false" />
+        </edit-config>
+    </platform>
+</plugin>

--- a/cordova-common/src/ConfigChanges/ConfigFile.js
+++ b/cordova-common/src/ConfigChanges/ConfigFile.js
@@ -103,7 +103,16 @@ ConfigFile.prototype.graft_child = function ConfigFile_graft_child(selector, xml
     var result;
     if (self.type === 'xml') {
         var xml_to_graft = [modules.et.XML(xml_child.xml)];
-        result = modules.xml_helpers.graftXML(self.data, xml_to_graft, selector, xml_child.after);
+        switch (xml_child.mode) {
+            case 'merge':
+                result = modules.xml_helpers.graftXMLMerge(self.data, xml_to_graft, selector, xml_child);
+                break;
+            case 'overwrite':
+                result = modules.xml_helpers.graftXMLOverwrite(self.data, xml_to_graft, selector, xml_child);
+                break;
+            default:
+                result = modules.xml_helpers.graftXML(self.data, xml_to_graft, selector, xml_child.after);
+        }
         if ( !result) {
             throw new Error('Unable to graft xml at selector "' + selector + '" from "' + filepath + '" during config install');
         }
@@ -123,7 +132,14 @@ ConfigFile.prototype.prune_child = function ConfigFile_prune_child(selector, xml
     var result;
     if (self.type === 'xml') {
         var xml_to_graft = [modules.et.XML(xml_child.xml)];
-        result = modules.xml_helpers.pruneXML(self.data, xml_to_graft, selector);
+        switch (xml_child.mode) {
+            case 'merge':
+            case 'overwrite':
+                result = modules.xml_helpers.pruneXMLRestore(self.data, selector, xml_child);
+                break;
+            default:
+                result = modules.xml_helpers.pruneXML(self.data, xml_to_graft, selector);
+        }
     } else {
         // plist file
         result = modules.plist_helpers.prunePLIST(self.data, xml_child.xml, selector);

--- a/cordova-common/src/ConfigChanges/munge-util.js
+++ b/cordova-common/src/ConfigChanges/munge-util.js
@@ -52,6 +52,9 @@ exports.deep_remove = function deep_remove(obj, keys /* or key1, key2 .... */ ) 
             return element.xml == k.xml;
         });
         if (found) {
+            if (parentArray[index].oldAttrib) {
+                k.oldAttrib = _.extend({}, parentArray[index].oldAttrib);
+            }
             found.count -= k.count;
             if (found.count > 0) {
                 return false;

--- a/cordova-common/src/PlatformJson.js
+++ b/cordova-common/src/PlatformJson.js
@@ -162,8 +162,8 @@ PlatformJson.prototype.removePluginMetadata = function (pluginInfo) {
     return this;
 };
 
-PlatformJson.prototype.addInstalledPluginToPrepareQueue = function(pluginDirName, vars, is_top_level) {
-    this.root.prepare_queue.installed.push({'plugin':pluginDirName, 'vars':vars, 'topLevel':is_top_level});
+PlatformJson.prototype.addInstalledPluginToPrepareQueue = function(pluginDirName, vars, is_top_level, force) {
+    this.root.prepare_queue.installed.push({'plugin':pluginDirName, 'vars':vars, 'topLevel':is_top_level, 'force':force});
 };
 
 PlatformJson.prototype.addUninstalledPluginToPrepareQueue = function(pluginId, is_top_level) {
@@ -276,4 +276,3 @@ function ModuleMetadata (pluginId, jsModule) {
 }
 
 module.exports = PlatformJson;
-

--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -146,6 +146,22 @@ function PluginInfo(dirname) {
         return configFile;
     }
 
+    self.getEditConfigs = getEditConfigs;
+    function getEditConfigs(platform) {
+        var editConfigs = _getTags(self._et, 'edit-config', platform, _parseEditConfigs);
+        return editConfigs;
+    }
+
+    function _parseEditConfigs(tag) {
+        var editConfig =
+        { file : tag.attrib['file']
+        , target : tag.attrib['target']
+        , mode : tag.attrib['mode']
+        , xmls : tag.getchildren()
+        };
+        return editConfig;
+    }
+
     // <info> tags, both global and within a <platform>
     // TODO (kamrik): Do we ever use <info> under <platform>? Example wanted.
     self.getInfo = getInfo;

--- a/cordova-common/src/PluginManager.js
+++ b/cordova-common/src/PluginManager.js
@@ -123,7 +123,7 @@ PluginManager.prototype.doOperation = function (operation, plugin, options) {
         if (operation === PluginManager.INSTALL) {
             // Ignore passed `is_top_level` option since platform itself doesn't know
             // anything about managing dependencies - it's responsibility of caller.
-            self.munger.add_plugin_changes(plugin, options.variables, /*is_top_level=*/true, /*should_increment=*/true);
+            self.munger.add_plugin_changes(plugin, options.variables, /*is_top_level=*/true, /*should_increment=*/true, options.force);
             self.munger.platformJson.addPluginMetadata(plugin);
         } else {
             self.munger.remove_plugin_changes(plugin, /*is_top_level=*/true);


### PR DESCRIPTION
New edit-config tag for plugin.xml will allow users to modify xml attributes of any xml file. 

Using AndroidManifest.xml as an example. Assumes your AndroidManifest.xml has a second activity element with attribute android:name="SecondActivity"
```xml
<!-- Will modify first activity -->
<edit-config file="AndroidManifest.xml" target="/manifest/application/activity" mode="merge">
            <activity android:enabled="true" android:configChanges="orientation|keyboardHidden" />
</edit-config>
<!-- Will modify second activity -->
<edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:name='SecondActivity']" mode="overwrite">
            <activity android:enabled="true" android:name="SecondActivity" />
</edit-config>
```
file: specifies the file location
target: specifies an xpath to the element that you want to modify
modes: 
- merge: add attributes in the target with the ones specified by edit-config and will replace if the attribute names are the same
- overwrite: replace all of the attributes at the target with the one specified by edit-config

children: will only modify one element per edit-config tag

There is conflict checking now....if a plugin wants to modify an attribute another plugin has already modified, an error will be thrown and plugin install will fail. The user must fix the conflict or they can use --force to force add the plugin and overwrite the conflict. 

Lastly, on plugin uninstall, the plugin should restore the attributes to the state it was before installing.

Note: Using --force to overwrite a conflict will remove the conflicting attribute changes from the file. These changes will not be restorable since the attributes were forced to be overwritten. To get your changes back, you should uninstall then reinstall that plugin.  