### PR TITLE
CB-12163 Add reference attrib to resource-file for Windows

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -225,7 +225,8 @@ function PluginInfo(dirname) {
                 target: tag.attrib.target,
                 versions: tag.attrib.versions,
                 deviceTarget: tag.attrib['device-target'],
-                arch: tag.attrib.arch
+                arch: tag.attrib.arch,
+                reference: tag.attrib.reference
             };
         });
         return resourceFiles;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
cordova-common for Windows

### What does this PR do?
Adds a new attribute to the resource-file tag for Windows. The attribute is for moving the current functionality of "referencing files" to be switched on by this flag in order to bring back the copy functionality to be default for resource-file. 

ex. 
```
<resource-file src="x86/foo.dll" target="foo.dll" arch="x86" reference="true" />
<resource-file src="x64/foo.dll" target="foo.dll" arch="x64" reference="true" />
```

### What testing has been done on this change?
Manual testing and unit testing. Should work with this cordova-windows pull request to get it working: https://github.com/apache/cordova-windows/pull/213

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

