### PR TITLE
CB-11976 - Add deprecated node version warning for 0.x

### DIFF
--- a/cordova-lib/src/platforms/platforms.js
+++ b/cordova-lib/src/platforms/platforms.js
@@ -29,6 +29,12 @@ var cachedApis = {};
 // PlatformProject classes for now.
 function getPlatformApi(platform, platformRootDir) {
 
+    if (/^v0.\d+[.\d+]*/.exec(process.version)) { // matches v0.* 
+        var msg = 'Warning: using node version ' + process.version +
+                ' which has been deprecated. Please upgrade to the latest node version available (v6.x is recommended).';
+        events.emit('warn', msg);
+    }
+
     // if platformRootDir is not specified, try to detect it first
     if (!platformRootDir) {
         var projectRootDir = util.isCordova();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Prints out a warning on `prepare` that you are using a deprecated node version, if you are using any node version 0.x

### What testing has been done on this change?

Tested locally.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.


