### PR TITLE
CB-11998 - cordova platform add error with cordova-common@1.5.0

### DIFF
--- a/cordova-common/src/FileUpdater.js
+++ b/cordova-common/src/FileUpdater.js
@@ -291,7 +291,7 @@ function mergeAndUpdateDir(sourceDirs, targetDir, options, log) {
             if (!fs.existsSync(sourcePath)) {
                 throw new Error("Source directory does not exist: " + sourcePath);
             }
-            return mapDirectory(rootDir, sourcePath, include, exclude);
+            return mapDirectory(rootDir, path.relative(rootDir, sourcePath), include, exclude);
         });
 
     // Scan the files in the target directory, if it exists.


### PR DESCRIPTION
### Platforms affected

All platforms.

### What does this PR do?

Fixes "ENOENT: no such file or directory" error when adding a platform that has cordova-common@1.5.0

### What testing has been done on this change?

Added failing test in cordova-common library, then fixed it. 
Added a platform with cordova-common@1.5.0 that has this fix.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

