### PR TITLE
Support a display name via config.xml

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -83,7 +83,20 @@ describe('config.xml parser', function () {
                 cfg.setName('this.is.bat.country');
                 expect(cfg.name()).toEqual('this.is.bat.country');
             });
+
+            describe('short name', function() {
+                it('should default to the app name', function() {
+                    expect(cfg.shortName()).toEqual('Hello Cordova');
+                });
+
+                it('should allow setting the app short name', function() {
+                    cfg.setShortName('Hi CDV');
+                    expect(cfg.name()).toEqual('Hello Cordova');
+                    expect(cfg.shortName()).toEqual('Hi CDV');
+                });
+            });
         });
+
         describe('preference', function() {
             it('Test 010 : should return the value of a global preference', function() {
                 expect(cfg.getPreference('fullscreen')).toEqual('true');

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -116,6 +116,16 @@ ConfigParser.prototype = {
         var el = findOrCreate(this.doc, 'name');
         el.text = name;
     },
+    shortName: function() {
+        return this.doc.find('name').attrib['short'] || this.name();
+    },
+    setShortName: function(shortname) {
+        var el = findOrCreate(this.doc, 'name');
+        if (!el.text) {
+            el.text = shortname;
+        }
+        el.attrib['short'] = shortname;
+    },
     description: function() {
         return getNodeTextSafe(this.doc.find('description'));
     },


### PR DESCRIPTION
The W3C Widgets spec allows for a `short` attribute on the `<name>` element in config.xml, which is to be used for a display name:  
https://www.w3.org/TR/widgets/#the-short-attribute

This adds a new `shortName` function to ConfigParser, which will return the value of that attribute, falling back to returning the content of the `<name>` element.
The `setShortName` function will attempt to set the attribute on the `<name>` element to the specified value. If the `<name>` element does not exist, it will be created with both the text content and the `short` attribute having the specified value.

I've updated the legacy/compat project metadata helpers here, and will open pull requests against the  Platform API projects. I'm not entirely sure how to best approach that given the API addition to ConfigParser. Maybe it's best to test for the existence of the `shortName` function before calling it?
