### PR TITLE
CB-11652 Update run and emulate to skip build

### DIFF
--- a/cordova-lib/spec-cordova/emulate.spec.js
+++ b/cordova-lib/spec-cordova/emulate.spec.js
@@ -131,6 +131,30 @@ describe('emulate command', function() {
                 }).fin(done);
             });
         });
+
+        it('should call platform\'s build method', function (done) {
+            cordova.raw.emulate({platforms: ['blackberry10']})
+            .then(function() {
+                expect(prepare_spy).toHaveBeenCalled();
+                expect(platformApi.build).toHaveBeenCalledWith({device: false, emulator: true});
+                expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({nobuild: true}));
+            }, function(err) {
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+        });
+
+        it('should not call build if --nobuild option is passed', function (done) {
+            cordova.raw.emulate({platforms: ['blackberry10'], options: { nobuild: true }})
+            .then(function() {
+                expect(prepare_spy).toHaveBeenCalled();
+                expect(platformApi.build).not.toHaveBeenCalled();
+                expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({nobuild: true}));
+            }, function(err) {
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+        });
     });
 
     describe('hooks', function() {

--- a/cordova-lib/spec-cordova/run.spec.js
+++ b/cordova-lib/spec-cordova/run.spec.js
@@ -107,6 +107,31 @@ describe('run command', function() {
                 done();
             });
         });
+
+        it('should call platform\'s build method', function (done) {
+            cordova.raw.run({platforms: ['blackberry10']})
+            .then(function() {
+                expect(prepare_spy).toHaveBeenCalled();
+                expect(platformApi.build).toHaveBeenCalledWith({});
+                expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({nobuild: true}));
+            }, function(err) {
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+        });
+
+        it('should not call build if --nobuild option is passed', function (done) {
+            cordova.raw.run({platforms: ['blackberry10'], options: { nobuild: true }})
+            .then(function() {
+                expect(prepare_spy).toHaveBeenCalled();
+                expect(platformApi.build).not.toHaveBeenCalled();
+                expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({nobuild: true}));
+            }, function(err) {
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+        });
+
         describe('run parameters should not be altered by intermediate build command', function() {
             var originalBuildSpy;
             beforeEach(function() {

--- a/cordova-lib/src/cordova/run.js
+++ b/cordova-lib/src/cordova/run.js
@@ -30,6 +30,10 @@ module.exports = function run(options) {
         var projectRoot = cordova_util.cdProjectRoot();
         options = cordova_util.preProcessOptions(options);
 
+        // This is needed as .build modifies opts
+        var optsClone = _.clone(options.options);
+        optsClone.nobuild = true;
+
         var hooksRunner = new HooksRunner(projectRoot);
         return hooksRunner.fire('before_run', options)
         .then(function() {
@@ -40,20 +44,17 @@ module.exports = function run(options) {
         }).then(function() {
             // Deploy in parallel (output gets intermixed though...)
             return Q.all(options.platforms.map(function(platform) {
-                // This is needed as .build modifies opts
-                var optsClone = _.clone(options.options);
-                return platform_lib
-                    .getPlatformApi(platform)
-                    .build(options.options)
-                    .then(function() {
-                        return hooksRunner.fire('before_deploy', options);
-                    })
-                    .then(function() {
-                        optsClone.nobuild = true;
-                        return platform_lib
-                            .getPlatformApi(platform)
-                            .run(optsClone);
-                    });
+
+                var buildPromise = options.options.nobuild ? Q() :
+                    platform_lib.getPlatformApi(platform).build(options.options);
+
+                return buildPromise
+                .then(function() {
+                    return hooksRunner.fire('before_deploy', options);
+                })
+                .then(function() {
+                    return platform_lib.getPlatformApi(platform).run(optsClone);
+                });
             }));
         }).then(function() {
             return hooksRunner.fire('after_run', options);


### PR DESCRIPTION
This PR moves handling of `--nobuild` option to CLI. CLI previously has delegated this logic to platform's
`run` method but since introducing `before_deploy` hook we call platform's `build` and `run` separately and now need to handle this option here.

JIRA issue: [CB-11652](https://issues.apache.org/jira/browse/CB-11652)