### PR TITLE
Bugfix in PlatformApiPoly#prepare()

### DIFF
--- a/cordova-lib/src/platforms/PlatformApiPoly.js
+++ b/cordova-lib/src/platforms/PlatformApiPoly.js
@@ -178,7 +178,7 @@ PlatformApiPoly.prototype.prepare = function (cordovaProject, options) {
     var defaultConfig = path.join(this.root, 'cordova', 'defaults.xml');
     var ownConfig = this.getPlatformInfo().locations.configXml;
 
-    var sourceCfg = cordovaProject.projectConfig.path;
+    var sourceCfg = cordovaProject.projectConfig;
     // If defaults.xml is present, overwrite platform config.xml with it.
     // Otherwise save whatever is there as defaults so it can be
     // restored or copy project config into platform if none exists.


### PR DESCRIPTION
sourceCfg was being assigned the 'path' property, rather than the whole project config object. This was causing an error when attempting to access the path property on line 191.