### PR TITLE
[CB-11730] Modify condition of if clause to avoid similar project nam…

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -330,7 +330,7 @@ function copyPlugin(pinfo, plugins_dir, link) {
 
     shell.rm('-rf', dest);
 
-    if(!link && dest.indexOf(path.resolve(plugin_dir)) === 0) {
+    if(!link && dest.indexOf(path.resolve(plugin_dir)+'\\') === 0) {
 
         if(/^win/.test(process.platform)) {
             /*

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -330,7 +330,7 @@ function copyPlugin(pinfo, plugins_dir, link) {
 
     shell.rm('-rf', dest);
 
-    if(!link && dest.indexOf(path.resolve(plugin_dir)+'\\') === 0) {
+    if(!link && dest.indexOf(path.resolve(plugin_dir)+path.sep) === 0) {
 
         if(/^win/.test(process.platform)) {
             /*


### PR DESCRIPTION
…e with plugin name

The original if clause accepts 
 c:\work\SimplePlugin_TestBed with c:\work\SimplePlugin

So I add \ to the plugin directory name for only enable the if clause to complete match the directory name.
 c:\work\SimplePlugin\

nodejs.org description explains the path.resolve removes trailing slashes, the code should work with the situation.

https://nodejs.org/dist/latest-v6.x/docs/api/path.html#path_path_resolve_path
'The resulting path is normalized and trailing slashes are removed unless the path is resolved to the root directory.'