### PR TITLE
CB-11985 Check if cached platform/plugin exists before 'npm cache'

### DIFF
--- a/cordova-lib/spec-cordova/lazy_load.spec.js
+++ b/cordova-lib/spec-cordova/lazy_load.spec.js
@@ -20,6 +20,7 @@
 /* jshint sub:true */
 
 var lazy_load = require('../src/cordova/lazy_load'),
+    npmHelper = require('../src/util/npm-helper'),
     config = require('../src/cordova/config'),
     shell = require('shelljs'),
     npm = require('npm'),
@@ -31,11 +32,11 @@ var lazy_load = require('../src/cordova/lazy_load'),
     platforms = require('../src/platforms/platforms');
 
 describe('lazy_load module', function() {
-    var custom_path, npm_cache_add, fakeLazyLoad;
+    var custom_path, cachePackage, fakeLazyLoad;
     beforeEach(function() {
         custom_path = spyOn(config, 'has_custom_path').andReturn(false);
-        npm_cache_add = spyOn(lazy_load, 'npm_cache_add').andReturn(Q(path.join('lib','dir')));
-        fakeLazyLoad = function(id, platform, version) {
+        cachePackage = spyOn(npmHelper, 'cachePackage').andReturn(Q(path.join('lib', 'dir')));
+        fakeLazyLoad = function (id, platform, version) {
             if (platform == 'wp7' || platform == 'wp8') {
                 return Q(path.join('lib', 'wp', id, version, platform));
             } else {
@@ -63,7 +64,7 @@ describe('lazy_load module', function() {
         });
         it('should invoke lazy_load.custom with appropriate url, platform, and version as specified in platforms manifest', function(done) {
             lazy_load.cordova('android').then(function(dir) {
-                expect(npm_cache_add).toHaveBeenCalled();
+                expect(cachePackage).toHaveBeenCalled();
                 expect(dir).toBeDefined();
                 done();
             });

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -248,7 +248,7 @@ describe('util module', function() {
         });
 
         it('should pick buildConfig if no option is provided, but buildConfig.json exists', function() {
-            spyOn(fs, 'existsSync').andReturn(true);
+            spyOn(util, 'existsSync').andReturn(true);
             // Using path.join below to normalize path separators
             expect(util.preProcessOptions())
                 .toEqual(jasmine.objectContaining({options: {buildConfig: path.join('/fake/path/build.json')}}));

--- a/cordova-lib/src/cordova/lazy_load.js
+++ b/cordova-lib/src/cordova/lazy_load.js
@@ -35,7 +35,6 @@ var path          = require('path'),
     Q             = require('q'),
     npm           = require('npm'),
     npmhelper     = require('../util/npm-helper'),
-    unpack        = require('../util/unpack'),
     util          = require('./util'),
     gitclone      = require('../gitclone'),
     stubplatform  = {
@@ -49,7 +48,6 @@ exports.cordova = cordova;
 exports.cordova_git = cordova_git;
 exports.git_clone = git_clone_platform;
 exports.cordova_npm = cordova_npm;
-exports.npm_cache_add = npm_cache_add;
 exports.custom = custom;
 exports.based_on_config = based_on_config;
 
@@ -137,28 +135,7 @@ function cordova_npm(platform) {
 
         // Note that because the version of npm we use internally doesn't support caret versions, in order to allow them
         // from the command line and in config.xml, we use the actual version returned by getLatestMatchingNpmVersion().
-        var pkg = platform.packageName + '@' + version;
-        return exports.npm_cache_add(pkg);
-    });
-}
-
-// Equivalent to a command like
-// npm cache add cordova-android@3.5.0
-// Returns a promise that resolves to directory containing the package.
-function npm_cache_add(pkg) {
-    var npm_cache_dir = path.join(util.libDirectory, 'npm_cache');
-    var platformNpmConfig = {
-        cache: npm_cache_dir
-    };
-
-    return npmhelper.loadWithSettingsThenRestore(platformNpmConfig, function () {
-        return Q.ninvoke(npm.commands, 'cache', ['add', pkg])
-        .then(function (info) {
-            var pkgDir = path.resolve(npm.cache, info.name, info.version, 'package');
-            // Unpack the package that was added to the cache (CB-8154)
-            var package_tgz = path.resolve(npm.cache, info.name, info.version, 'package.tgz');
-            return unpack.unpackTgz(package_tgz, pkgDir);
-        });
+        return npmhelper.cachePackage(platform.packageName, version);
     });
 }
 


### PR DESCRIPTION
### What does this PR do?
Before calling `npm cache add` when installing a platform or plugin, look for an existing `package.tgz` file in the cache directory. This avoids unnecessary `npm` call with long timeout if not connected to the internet.

Background: First time build failures in Cordova tools in Visual Studio are primarily due to `npm` failures. Therefore we are working to avoid any requirement for `npm` to hit the internet in simple build scenarios. This includes pre-installing cached versions of certain platforms and plugins. But we only get the full benefit if Cordova uses these cached versions if it finds them, without calling npm cache add.

A couple of things to note:
* This change uses shared code for platforms and plugins, and means plugins will also be cached to the `.cordova` directory rather than the global npm cache directory. Is that a concern?
* It is likely this change will be meaningless with the proposed changes to installing platforms and plugins in Cordova 7.x. We'll cross the bridge when we come to it 😄.

### What testing has been done on this change?
Local testing.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
