### PR TITLE
Fixed typos in 'platform' name

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -398,7 +398,7 @@ function _getTags(pelem, tag, platform, transform) {
     return tags;
 }
 
-// Same as _getTags() but only looks inside a platfrom section.
+// Same as _getTags() but only looks inside a platforrm section.
 function _getTagsInPlatform(pelem, tag, platform, transform) {
     var platformTag = pelem.find('./platform[@name="' + platform + '"]');
     var tags = platformTag ? platformTag.findall(tag) : [];

--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -398,7 +398,7 @@ function _getTags(pelem, tag, platform, transform) {
     return tags;
 }
 
-// Same as _getTags() but only looks inside a platforrm section.
+// Same as _getTags() but only looks inside a platform section.
 function _getTagsInPlatform(pelem, tag, platform, transform) {
     var platformTag = pelem.find('./platform[@name="' + platform + '"]');
     var tags = platformTag ? platformTag.findall(tag) : [];

--- a/cordova-lib/RELEASENOTES.md
+++ b/cordova-lib/RELEASENOTES.md
@@ -445,7 +445,7 @@
 * [CB-7839](https://issues.apache.org/jira/browse/CB-7839) android: Fix versionCode logic when version is less than 3 digits
 * [CB-7033](https://issues.apache.org/jira/browse/CB-7033) Improve cordova platform check
 * [CB-7311](https://issues.apache.org/jira/browse/CB-7311) Fix xcode project manipulation on Windows host
-* [CB-7820](https://issues.apache.org/jira/browse/CB-7820) Make cordova platfrom restore not stop if a platforms fails to restore
+* [CB-7820](https://issues.apache.org/jira/browse/CB-7820) Make cordova platform restore not stop if a platforms fails to restore
 * [CB-7649](https://issues.apache.org/jira/browse/CB-7649) Support iPhone 6 Plus Icon in CLI config.xml
 * [CB-7647](https://issues.apache.org/jira/browse/CB-7647) Support new iPhone 6 and 6 Plus Images in the CLI config.xml
 * [CB-7909](https://issues.apache.org/jira/browse/CB-7909) "plugman platform add" fixes

--- a/cordova-lib/src/platforms/PlatformApiPoly.js
+++ b/cordova-lib/src/platforms/PlatformApiPoly.js
@@ -444,7 +444,7 @@ PlatformApiPoly.prototype.requirements = function() {
         return require(modulePath).check_all();
     } catch (e) {
         var errorMsg = 'Failed to check requirements for ' + this.platform + ' platform. ' +
-            'check_reqs module is missing for platfrom. Skipping it...';
+            'check_reqs module is missing for platform. Skipping it...';
         return Q.reject(errorMsg);
     }
 };


### PR DESCRIPTION
I found 3 typos in the word "platform" inside the repository, one of which is visible straight after the requirements checks. I suggest the attached fixes. Thank you.