### PR TITLE
CB-11979 added deprecation warning for subdirectories

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -69,7 +69,7 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 options.subdir = result[2];
             //if --fetch was used, throw error for subdirectories
         
-        if(option.subdir) {
+        if(options.subdir) {
             events.emit('warn', 'support for subdirectories is depreated and will be removed in Cordova@7');
         if (options.fetch) {
             return Q.reject(new CordovaError('--fetch does not support subdirectories'));

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -70,6 +70,10 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
             //if --fetch was used, throw error for subdirectories
             if (result[2] && options.fetch) {
                 return Q.reject(new CordovaError('--fetch does not support subdirectories'));
+            } else {
+                if(result[2]) {
+                    events.emit('warn', 'support for subdirectories is depreated and will be removed in Cordova@7');
+                }
             }
 
             // Recurse and exit with the new options and truncated URL.

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -68,13 +68,13 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
             if (result[2])
                 options.subdir = result[2];
             //if --fetch was used, throw error for subdirectories
-        
-        if(options.subdir) {
-            events.emit('warn', 'support for subdirectories is depreated and will be removed in Cordova@7');
-        if (options.fetch) {
-            return Q.reject(new CordovaError('--fetch does not support subdirectories'));
-            } 
-        }
+
+            if(options.subdir) {
+                events.emit('warn', 'support for subdirectories is deprecated and will be removed in Cordova@7');
+                if (options.fetch) {
+                    return Q.reject(new CordovaError('--fetch does not support subdirectories'));
+                }
+            }
 
             // Recurse and exit with the new options and truncated URL.
             var new_dir = plugin_src.substring(0, plugin_src.indexOf('#'));

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -68,13 +68,13 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
             if (result[2])
                 options.subdir = result[2];
             //if --fetch was used, throw error for subdirectories
-            if (result[2] && options.fetch) {
-                return Q.reject(new CordovaError('--fetch does not support subdirectories'));
-            } else {
-                if(result[2]) {
-                    events.emit('warn', 'support for subdirectories is depreated and will be removed in Cordova@7');
-                }
-            }
+        
+        if(option.subdir) {
+            events.emit('warn', 'support for subdirectories is depreated and will be removed in Cordova@7');
+        if (options.fetch) {
+            return Q.reject(new CordovaError('--fetch does not support subdirectories'));
+            } 
+        }
 
             // Recurse and exit with the new options and truncated URL.
             var new_dir = plugin_src.substring(0, plugin_src.indexOf('#'));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### What does this PR do?
warns of deprecation of subdirectories in Cordova@7

### What testing has been done on this change?
added and removed a subdirectory plugin, saw warning

### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

