### PR TITLE
CB-12088 Fix misleading warning when adding platform without Api.js

### DIFF
--- a/cordova-lib/src/platforms/platforms.js
+++ b/cordova-lib/src/platforms/platforms.js
@@ -56,10 +56,14 @@ function getPlatformApi(platform, platformRootDir) {
         PlatformApi = require(platformApiModule);
     } catch (err) {
         // Check if platform already compatible w/ PlatformApi and show deprecation warning
-        if (err && err.code === 'MODULE_NOT_FOUND' && platforms[platform].apiCompatibleSince) {
-            events.emit('warn', ' Using this version of Cordova with older version of cordova-' + platform +
-                ' is being deprecated. Consider upgrading to cordova-' + platform + '@' +
-                platforms[platform].apiCompatibleSince + ' or newer.');
+        if (err && err.code === 'MODULE_NOT_FOUND') {
+            if (platforms[platform].apiCompatibleSince) {
+                events.emit('warn', ' Using this version of Cordova with older version of cordova-' + platform +
+                    ' is being deprecated. Consider upgrading to cordova-' + platform + '@' +
+                    platforms[platform].apiCompatibleSince + ' or newer.');
+            }
+            // else nothing - there is no Api.js and no deprecation information hence
+            // the platform just does not expose Api and we will use polyfill as usual
         } else {
             events.emit('warn', 'Error loading cordova-'+platform);
         }


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
Changes the logic that emits warning when require `Api.js` for platform fails to skip the warning when platform does not expose its Api

### What testing has been done on this change?
Manual testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

