### PR TITLE
CB-11908 Add tests for edit-config in config.xml and fix typo

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -231,6 +231,10 @@ describe('config.xml parser', function () {
                 var intents = cfg.getAllowIntents();
                 expect(intents.length).not.toEqual(0);
             });
+            it('it should read <edit-config> tag entries', function(){
+                var editConfigs = cfg.getEditConfigs('android');
+                expect(editConfigs.length).not.toEqual(0);
+            });
         });
         describe('static resources', function() {
             var hasPlatformPropertyDefined = function (e) { return !!e.platform; };

--- a/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
+++ b/cordova-common/spec/fixtures/plugins/org.test.editconfigtest_two/plugin.xml
@@ -34,7 +34,7 @@
             <activity android:name="ChildApp" android:label="@string/app_name" android:enabled="false" />
         </edit-config>
         <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
-            <activity android:maxSdkVersion="23" />
+            <uses-sdk android:maxSdkVersion="24" android:targetSdkVersion="23" />
         </edit-config>
     </platform>
 </plugin>

--- a/cordova-common/spec/fixtures/test-config.xml
+++ b/cordova-common/spec/fixtures/test-config.xml
@@ -88,6 +88,15 @@
         <icon cdv:density="mdpi" height="255" src="logo-android-cdv.png" width="255" />
         <preference name="android-minSdkVersion" value="10" />
         <preference name="orientation" value="landscape" />
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
+            <uses-sdk android:targetSdkVersion="24" />
+        </edit-config>
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="overwrite">
+            <uses-sdk android:minSdkVersion="14" android:maxSdkVersion="24" android:targetSdkVersion="24" />
+        </edit-config>
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="remove">
+            <uses-sdk android:maxSdkVersion="24" />
+        </edit-config>
     </platform>
     <platform name="windows">
         <icon src="res/windows/logo.scale-200.png" target="logo.png"/>

--- a/cordova-common/spec/fixtures/test-editconfig.xml
+++ b/cordova-common/spec/fixtures/test-editconfig.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget android-packageName="io.cordova.hellocordova.android" id="io.cordova.hellocordova" ios-CFBundleIdentifier="io.cordova.hellocordova.ios" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>Hello Cordova</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html" />
+    <access origin="*" />
+    <platform name="android">
+        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
+            <uses-sdk android:targetSdkVersion="23" />
+        </edit-config>
+    </platform>
+</widget>

--- a/cordova-common/src/ConfigChanges/ConfigFile.js
+++ b/cordova-common/src/ConfigChanges/ConfigFile.js
@@ -111,7 +111,7 @@ ConfigFile.prototype.graft_child = function ConfigFile_graft_child(selector, xml
                 result = modules.xml_helpers.graftXMLOverwrite(self.data, xml_to_graft, selector, xml_child);
                 break;
             case 'remove':
-                result= true;
+                result = modules.xml_helpers.pruneXMLRemove(self.data, selector, xml_to_graft);
                 break;
             default:
                 result = modules.xml_helpers.graftXML(self.data, xml_to_graft, selector, xml_child.after);
@@ -141,7 +141,7 @@ ConfigFile.prototype.prune_child = function ConfigFile_prune_child(selector, xml
                 result = modules.xml_helpers.pruneXMLRestore(self.data, selector, xml_child);
                 break;
             case 'remove':
-                result = modules.xml_helpers.prunXMLRemove(self.data, selector, xml_to_graft);
+                result = modules.xml_helpers.pruneXMLRemove(self.data, selector, xml_to_graft);
                 break;
             default:
                 result = modules.xml_helpers.pruneXML(self.data, xml_to_graft, selector);

--- a/cordova-common/src/util/xml-helpers.js
+++ b/cordova-common/src/util/xml-helpers.js
@@ -160,7 +160,7 @@ module.exports = {
         return true;
     },
 
-    prunXMLRemove: function(doc, selector, nodes) {
+    pruneXMLRemove: function(doc, selector, nodes) {
         var target = module.exports.resolveParent(doc, selector);
         if (!target) return false;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
cordova-common

### What does this PR do?
I had this commit ready to go, but forgot to commit and push it. Here I'm adding tests for the 'edit-config' functionality that was added to config.xml a while back

### What testing has been done on this change?
Manual tests and adding unit tests. 

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.