### PR TITLE
CB-11777: Restore plugins before preparing

### DIFF
--- a/cordova-lib/src/cordova/prepare.js
+++ b/cordova-lib/src/cordova/prepare.js
@@ -52,6 +52,9 @@ function prepare(options) {
                 return platforms.getPlatformApi(p, platform_path).getPlatformInfo().locations.www;
             });
             options.paths = paths;
+        }).then(function () {
+            options = cordova_util.preProcessOptions(options);
+            return restore.installPluginsFromConfigXML(options);
         }).then(function() {
             options = cordova_util.preProcessOptions(options);
             options.searchpath = options.searchpath || config_json.plugin_search_path;
@@ -62,8 +65,6 @@ function prepare(options) {
                 return platforms.getPlatformApi(platform).getPlatformInfo().locations.www;
             });
             return hooksRunner.fire('after_prepare', options);
-        }).then(function () {
-            return restore.installPluginsFromConfigXML(options);
         });
     });
 }


### PR DESCRIPTION
When running `cordova prepare` to restore platforms and plugins, the platform has prepare called before the plugins are restored. This leads to the top-level config.xml data being copied into the platform at prepare time, and then plugin config being appended when they are later restored.

In my case, this was causing the Crosswalk version defined in my top-level config.xml to be overwritten by an undefined version when the plugin was installed. A workaround is to run `cordova prepare` a second time.

A better fix is probably to restore the platforms, restore the plugins, and then run prepare after everything has been restored.

All the existing tests pass, but this does change the order of operations around the prepare hooks, and I'm not certain if other projects/plugins have dependencies on that ordering.
/cc @vladimir-kotikov 
