### PR TITLE
CB-11493: Add cordova emulate option to skip prepare

### DIFF
--- a/cordova-lib/src/cordova/emulate.js
+++ b/cordova-lib/src/cordova/emulate.js
@@ -35,8 +35,10 @@ module.exports = function emulate(options) {
         var hooksRunner = new HooksRunner(projectRoot);
         return hooksRunner.fire('before_emulate', options)
         .then(function() {
-            // Run a prepare first!
-            return require('./cordova').raw.prepare(options);
+            if (!options.options.noprepare) {
+                // Run a prepare first!
+                return require('./cordova').raw.prepare(options);
+            }
         }).then(function() {
             // Deploy in parallel (output gets intermixed though...)
             return Q.all(options.platforms.map(function(platform) {


### PR DESCRIPTION
I just created an issue for this over at the apache jira: https://issues.apache.org/jira/browse/CB-11493.
I hope it's ok that I created a PR right away.

> Analogous to the recently added `--no-prepare` options for `cordova run` in version 6.2 (issue: https://issues.apache.org/jira/browse/CB-11042) I'd like to implement a similar option for `cordova emulate`.
