### PR TITLE
CB-12002 - Add getAllowIntents() to ConfigParser

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -227,6 +227,10 @@ describe('config.xml parser', function () {
                 var navigations = cfg.getAllowNavigations();
                 expect(navigations.length).not.toEqual(0);
             });
+            it('it should read <allow-intent> tag entries', function(){
+                var intents = cfg.getAllowIntents();
+                expect(intents.length).not.toEqual(0);
+            });
         });
         describe('static resources', function() {
             var hasPlatformPropertyDefined = function (e) { return !!e.platform; };

--- a/cordova-common/spec/fixtures/test-config.xml
+++ b/cordova-common/spec/fixtures/test-config.xml
@@ -74,6 +74,9 @@
     <allow-navigation href="*://server39.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="true" />
     <allow-navigation href="*://server40.com" minimum-tls-version="TLSv1.1" requires-forward-secrecy="false" />
 
+    <allow-intent href="https://*" />
+    <allow-intent href="com.example.myapp:*" />
+
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <preference name="orientation" value="portrait" />

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -480,6 +480,15 @@ ConfigParser.prototype = {
             };
         });
     },
+    /* Get all the allow-intent tags */
+    getAllowIntents: function() {
+        var allow_intents = this.doc.findall('./allow-intent');
+        return allow_intents.map(function(allow_intent){
+            return {
+                'href': allow_intent.attrib.href
+            };
+        });
+    },
     /* Get all edit-config tags */
     getEditConfigs: function(platform) {
         var platform_tag = this.doc.find('./platform[@name="' + platform + '"]');


### PR DESCRIPTION
### Platforms affected
None, but I'm adding this as preparation for an iOS feature.

### What does this PR do?
Adds a convenience method to retrieve the list of `<allow-intent>` tags from config.xml, similar to the `getAllowNavigations()` and `getAccesses()` methods.

### What testing has been done on this change?
Additions to the existing spec tests.

### Checklist
- [x] Reported an issue in the JIRA database: [CB-12002](https://issues.apache.org/jira/browse/CB-12002)
- [x] Commit message follows the format
- [x] Added automated test coverage as appropriate for this change.

