### PR TITLE
CB-11698 Fix plugin installation when restoring platform

### DIFF
--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -676,6 +676,29 @@ describe('(save flag)', function () {
                 done();
             });
         });
+
+        it('spec.25 should install plugins already added to the project into platform when restoring it', function (done) {
+            var fail = jasmine.createSpy('fail').andCallFake(function (err) {
+                console.log(err.message);
+            });
+
+            cordova.raw.plugin('add', localPluginPath)
+            .then(function () {
+                helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
+                return prepare({ platforms: [ platformName ] });
+            })
+            .then(function () {
+                expect(path.join(appPath, 'platforms', platformName)).toExist();
+                // Validate that plugin has been installed to platform by checking
+                // platformJson file for plugin entry added
+                var platformJson = require(path.join(appPath, 'platforms', platformName, platformName + '.json'));
+                expect(platformJson.installed_plugins[localPluginName]).toBeDefined();
+            })
+            .finally(function () {
+                expect(fail).not.toHaveBeenCalled();
+                done();
+            });
+        });
     });
 
     describe('(cleanup)', function () {

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -198,7 +198,7 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     }
                 })
                 .then(function() {
-                    if (cmd == 'add' && !opts.restoring) {
+                    if (cmd == 'add') {
                         return installPluginsForNewPlatform(platform, projectRoot, opts);
                     }
                 })


### PR DESCRIPTION
This partially reverts #464 and forces cordova to always check for and install plugins, added to the project, to platform that is being restored at the moment.

JIRA link: [CB-11698](https://issues.apache.org/jira/browse/CB-11698)