### PR TITLE
CB-11589: Fix missing plugin files after restore

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -193,22 +193,26 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
 
                 return promise()
                 .then(function () {
-                    return prepare.preparePlatforms([platform], projectRoot, { searchpath: opts.searchpath });
+                    if (!opts.restoring) {
+                        return prepare.preparePlatforms([platform], projectRoot, { searchpath: opts.searchpath });
+                    }
                 })
                 .then(function() {
-                    if (cmd == 'add') {
+                    if (cmd == 'add' && !opts.restoring) {
                         return installPluginsForNewPlatform(platform, projectRoot, opts);
                     }
                 })
                 .then(function () {
-                    // Call prepare for the current platform.
-                    var prepOpts = {
-                        platforms :[platform],
-                        searchpath :opts.searchpath,
-                        fetch: opts.fetch || false,
-                        save: opts.save || false
-                    };
-                    return require('./cordova').raw.prepare(prepOpts);
+                    if (!opts.restoring) {
+                        // Call prepare for the current platform if we're not restoring from config.xml
+                        var prepOpts = {
+                            platforms :[platform],
+                            searchpath :opts.searchpath,
+                            fetch: opts.fetch || false,
+                            save: opts.save || false
+                        };
+                        return require('./cordova').raw.prepare(prepOpts);
+                    }
                 })
                 .then(function() {
                     var saveVersion = !spec || semver.validRange(spec, true);

--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -43,7 +43,7 @@ function prepare(options) {
         var hooksRunner = new HooksRunner(projectRoot);
         return hooksRunner.fire('before_prepare', options)
         .then(function(){
-            return restore.installPlatformsFromConfigXML(options.platforms, { searchpath : options.searchpath, fetch : options.fetch, save : options.save });
+            return restore.installPlatformsFromConfigXML(options.platforms, { searchpath : options.searchpath, fetch : options.fetch, restoring : true });
         })
         .then(function(){
             options = cordova_util.preProcessOptions(options);


### PR DESCRIPTION
This avoid running prepare unnecessarily when restoring platforms as part of a prepare. This solves warnings about plugins already being installed, is a performance improvement, and fixes the weird case where I was getting an empty ios.json file after restoring plugins.

One thing that isn't clear to me is why `options.save` gets passed through the restore process. Restore is, by definition, adding stuff that has already been saved, so there should be no case in which that ever saves new platforms/plugins to config.xml?

/cc @vladimir-kotikov @riknoll @stevengill 