### PR TITLE
CB-8978 Add resource-file parsing to config.xml

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -281,5 +281,21 @@ describe('config.xml parser', function () {
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('mdpi').src).toBe('logo-android.png');
             });
         });
+
+        describe('file resources', function() {
+            var hasSrcPropertyDefined = function (e) { return !!e.src; };
+            var hasTargetPropertyDefined = function (e) { return !!e.target; };
+            var hasArchPropertyDefined = function (e) { return !!e.arch; };
+
+            it('should fetch platform-specific resources', function() {
+                expect(cfg.getFileResources('android').length).toBe(2);
+            });
+
+            it('should parse resources\' attributes', function() {
+                expect(cfg.getFileResources('android').every(hasSrcPropertyDefined)).toBeTruthy();
+                expect(cfg.getFileResources('android').every(hasTargetPropertyDefined)).toBeTruthy();
+                expect(cfg.getFileResources('windows').every(hasArchPropertyDefined)).toBeTruthy();
+            });
+        });
     });
 });

--- a/cordova-common/spec/fixtures/test-config.xml
+++ b/cordova-common/spec/fixtures/test-config.xml
@@ -86,6 +86,8 @@
         <icon density="mdpi" height="255" src="logo-android.png" width="255" />
         <icon gap:density="mdpi" height="255" src="logo-android-gap.png" width="255" />
         <icon cdv:density="mdpi" height="255" src="logo-android-cdv.png" width="255" />
+        <resource-file src="appconfig.json" target="appconfig.json" />
+        <resource-file src="androidconfig.json" target="androidconfig.json" />
         <preference name="android-minSdkVersion" value="10" />
         <preference name="orientation" value="landscape" />
     </platform>
@@ -93,6 +95,7 @@
         <icon src="res/windows/logo.scale-200.png" target="logo.png"/>
         <icon src="res/windows/logo-small.scale-400.png" width="72" target="logo.png"/>
         <icon src="res/windows/logo-small.scale-400_48.png" height="48" target="logo.png"/>
+        <resource-file src="windowsconfig.json" target="windowsconfig.json" arch="x86" device-target="all" />
     </platform>
     <plugin name="org.apache.cordova.pluginwithvars">
         <variable name="var" value="varvalue" />

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -257,6 +257,30 @@ ConfigParser.prototype = {
     },
 
     /**
+     * Returns all resource-files for a specific platform.
+     * @param  {string} platform Platform name
+     * @return {Resource[]}      Array of resource file objects.
+     */
+    getFileResources: function(platform) {
+        var fileResources = [];
+
+        if (platform) { // platform specific resources
+            fileResources = this.doc.findall('platform[@name=\'' + platform + '\']/resource-file').map(function(tag) {
+                return {
+                    platform: platform,
+                    src: tag.attrib.src,
+                    target: tag.attrib.target,
+                    versions: tag.attrib.versions,
+                    deviceTarget: tag.attrib['device-target'],
+                    arch: tag.attrib.arch
+                };
+            });
+        }
+
+        return fileResources;
+    },
+
+    /**
      * Returns all hook scripts for the hook type specified.
      * @param  {String} hook     The hook type.
      * @param {Array}  platforms Platforms to look for scripts into (root scripts will be included as well).


### PR DESCRIPTION
Original JIRA issue https://issues.apache.org/jira/browse/CB-8978
Related to/replaces https://github.com/apache/cordova-lib/pull/214
See also https://github.com/cordova/cordova-discuss/issues/6

This is just the first pass, we'll also need to update the platform API in each platform to actually copy the resource files around on prepare.

This returns the same data structure as the PluginInfo class. To be determined if we think having top-level `resource-file` elements makes sense, it appears that plugin.xml does not support them.

/cc @ktop @jcesarmobile
