### PR TITLE
CB-11645: Check for getEditConfigs before invoking it on pluginInfo

### DIFF
--- a/cordova-common/src/ConfigChanges/ConfigChanges.js
+++ b/cordova-common/src/ConfigChanges/ConfigChanges.js
@@ -97,7 +97,9 @@ function remove_plugin_changes(pluginInfo, is_top_level) {
     var plugin_vars = is_top_level ?
         platform_config.installed_plugins[pluginInfo.id] :
         platform_config.dependent_plugins[pluginInfo.id];
-    var edit_config_changes = pluginInfo.getEditConfigs(self.platform);
+
+    // Requires the CLI to be using cordova common version 1.4.0+
+    var edit_config_changes = pluginInfo.getEditConfigs ? pluginInfo.getEditConfigs(self.platform) : undefined;
 
     // get config munge, aka how did this plugin change various config files
     var config_munge = self.generate_plugin_config_munge(pluginInfo, plugin_vars, edit_config_changes);
@@ -131,7 +133,10 @@ PlatformMunger.prototype.add_plugin_changes = add_plugin_changes;
 function add_plugin_changes(pluginInfo, plugin_vars, is_top_level, should_increment, plugin_force) {
     var self = this;
     var platform_config = self.platformJson.root;
-    var edit_config_changes = pluginInfo.getEditConfigs(self.platform);
+
+    // Requires the CLI to be using cordova common version 1.4.0+
+    var edit_config_changes = pluginInfo.getEditConfigs ? pluginInfo.getEditConfigs(self.platform) : undefined;
+
     var config_munge;
 
     if (!edit_config_changes || edit_config_changes.length === 0) {


### PR DESCRIPTION
Adding a guard to prevent a type error when platforms and CLI have mismatching cordova-common versions. The issue here is that the `PluginInfo` object crosses the platform API barrier between the two so when 5fb8dffb2dc92e4d08d286432f23299da0e812 added `getEditConfigs`, it ended up being a breaking change. This just checks for the function and ignores `edit-config` changes if it is not defined. More permanent fix might be to move its functionality elsewhere so that it does not cross the platform API barrier. Plugins that rely on `edit-config` (which should be none at this point) should [specify the platform and cordova cli version they need](http://cordova.apache.org/docs/en/latest/guide/hybrid/plugins/index.html#specifying-cordova-dependencies) in package.json.