### PR TITLE
CB-11776 check edit-config target exists

### DIFF
--- a/cordova-common/src/ConfigChanges/ConfigChanges.js
+++ b/cordova-common/src/ConfigChanges/ConfigChanges.js
@@ -378,7 +378,7 @@ function is_conflicting(editchanges, config_munge, self, force) {
                 conflictingParent = editchange.target;
             }
 
-            if (target.length !== 0) {
+            if (target && target.length !== 0) {
                 // conflict has been found, exit and throw an error
                 conflictFound = true;
                 if (!force) {


### PR DESCRIPTION
Missing a case in the conflict checking for edit-config. If the target doesn't exist in <platform>.json, and cannot resolve to an existing target, then no conflict should be found. 