### PR TITLE
CB-11776 Add test case for different edit-config targets

### DIFF
--- a/cordova-common/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/cordova-common/spec/ConfigChanges/ConfigChanges.spec.js
@@ -298,9 +298,10 @@ describe('config-changes module', function() {
 
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(2);
+                    expect(spy.calls.length).toEqual(3);
                     expect(spy.argsForCall[0][2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
                     expect(spy.argsForCall[1][2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
+                    expect(spy.argsForCall[2][2]).toEqual('/manifest/uses-sdk');
                 });
                 it('should call graftXMLOverwrite for every new config munge with mode \'overwrite\' it introduces', function() {
                     shell.cp('-rf', editconfigplugin, plugins_dir);

--- a/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
+++ b/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
@@ -33,5 +33,8 @@
         <edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:name='ChildApp']" mode="overwrite">
             <activity android:name="ChildApp" android:label="@string/app_name" android:enabled="false" />
         </edit-config>
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
+            <activity android:maxSdkVersion="23" />
+        </edit-config>
     </platform>
 </plugin>


### PR DESCRIPTION
An error was thrown when adding two plugins with different edit-config targets. The conflict checking code was missing a case, so it errors out and the second plugin cannot be added. 

This PR is just adding the test case.