### PR TITLE
CB-11994 - appveyor tests on cordova-lib are not testing on all node versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
   - nodejs_version: "6"
   
 install:
+  - ps: Install-Product node $env:nodejs_version
   - git clone https://github.com/apache/cordova-js --depth 10
   - cd cordova-lib
   - npm link ../cordova-js
@@ -20,6 +21,14 @@ install:
   - cd ../cordova-lib
   - npm link ../cordova-fetch
   - npm install
+  # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent
+  # module's 'node_modules' In our case 'cordova-common' -> jshint' -> 'cli' dependency
+  # is moved to 'cordova-lib' and hence 'npm run jshint' on 'cordova-common' is failing
+  - cd ../cordova-common
+  - npm install
+  - cd ../cordova-fetch
+  - npm install
+  - npm link ../cordova-common
 
 build: off
 


### PR DESCRIPTION
### Platforms affected

Self

### What does this PR do?

appveyor.yml wasn't testing on all the specified versions of node, it was only testing on 4.x (LTS)

### What testing has been done on this change?

About to find out on AppVeyor :)

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

