### PR TITLE
Fixjasmine : CB:12018 - updating tests in cordova-lib to use jasmine instead of jasmine-node

### DIFF
--- a/cordova-common/package.json
+++ b/cordova-common/package.json
@@ -18,9 +18,9 @@
   },
   "scripts": {
     "test": "npm run jshint && npm run jasmine",
-    "jshint": "node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint spec",
-    "jasmine": "node node_modules/jasmine-node/bin/jasmine-node --captureExceptions --color spec",
-    "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec"
+    "jshint": "jshint src && jshint spec",
+    "jasmine": "jasmine --captureExceptions --color",
+    "cover": "istanbul cover --root src --print detail jasmine"
   },
   "dependencies": {
     "ansi": "^0.3.1",

--- a/cordova-common/package.json
+++ b/cordova-common/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.5",
-    "jasmine-node": "^1.14.5",
+    "jasmine": "^2.5.2",
     "jshint": "^2.8.0",
     "promise-matchers": "^0.9.6",
     "rewire": "^2.5.1"

--- a/cordova-common/spec/ActionStack.spec.js
+++ b/cordova-common/spec/ActionStack.spec.js
@@ -48,7 +48,7 @@ describe('action-stack', function() {
             var first_reverter = jasmine.createSpy();
             var first_reverter_args = [true];
             var process_err = new Error('process_err');
-            var second_spy = jasmine.createSpy().andCallFake(function() {
+            var second_spy = jasmine.createSpy().and.callFake(function() {
                 throw process_err;
             });
             var second_args = [2];

--- a/cordova-common/spec/ActionStack.spec.js
+++ b/cordova-common/spec/ActionStack.spec.js
@@ -60,7 +60,7 @@ describe('action-stack', function() {
             // process should throw
             var error;
             stack.process('android', android_one_project)
-            .then(function(something){
+            .then(function(){
                 expect(false).toBe(true);
             }).fail(function(err){
                 error = err;

--- a/cordova-common/spec/ActionStack.spec.js
+++ b/cordova-common/spec/ActionStack.spec.js
@@ -26,7 +26,7 @@ describe('action-stack', function() {
         stack = new action_stack();
     });
     describe('processing of actions', function() {
-        it('should process actions one at a time until all are done', function() {
+        it('Test 001 : should process actions one at a time until all are done', function() {
             var first_spy = jasmine.createSpy();
             var first_args = [1];
             var second_spy = jasmine.createSpy();
@@ -41,7 +41,7 @@ describe('action-stack', function() {
             expect(second_spy).toHaveBeenCalledWith(second_args[0]);
             expect(third_spy).toHaveBeenCalledWith(third_args[0]);
         });
-        it('should revert processed actions if an exception occurs', function() {
+        it('Test 002 : should revert processed actions if an exception occurs', function(done) {
             spyOn(console, 'log');
             var first_spy = jasmine.createSpy();
             var first_args = [1];
@@ -59,11 +59,11 @@ describe('action-stack', function() {
             stack.push(stack.createAction(third_spy, third_args, function(){}, []));
             // process should throw
             var error;
-            runs(function() {
-                stack.process('android', android_one_project).fail(function(err) { error = err; });
-            });
-            waitsFor(function(){ return error; }, 'process promise never resolved', 500);
-            runs(function() {
+            stack.process('android', android_one_project)
+            .then(function(something){
+                expect(false).toBe(true);
+            }).fail(function(err){
+                error = err;
                 expect(error).toEqual(process_err);
                 // first two actions should have been called, but not the third
                 expect(first_spy).toHaveBeenCalledWith(first_args[0]);
@@ -71,7 +71,7 @@ describe('action-stack', function() {
                 expect(third_spy).not.toHaveBeenCalledWith(third_args[0]);
                 // first reverter should have been called after second action exploded
                 expect(first_reverter).toHaveBeenCalledWith(first_reverter_args[0]);
-            });
+            }).fin(done);
         });
     });
 });

--- a/cordova-common/spec/ConfigChanges/ConfigChanges.spec.js
+++ b/cordova-common/spec/ConfigChanges/ConfigChanges.spec.js
@@ -68,14 +68,14 @@ describe('config-changes module', function() {
 
     describe('queue methods', function() {
         describe('addInstalledPluginToPrepareQueue', function() {
-            it('should append specified plugin to platform.json', function() {
+            it('Test 001 : should append specified plugin to platform.json', function() {
                 var platformJson = new PlatformJson(null, 'android', null);
                 platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.dummyplugin', {});
                 var json = platformJson.root;
                 expect(json.prepare_queue.installed[0].plugin).toEqual('org.test.plugins.dummyplugin');
                 expect(json.prepare_queue.installed[0].vars).toEqual({});
             });
-            it('should append specified plugin with any variables to platform.json', function() {
+            it('Test 002 : should append specified plugin with any variables to platform.json', function() {
                 var platformJson = new PlatformJson(null, 'android', null);
                 platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.dummyplugin', {'dude':'man'});
                 var json = platformJson.root;
@@ -85,7 +85,7 @@ describe('config-changes module', function() {
         });
 
         describe('addUninstalledPluginToPrepareQueue', function() {
-            it('should append specified plugin to platform.json', function() {
+            it('Test 003 : should append specified plugin to platform.json', function() {
                 var platformJson = new PlatformJson(null, 'android', null);
                 platformJson.addUninstalledPluginToPrepareQueue('org.test.plugins.dummyplugin');
                 var json = platformJson.root;
@@ -95,14 +95,14 @@ describe('config-changes module', function() {
     });
 
     describe('load method', function() {
-        it('should return an empty config json object if file doesn\'t exist', function() {
+        it('Test 004 : should return an empty config json object if file doesn\'t exist', function() {
             var platformJson = PlatformJson.load(plugins_dir, 'android');
             expect(platformJson.root).toBeDefined();
             expect(platformJson.root.prepare_queue).toBeDefined();
             expect(platformJson.root.config_munge).toBeDefined();
             expect(platformJson.root.installed_plugins).toBeDefined();
         });
-        it('should return the json file if it exists', function() {
+        it('Test 005 : should return the json file if it exists', function() {
             var filepath = path.join(plugins_dir, 'android.json');
             var json = {
                 prepare_queue: {installed: [], uninstalled: []},
@@ -116,7 +116,7 @@ describe('config-changes module', function() {
     });
 
     describe('save method', function() {
-        it('should write out specified json', function() {
+        it('Test 006 : should write out specified json', function() {
             var filepath = path.join(plugins_dir, 'android.json');
             var platformJson = new PlatformJson(filepath, 'android', {foo:true});
             platformJson.save();
@@ -129,7 +129,7 @@ describe('config-changes module', function() {
             beforeEach(function() {
                 shell.cp('-rf', android_two_project, temp);
             });
-            it('should return a flat config hierarchy for simple, one-off config changes', function() {
+            it('Test 007 : should return a flat config hierarchy for simple, one-off config changes', function() {
                 var xml;
                 var dummy_xml = new et.ElementTree(et.XML(fs.readFileSync(path.join(dummyplugin, 'plugin.xml'), 'utf-8')));
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
@@ -150,7 +150,7 @@ describe('config-changes module', function() {
                 xml = innerXML(xml);
                 expect(get_munge_change(munge, 'res/xml/config.xml', '/cordova/plugins', xml).count).toEqual(1);
             });
-            it('should split out multiple children of config-file elements into individual leaves', function() {
+            it('Test 008 : should split out multiple children of config-file elements into individual leaves', function() {
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
                 var munge = munger.generate_plugin_config_munge(pluginInfoProvider.get(childrenplugin), {PACKAGE_NAME: 'com.alunny.childapp'});
                 expect(munge.files['AndroidManifest.xml']).toBeDefined();
@@ -165,23 +165,23 @@ describe('config-changes module', function() {
                 expect(get_munge_change(munge, 'AndroidManifest.xml', '/manifest', '<uses-permission android:name="com.alunny.childapp.permission.C2D_MESSAGE" />')).toBeDefined();
                 expect(get_munge_change(munge, 'AndroidManifest.xml', '/manifest', '<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />')).toBeDefined();
             });
-            it('should not use xml comments as config munge leaves', function() {
+            it('Test 009 : should not use xml comments as config munge leaves', function() {
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
                 var munge = munger.generate_plugin_config_munge(pluginInfoProvider.get(childrenplugin), {});
                 expect(get_munge_change(munge, 'AndroidManifest.xml', '/manifest', '<!--library-->')).not.toBeDefined();
                 expect(get_munge_change(munge, 'AndroidManifest.xml', '/manifest', '<!-- GCM connects to Google Services. -->')).not.toBeDefined();
             });
-            it('should increment config hierarchy leaves if different config-file elements target the same file + selector + xml', function() {
+            it('Test 010 : should increment config hierarchy leaves if different config-file elements target the same file + selector + xml', function() {
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
                 var munge = munger.generate_plugin_config_munge(pluginInfoProvider.get(configplugin), {});
                 expect(get_munge_change(munge, 'res/xml/config.xml', '/widget', '<poop />').count).toEqual(2);
             });
-            it('should take into account interpolation variables', function() {
+            it('Test 011 : should take into account interpolation variables', function() {
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
                 var munge = munger.generate_plugin_config_munge(pluginInfoProvider.get(childrenplugin), {PACKAGE_NAME:'ca.filmaj.plugins'});
                 expect(get_munge_change(munge, 'AndroidManifest.xml', '/manifest', '<uses-permission android:name="ca.filmaj.plugins.permission.C2D_MESSAGE" />')).toBeDefined();
             });
-            it('should create munges for platform-agnostic config.xml changes', function() {
+            it('Test 012 : should create munges for platform-agnostic config.xml changes', function() {
                 var munger = new configChanges.PlatformMunger('android', temp, 'unused', null, pluginInfoProvider);
                 var munge = munger.generate_plugin_config_munge(pluginInfoProvider.get(dummyplugin), {});
                 expect(get_munge_change(munge, 'config.xml', '/*', '<access origin="build.phonegap.com" />')).toBeDefined();
@@ -194,12 +194,12 @@ describe('config-changes module', function() {
         beforeEach(function() {
             shell.cp('-rf', dummyplugin, plugins_dir);
         });
-        it('should generate config munges for queued plugins', function() {
+        it('Test 014 : should generate config munges for queued plugins', function() {
             shell.cp('-rf', android_two_project, temp);
             var platformJson = PlatformJson.load(plugins_dir, 'android');
             platformJson.root.prepare_queue.installed = [{'plugin':'org.test.plugins.dummyplugin', 'vars':{}}];
             var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
-            var spy = spyOn(munger, 'generate_plugin_config_munge').andReturn({});
+            var spy = spyOn(munger, 'generate_plugin_config_munge').and.returnValue({});
             munger.process(plugins_dir);
             expect(spy).toHaveBeenCalledWith(jasmine.any(PluginInfo), {});
         });
@@ -208,96 +208,96 @@ describe('config-changes module', function() {
                 beforeEach(function() {
                     shell.cp('-rf', android_two_project, temp);
                 });
-                it('should call graftXML for every new config munge it introduces (every leaf in config munge that does not exist)', function() {
+                it('Test 015 : should call graftXML for every new config munge it introduces (every leaf in config munge that does not exist)', function() {
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
                     platformJson.root.prepare_queue.installed = [{'plugin':'org.test.plugins.dummyplugin', 'vars':{}}];
 
-                    var spy = spyOn(xml_helpers, 'graftXML').andReturn(true);
+                    var spy = spyOn(xml_helpers, 'graftXML').and.returnValue(true);
 
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(4);
-                    expect(spy.argsForCall[0][2]).toEqual('/*');
-                    expect(spy.argsForCall[1][2]).toEqual('/*');
-                    expect(spy.argsForCall[2][2]).toEqual('/manifest/application');
-                    expect(spy.argsForCall[3][2]).toEqual('/cordova/plugins');
+                    expect(spy.calls.count()).toEqual(4);
+                    expect(spy.calls.argsFor(0)[2]).toEqual('/*');
+                    expect(spy.calls.argsFor(1)[2]).toEqual('/*');
+                    expect(spy.calls.argsFor(2)[2]).toEqual('/manifest/application');
+                    expect(spy.calls.argsFor(3)[2]).toEqual('/cordova/plugins');
                 });
-                it('should not call graftXML for a config munge that already exists from another plugin', function() {
+                it('Test 016 : should not call graftXML for a config munge that already exists from another plugin', function() {
                     shell.cp('-rf', configplugin, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
                     platformJson.addInstalledPluginToPrepareQueue('org.test.configtest', {});
 
-                    var spy = spyOn(xml_helpers, 'graftXML').andReturn(true);
+                    var spy = spyOn(xml_helpers, 'graftXML').and.returnValue(true);
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(1);
+                    expect(spy.calls.count()).toEqual(1);
                 });
-                it('should not call graftXML for a config munge targeting a config file that does not exist', function() {
+                it('Test 017 : should not call graftXML for a config munge targeting a config file that does not exist', function() {
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
                     platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.dummyplugin', {});
 
-                    var spy = spyOn(fs, 'readFileSync').andCallThrough();
+                    var spy = spyOn(fs, 'readFileSync').and.callThrough();
 
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
                     expect(spy).not.toHaveBeenCalledWith(path.join(temp, 'res', 'xml', 'plugins.xml'), 'utf-8');
                 });
-                it('should call graftXMLMerge for every new config munge with mode \'merge\' it introduces', function() {
+                it('Test 018 : should call graftXMLMerge for every new config munge with mode \'merge\' it introduces', function() {
                     shell.cp('-rf', editconfigplugin, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
                     platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
 
-                    var spy = spyOn(xml_helpers, 'graftXMLMerge').andReturn(true);
+                    var spy = spyOn(xml_helpers, 'graftXMLMerge').and.returnValue(true);
 
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(1);
-                    expect(spy.argsForCall[0][2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
+                    expect(spy.calls.count()).toEqual(1);
+                    expect(spy.calls.argsFor(0)[2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
                 });
-                it('should call graftXMLMerge with --force for every new config munge with mode \'merge\' it introduces', function() {
-                    shell.cp('-rf', editconfigplugin, plugins_dir);
-                    shell.cp('-rf', editconfigplugin_two, plugins_dir);
-                    var platformJson = PlatformJson.load(plugins_dir, 'android');
-                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
-                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest_two', {}, true, true);
-
-                    var spy = spyOn(xml_helpers, 'graftXMLMerge').andReturn(true);
-
-                    var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
-                    munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(3);
-                    expect(spy.argsForCall[0][2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
-                    expect(spy.argsForCall[1][2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
-                    expect(spy.argsForCall[2][2]).toEqual('/manifest/uses-sdk');
-                });
-                it('should call graftXMLOverwrite for every new config munge with mode \'overwrite\' it introduces', function() {
-                    shell.cp('-rf', editconfigplugin, plugins_dir);
-                    var platformJson = PlatformJson.load(plugins_dir, 'android');
-                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
-
-                    var spy = spyOn(xml_helpers, 'graftXMLOverwrite').andReturn(true);
-
-                    var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
-                    munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(1);
-                    expect(spy.argsForCall[0][2]).toEqual('/manifest/application/activity');
-                });
-                it('should call graftXMLOverwrite with --force for every new config munge with mode \'overwrite\' it introduces', function() {
+                it('Test 019 : should call graftXMLMerge with --force for every new config munge with mode \'merge\' it introduces', function() {
                     shell.cp('-rf', editconfigplugin, plugins_dir);
                     shell.cp('-rf', editconfigplugin_two, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
                     platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
                     platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest_two', {}, true, true);
 
-                    var spy = spyOn(xml_helpers, 'graftXMLOverwrite').andReturn(true);
+                    var spy = spyOn(xml_helpers, 'graftXMLMerge').and.returnValue(true);
 
                     var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
                     munger.process(plugins_dir);
-                    expect(spy.calls.length).toEqual(2);
-                    expect(spy.argsForCall[0][2]).toEqual('/manifest/application/activity');
-                    expect(spy.argsForCall[1][2]).toEqual('/manifest/application/activity[@android:name=\'ChildApp\']');
+                    expect(spy.calls.count()).toEqual(3);
+                    expect(spy.calls.argsFor(0)[2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
+                    expect(spy.calls.argsFor(1)[2]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
+                    expect(spy.calls.argsFor(2)[2]).toEqual('/manifest/uses-sdk');
                 });
-                it('should not install plugin when there are edit-config conflicts', function() {
+                it('Test 020 : should call graftXMLOverwrite for every new config munge with mode \'overwrite\' it introduces', function() {
+                    shell.cp('-rf', editconfigplugin, plugins_dir);
+                    var platformJson = PlatformJson.load(plugins_dir, 'android');
+                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
+
+                    var spy = spyOn(xml_helpers, 'graftXMLOverwrite').and.returnValue(true);
+
+                    var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
+                    munger.process(plugins_dir);
+                    expect(spy.calls.count()).toEqual(1);
+                    expect(spy.calls.argsFor(0)[2]).toEqual('/manifest/application/activity');
+                });
+                it('Test 021 : should call graftXMLOverwrite with --force for every new config munge with mode \'overwrite\' it introduces', function() {
+                    shell.cp('-rf', editconfigplugin, plugins_dir);
+                    shell.cp('-rf', editconfigplugin_two, plugins_dir);
+                    var platformJson = PlatformJson.load(plugins_dir, 'android');
+                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest', {});
+                    platformJson.addInstalledPluginToPrepareQueue('org.test.editconfigtest_two', {}, true, true);
+
+                    var spy = spyOn(xml_helpers, 'graftXMLOverwrite').and.returnValue(true);
+
+                    var munger = new configChanges.PlatformMunger('android', temp, platformJson, pluginInfoProvider);
+                    munger.process(plugins_dir);
+                    expect(spy.calls.count()).toEqual(2);
+                    expect(spy.calls.argsFor(0)[2]).toEqual('/manifest/application/activity');
+                    expect(spy.calls.argsFor(1)[2]).toEqual('/manifest/application/activity[@android:name=\'ChildApp\']');
+                });
+                it('Test 022 : should not install plugin when there are edit-config conflicts', function() {
                     shell.cp('-rf', editconfigplugin, plugins_dir);
                     shell.cp('-rf', editconfigplugin_two, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'android');
@@ -309,7 +309,7 @@ describe('config-changes module', function() {
                 });
             });
             describe('of plist config files', function() {
-                it('should write empty string nodes with no whitespace', function() {
+                it('Test 023 : should write empty string nodes with no whitespace', function() {
                     shell.cp('-rf', ios_config_xml, temp);
                     shell.cp('-rf', varplugin, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'ios');
@@ -317,7 +317,7 @@ describe('config-changes module', function() {
                     configChanges.process(plugins_dir, temp, 'ios', platformJson, pluginInfoProvider);
                     expect(fs.readFileSync(path.join(temp, 'SampleApp', 'SampleApp-Info.plist'), 'utf-8')).toMatch(/<key>APluginNode<\/key>\n    <string\/>/m);
                 });
-                it('should merge dictionaries and arrays, removing duplicates', function() {
+                it('Test 024 : should merge dictionaries and arrays, removing duplicates', function() {
                     shell.cp('-rf', ios_config_xml, temp);
                     shell.cp('-rf', plistplugin, plugins_dir);
                     var platformJson = PlatformJson.load(plugins_dir, 'ios');
@@ -328,18 +328,18 @@ describe('config-changes module', function() {
                     expect(fs.readFileSync(path.join(temp, 'SampleApp', 'SampleApp-Info.plist'), 'utf-8')).not.toMatch(/(<string>schema-a<\/string>[^]*){2,}/);
                 });
             });
-            it('should resolve wildcard config-file targets to the project, if applicable', function() {
+            it('Test 025 : should resolve wildcard config-file targets to the project, if applicable', function() {
                 shell.cp('-rf', ios_config_xml, temp);
                 shell.cp('-rf', cbplugin, plugins_dir);
                 var platformJson = PlatformJson.load(plugins_dir, 'ios');
                 platformJson.addInstalledPluginToPrepareQueue('org.test.plugins.childbrowser', {});
-                var spy = spyOn(fs, 'readFileSync').andCallThrough();
+                var spy = spyOn(fs, 'readFileSync').and.callThrough();
 
                 var munger = new configChanges.PlatformMunger('ios', temp, platformJson, pluginInfoProvider);
                 munger.process(plugins_dir);
                 expect(spy).toHaveBeenCalledWith(path.join(temp, 'SampleApp', 'SampleApp-Info.plist').replace(/\\/g, '/'), 'utf8');
             });
-            it('should move successfully installed plugins from queue to installed plugins section, and include/retain vars if applicable', function() {
+            it('Test 026 : should move successfully installed plugins from queue to installed plugins section, and include/retain vars if applicable', function() {
                 shell.cp('-rf', android_two_project, temp);
                 shell.cp('-rf', varplugin, plugins_dir);
                 var platformJson = PlatformJson.load(plugins_dir, 'android');
@@ -355,7 +355,7 @@ describe('config-changes module', function() {
         });
 
         describe(': uninstallation', function() {
-            it('should call pruneXML for every config munge it completely removes from the app (every leaf that is decremented to 0)', function() {
+            it('Test 027 : should call pruneXML for every config munge it completely removes from the app (every leaf that is decremented to 0)', function() {
                 shell.cp('-rf', android_two_project, temp);
 
                 // Run through an "install"
@@ -366,15 +366,15 @@ describe('config-changes module', function() {
 
                 // Now set up an uninstall and make sure prunexml is called properly
                 platformJson.addUninstalledPluginToPrepareQueue('org.test.plugins.dummyplugin');
-                var spy = spyOn(xml_helpers, 'pruneXML').andReturn(true);
+                var spy = spyOn(xml_helpers, 'pruneXML').and.returnValue(true);
                 munger.process(plugins_dir);
-                expect(spy.calls.length).toEqual(4);
-                expect(spy.argsForCall[0][2]).toEqual('/*');
-                expect(spy.argsForCall[1][2]).toEqual('/*');
-                expect(spy.argsForCall[2][2]).toEqual('/manifest/application');
-                expect(spy.argsForCall[3][2]).toEqual('/cordova/plugins');
+                expect(spy.calls.count()).toEqual(4);
+                expect(spy.calls.argsFor(0)[2]).toEqual('/*');
+                expect(spy.calls.argsFor(1)[2]).toEqual('/*');
+                expect(spy.calls.argsFor(2)[2]).toEqual('/manifest/application');
+                expect(spy.calls.argsFor(3)[2]).toEqual('/cordova/plugins');
             });
-            it('should generate a config munge that interpolates variables into config changes, if applicable', function() {
+            it('Test 028 : should generate a config munge that interpolates variables into config changes, if applicable', function() {
                 shell.cp('-rf', android_two_project, temp);
                 shell.cp('-rf', varplugin, plugins_dir);
                 // Run through an "install"
@@ -385,14 +385,14 @@ describe('config-changes module', function() {
 
                 // Now set up an uninstall and make sure prunexml is called properly
                 platformJson.addUninstalledPluginToPrepareQueue('com.adobe.vars');
-                var spy = spyOn(munger, 'generate_plugin_config_munge').andReturn({});
+                var spy = spyOn(munger, 'generate_plugin_config_munge').and.returnValue({});
                 munger.process(plugins_dir);
-                var munge_params = spy.mostRecentCall.args;
+                var munge_params = spy.calls.argsFor(0);
                 expect(munge_params[0]).toEqual(jasmine.any(PluginInfo));
                 expect(munge_params[0].dir).toEqual(path.join(plugins_dir, 'com.adobe.vars'));
                 expect(munge_params[1]['API_KEY']).toEqual('canucks');
             });
-            it('should not call pruneXML for a config munge that another plugin depends on', function() {
+            it('Test 029 : should not call pruneXML for a config munge that another plugin depends on', function() {
                 shell.cp('-rf', android_two_no_perms_project, temp);
                 shell.cp('-rf', childrenplugin, plugins_dir);
                 shell.cp('-rf', shareddepsplugin, plugins_dir);
@@ -413,7 +413,7 @@ describe('config-changes module', function() {
                 expect(permission).toBeDefined();
                 expect(permission.attrib['android:name']).toEqual('android.permission.INTERNET');
             });
-            it('should not call pruneXML for a config munge targeting a config file that does not exist', function() {
+            it('Test 030 : should not call pruneXML for a config munge targeting a config file that does not exist', function() {
                 shell.cp('-rf', android_two_project, temp);
                 // install a plugin
                 var platformJson = PlatformJson.load(plugins_dir, 'android');
@@ -424,12 +424,12 @@ describe('config-changes module', function() {
                 // set up an uninstall for the same plugin
                 platformJson.addUninstalledPluginToPrepareQueue('org.test.plugins.dummyplugin');
 
-                var spy = spyOn(fs, 'readFileSync').andCallThrough();
+                var spy = spyOn(fs, 'readFileSync').and.callThrough();
                 munger.process(plugins_dir);
 
                 expect(spy).not.toHaveBeenCalledWith(path.join(temp, 'res', 'xml', 'plugins.xml'), 'utf-8');
             });
-            it('should remove uninstalled plugins from installed plugins list', function() {
+            it('Test 031 : should remove uninstalled plugins from installed plugins list', function() {
                 shell.cp('-rf', android_two_project, temp);
                 shell.cp('-rf', varplugin, plugins_dir);
                 // install the var plugin
@@ -445,7 +445,7 @@ describe('config-changes module', function() {
                 expect(platformJson.root.prepare_queue.uninstalled.length).toEqual(0);
                 expect(platformJson.root.installed_plugins['com.adobe.vars']).not.toBeDefined();
             });
-            it('should call pruneXMLRestore for every config munge with mode \'merge\' or \'overwrite\' it removes from the app', function() {
+            it('Test 032 : should call pruneXMLRestore for every config munge with mode \'merge\' or \'overwrite\' it removes from the app', function() {
                 shell.cp('-rf', android_two_project, temp);
                 shell.cp('-rf', editconfigplugin, plugins_dir);
 
@@ -457,12 +457,12 @@ describe('config-changes module', function() {
 
                 // Now set up an uninstall and make sure pruneXMLMerge is called properly
                 platformJson.addUninstalledPluginToPrepareQueue('org.test.editconfigtest');
-                var spy = spyOn(xml_helpers, 'pruneXMLRestore').andReturn(true);
+                var spy = spyOn(xml_helpers, 'pruneXMLRestore').and.returnValue(true);
                 munger.process(plugins_dir);
 
-                expect(spy.calls.length).toEqual(2);
-                expect(spy.argsForCall[0][1]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
-                expect(spy.argsForCall[1][1]).toEqual('/manifest/application/activity');
+                expect(spy.calls.count()).toEqual(2);
+                expect(spy.calls.argsFor(0)[1]).toEqual('/manifest/application/activity[@android:name=\'org.test.DroidGap\']');
+                expect(spy.calls.argsFor(1)[1]).toEqual('/manifest/application/activity');
             });
         });
     });

--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -25,10 +25,10 @@ var path = require('path'),
 describe('config.xml parser', function () {
     var readFile;
     beforeEach(function() {
-        readFile = spyOn(fs, 'readFileSync').andReturn(xml_contents);
+        readFile = spyOn(fs, 'readFileSync').and.returnValue(xml_contents);
     });
 
-    it('should create an instance based on an xml file', function() {
+    it('Test 001 : should create an instance based on an xml file', function() {
         var cfg;
         expect(function () {
             cfg = new ConfigParser(xml);
@@ -44,78 +44,78 @@ describe('config.xml parser', function () {
         });
 
         describe('package name / id', function() {
-            it('should get the (default) packagename', function() {
+            it('Test 002 : should get the (default) packagename', function() {
                 expect(cfg.packageName()).toEqual('io.cordova.hellocordova');
             });
-            it('should allow setting the packagename', function() {
+            it('Test 003 : should allow setting the packagename', function() {
                 cfg.setPackageName('this.is.bat.country');
                 expect(cfg.packageName()).toEqual('this.is.bat.country');
             });
         });
 
         describe('package name / android-packageName', function() {
-            it('should get the android packagename', function() {
+            it('Test 004 : should get the android packagename', function() {
                 expect(cfg.android_packageName()).toEqual('io.cordova.hellocordova.android');
             });
         });
 
         describe('package name / ios-CFBundleIdentifier', function() {
-            it('should get the ios packagename', function() {
+            it('Test 005 : should get the ios packagename', function() {
                 expect(cfg.ios_CFBundleIdentifier()).toEqual('io.cordova.hellocordova.ios');
             });
         });
 
         describe('version', function() {
-            it('should get the version', function() {
+            it('Test 006 : should get the version', function() {
                 expect(cfg.version()).toEqual('0.0.1');
             });
-            it('should allow setting the version', function() {
+            it('Test 007 : should allow setting the version', function() {
                 cfg.setVersion('2.0.1');
                 expect(cfg.version()).toEqual('2.0.1');
             });
         });
 
         describe('app name', function() {
-            it('should get the (default) app name', function() {
+            it('Test 008 : should get the (default) app name', function() {
                 expect(cfg.name()).toEqual('Hello Cordova');
             });
-            it('should allow setting the app name', function() {
+            it('Test 009 : should allow setting the app name', function() {
                 cfg.setName('this.is.bat.country');
                 expect(cfg.name()).toEqual('this.is.bat.country');
             });
         });
         describe('preference', function() {
-            it('should return the value of a global preference', function() {
+            it('Test 010 : should return the value of a global preference', function() {
                 expect(cfg.getPreference('fullscreen')).toEqual('true');
             });
-            it('should return the value of a platform-specific preference', function() {
+            it('Test 011 : should return the value of a platform-specific preference', function() {
                 expect(cfg.getPreference('android-minSdkVersion', 'android')).toEqual('10');
             });
-            it('should return an empty string for a non-existing preference', function() {
+            it('Test 012 : should return an empty string for a non-existing preference', function() {
                 expect(cfg.getPreference('zimzooo!')).toEqual('');
             });
         });
         describe('global preference', function() {
-            it('should return the value of a global preference', function() {
+            it('Test 013 : should return the value of a global preference', function() {
                 expect(cfg.getGlobalPreference('orientation')).toEqual('portrait');
             });
-            it('should return an empty string for a non-existing preference', function() {
+            it('Test 014 : should return an empty string for a non-existing preference', function() {
                 expect(cfg.getGlobalPreference('foobar')).toEqual('');
             });
         });
         describe('platform-specific preference', function() {
-            it('should return the value of a platform specific preference', function() {
+            it('Test 015 : should return the value of a platform specific preference', function() {
                 expect(cfg.getPlatformPreference('orientation', 'android')).toEqual('landscape');
             });
-            it('should return an empty string when querying for a non-existing preference', function() {
+            it('Test 016 : should return an empty string when querying for a non-existing preference', function() {
                 expect(cfg.getPlatformPreference('foobar', 'android')).toEqual('');
             });
-            it('should return an empty string when querying with unsupported platform', function() {
+            it('Test 017 : should return an empty string when querying with unsupported platform', function() {
                 expect(cfg.getPlatformPreference('orientation', 'foobar')).toEqual('');
             });
         });
         describe('plugin',function(){
-            it('should read plugin id list', function() {
+            it('Test 018 : should read plugin id list', function() {
                var expectedList = [
                    'org.apache.cordova.pluginwithvars',
                    'org.apache.cordova.pluginwithurl',
@@ -132,35 +132,35 @@ describe('config.xml parser', function () {
                    expect(list).toContain(plugin);
                });
             });
-            it('should read plugin given id', function(){
+            it('Test 019 : should read plugin given id', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.justaplugin');
                 expect(plugin).toBeDefined();
                 expect(plugin.name).toEqual('org.apache.cordova.justaplugin');
                 expect(plugin.variables).toBeDefined();
             });
-            it('should not read plugin given undefined id', function(){
+            it('Test 020 : should not read plugin given undefined id', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.undefinedplugin');
                 expect(plugin).not.toBeDefined();
             });
-            it('should read plugin with src and store it in spec field', function(){
+            it('Test 021 : should read plugin with src and store it in spec field', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.pluginwithurl');
                 expect(plugin.spec).toEqual('http://cordova.apache.org/pluginwithurl');
             });
-            it('should read plugin with version and store it in spec field', function(){
+            it('Test 022 : should read plugin with version and store it in spec field', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.pluginwithversion');
                 expect(plugin.spec).toEqual('1.1.1');
             });
-            it('should read plugin with source and version and store source in spec field', function(){
+            it('Test 023 : should read plugin with source and version and store source in spec field', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.pluginwithurlandversion');
                 expect(plugin.spec).toEqual('http://cordova.apache.org/pluginwithurlandversion');
             });
-            it('should read plugin variables', function () {
+            it('Test 024 : should read plugin variables', function () {
                 var plugin = cfg.getPlugin('org.apache.cordova.pluginwithvars');
                 expect(plugin.variables).toBeDefined();
                 expect(plugin.variables.var).toBeDefined();
                 expect(plugin.variables.var).toEqual('varvalue');
             });
-            it('should allow adding a new plugin', function(){
+            it('Test 025 : should allow adding a new plugin', function(){
                 cfg.addPlugin({name:'myplugin'});
                 var plugins = cfg.doc.findall('plugin');
                 var pluginNames = plugins.map(function(plugin){
@@ -168,7 +168,7 @@ describe('config.xml parser', function () {
                 });
                 expect(pluginNames).toContain('myplugin');
             });
-            it('should allow adding features with params', function(){
+            it('Test 026 : should allow adding features with params', function(){
                 cfg.addPlugin({name:'aplugin'}, [{name:'paraname',value:'paravalue'}]);
                 // Additional check for new parameters syntax
                 cfg.addPlugin({name:'bplugin'}, {paraname: 'paravalue'});
@@ -183,7 +183,7 @@ describe('config.xml parser', function () {
                     expect(variables[0].attrib.value).toEqual('paravalue');
                 });
             });
-            it('should be able to read legacy feature entries with a version', function(){
+            it('Test 027 : should be able to read legacy feature entries with a version', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.legacyfeatureversion');
                 expect(plugin).toBeDefined();
                 expect(plugin.name).toEqual('org.apache.cordova.legacyfeatureversion');
@@ -191,19 +191,19 @@ describe('config.xml parser', function () {
                 expect(plugin.variables).toBeDefined();
                 expect(plugin.variables.aVar).toEqual('aValue');
             });
-            it('should be able to read legacy feature entries with a url', function(){
+            it('Test 028 : should be able to read legacy feature entries with a url', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.legacyfeatureurl');
                 expect(plugin).toBeDefined();
                 expect(plugin.name).toEqual('org.apache.cordova.legacyfeatureurl');
                 expect(plugin.spec).toEqual('http://cordova.apache.org/legacyfeatureurl');
             });
-            it('should be able to read legacy feature entries with a version and a url', function(){
+            it('Test 029 : should be able to read legacy feature entries with a version and a url', function(){
                 var plugin = cfg.getPlugin('org.apache.cordova.legacyfeatureversionandurl');
                 expect(plugin).toBeDefined();
                 expect(plugin.name).toEqual('org.apache.cordova.legacyfeatureversionandurl');
                 expect(plugin.spec).toEqual('http://cordova.apache.org/legacyfeatureversionandurl');
             });
-            it('it should remove given plugin', function(){
+            it('Test 030 : it should remove given plugin', function(){
                 cfg.removePlugin('org.apache.cordova.justaplugin');
                 var plugins = cfg.doc.findall('plugin');
                 var pluginNames = plugins.map(function(plugin){
@@ -211,7 +211,7 @@ describe('config.xml parser', function () {
                 });
                 expect(pluginNames).not.toContain('org.apache.cordova.justaplugin');
             });
-            it('it should remove given legacy feature id', function(){
+            it('Test 031 : it should remove given legacy feature id', function(){
                 cfg.removePlugin('org.apache.cordova.legacyplugin');
                 var plugins = cfg.doc.findall('feature');
                 var pluginNames = plugins.map(function(plugin){
@@ -219,15 +219,15 @@ describe('config.xml parser', function () {
                 });
                 expect(pluginNames).not.toContain('org.apache.cordova.legacyplugin');
             });
-            it('it should read <access> tag entries', function(){
+            it('Test 032 : it should read <access> tag entries', function(){
                 var accesses = cfg.getAccesses();
                 expect(accesses.length).not.toEqual(0);
             });
-            it('it should read <allow-navigation> tag entries', function(){
+            it('Test 033 : it should read <allow-navigation> tag entries', function(){
                 var navigations = cfg.getAllowNavigations();
                 expect(navigations.length).not.toEqual(0);
             });
-            it('it should read <allow-intent> tag entries', function(){
+            it('Test 034 : it should read <allow-intent> tag entries', function(){
                 var intents = cfg.getAllowIntents();
                 expect(intents.length).not.toEqual(0);
             });
@@ -239,35 +239,35 @@ describe('config.xml parser', function () {
             var hasDensityPropertyDefined = function (e) { return !!e.density; };
             var hasPlatformPropertyUndefined = function (e) { return !e.platform; };
 
-            it('should fetch shared resources if platform parameter is not specified', function() {
+            it('Test 035 : should fetch shared resources if platform parameter is not specified', function() {
                 expect(cfg.getStaticResources(null, 'icon').length).toBe(2);
                 expect(cfg.getStaticResources(null, 'icon').every(hasPlatformPropertyUndefined)).toBeTruthy();
             });
 
-            it('should fetch platform-specific resources along with shared if platform parameter is specified', function() {
+            it('Test 036 : should fetch platform-specific resources along with shared if platform parameter is specified', function() {
                 expect(cfg.getStaticResources('android', 'icon').length).toBe(5);
                 expect(cfg.getStaticResources('android', 'icon').some(hasPlatformPropertyDefined)).toBeTruthy();
                 expect(cfg.getStaticResources('android', 'icon').filter(hasPlatformPropertyDefined).length).toBe(3);
                 expect(cfg.getStaticResources('android', 'icon').some(hasPlatformPropertyUndefined)).toBeTruthy();
             });
 
-            it('should parse resources\' attributes', function() {
+            it('Test 037 : should parse resources\' attributes', function() {
                 expect(cfg.getStaticResources(null, 'icon').every(hasSrcPropertyDefined)).toBeTruthy();
                 expect(cfg.getStaticResources('windows', 'icon').filter(hasPlatformPropertyDefined).every(hasTargetPropertyDefined)).toBeTruthy();
                 expect(cfg.getStaticResources('android', 'icon').filter(hasPlatformPropertyDefined).every(hasDensityPropertyDefined)).toBeTruthy();
                 expect(cfg.getStaticResources('android', 'icon').filter(hasPlatformPropertyDefined).every(hasDensityPropertyDefined)).toBeTruthy();
             });
 
-            it('should have defaultResource property', function() {
+            it('Test 038 : should have defaultResource property', function() {
                 expect(cfg.getStaticResources(null, 'icon').defaultResource).toBeDefined();
                 expect(cfg.getStaticResources(null, 'icon').defaultResource.src).toBe('icon.png');
             });
 
-            it('should have getDefault method returning defaultResource property', function() {
+            it('Test 039 : should have getDefault method returning defaultResource property', function() {
                 expect(cfg.getStaticResources(null, 'icon').defaultResource).toEqual(cfg.getStaticResources(null, 'icon').getDefault());
             });
 
-            it('should have getBySize method returning resource with size specified or null', function() {
+            it('Test 040 : should have getBySize method returning resource with size specified or null', function() {
                 expect(cfg.getStaticResources('windows', 'icon').getBySize(128)).toBe(null);
                 expect(cfg.getStaticResources('windows', 'icon').getBySize(72)).toBeDefined();
                 expect(cfg.getStaticResources('windows', 'icon').getBySize(72).width).toBe(72);
@@ -275,7 +275,7 @@ describe('config.xml parser', function () {
                 expect(cfg.getStaticResources('windows', 'icon').getBySize(null, 48).height).toBe(48);
             });
 
-            it('should have getByDensity method returning resource with density specified or null', function() {
+            it('Test 041 : should have getByDensity method returning resource with density specified or null', function() {
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('hdpi')).toBe(null);
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('mdpi')).toBeDefined();
                 expect(cfg.getStaticResources('android', 'icon').getByDensity('mdpi').src).toBe('logo-android.png');

--- a/cordova-common/spec/CordovaCheck.spec.js
+++ b/cordova-common/spec/CordovaCheck.spec.js
@@ -30,11 +30,12 @@ describe('findProjectRoot method', function() {
         process.env.PWD = origPWD;
         process.chdir(cwd);
     });
+function removeDir(someDirectory) {
+    shell.rm('-rf', someDirectory);
+}
     it('should return false if it hits the home directory', function() {
         var somedir = path.join(home, 'somedir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir(somedir);
         expect(CordovaCheck.findProjectRoot(somedir)).toEqual(false);
     });
@@ -45,9 +46,7 @@ describe('findProjectRoot method', function() {
     it('should return the first directory it finds with a .cordova folder in it', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir('-p', anotherdir);
         shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
         expect(CordovaCheck.findProjectRoot(somedir)).toEqual(somedir);
@@ -56,9 +55,7 @@ describe('findProjectRoot method', function() {
         delete process.env.PWD;
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir('-p', anotherdir);
         shell.mkdir('-p', path.join(somedir, 'www'));
         shell.mkdir('-p', path.join(somedir, 'config.xml'));
@@ -68,9 +65,7 @@ describe('findProjectRoot method', function() {
     it('should use PWD when available', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir('-p', anotherdir);
         shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
         process.env.PWD = anotherdir;
@@ -80,9 +75,7 @@ describe('findProjectRoot method', function() {
     it('should use cwd as a fallback when PWD is not a cordova dir', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir('-p', anotherdir);
         shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
         process.env.PWD = path.sep;
@@ -92,9 +85,7 @@ describe('findProjectRoot method', function() {
     it('should ignore platform www/config.xml', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
-        this.after(function() {
-            shell.rm('-rf', somedir);
-        });
+        removeDir(somedir);
         shell.mkdir('-p', anotherdir);
         shell.mkdir('-p', path.join(anotherdir, 'www', 'config.xml'));
         shell.mkdir('-p', path.join(somedir, 'www'));

--- a/cordova-common/spec/CordovaCheck.spec.js
+++ b/cordova-common/spec/CordovaCheck.spec.js
@@ -30,9 +30,9 @@ describe('findProjectRoot method', function() {
         process.env.PWD = origPWD;
         process.chdir(cwd);
     });
-function removeDir(someDirectory) {
-    shell.rm('-rf', someDirectory);
-}
+    function removeDir(someDirectory) {
+        shell.rm('-rf', someDirectory);
+    }
     it('Test 001 : should return false if it hits the home directory', function() {
         var somedir = path.join(home, 'somedir');
         removeDir(somedir);

--- a/cordova-common/spec/CordovaCheck.spec.js
+++ b/cordova-common/spec/CordovaCheck.spec.js
@@ -33,17 +33,17 @@ describe('findProjectRoot method', function() {
 function removeDir(someDirectory) {
     shell.rm('-rf', someDirectory);
 }
-    it('should return false if it hits the home directory', function() {
+    it('Test 001 : should return false if it hits the home directory', function() {
         var somedir = path.join(home, 'somedir');
         removeDir(somedir);
         shell.mkdir(somedir);
         expect(CordovaCheck.findProjectRoot(somedir)).toEqual(false);
     });
-    it('should return false if it cannot find a .cordova directory up the directory tree', function() {
+    it('Test 002 : should return false if it cannot find a .cordova directory up the directory tree', function() {
         var somedir = path.join(home, '..');
         expect(CordovaCheck.findProjectRoot(somedir)).toEqual(false);
     });
-    it('should return the first directory it finds with a .cordova folder in it', function() {
+    it('Test 003 : should return the first directory it finds with a .cordova folder in it', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
         removeDir(somedir);
@@ -51,7 +51,7 @@ function removeDir(someDirectory) {
         shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
         expect(CordovaCheck.findProjectRoot(somedir)).toEqual(somedir);
     });
-    it('should ignore PWD when its undefined', function() {
+    it('Test 004 : should ignore PWD when its undefined', function() {
         delete process.env.PWD;
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
@@ -62,7 +62,7 @@ function removeDir(someDirectory) {
         process.chdir(anotherdir);
         expect(CordovaCheck.findProjectRoot()).toEqual(somedir);
     });
-    it('should use PWD when available', function() {
+    it('Test 005 : should use PWD when available', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
         removeDir(somedir);
@@ -72,7 +72,7 @@ function removeDir(someDirectory) {
         process.chdir(path.sep);
         expect(CordovaCheck.findProjectRoot()).toEqual(somedir);
     });
-    it('should use cwd as a fallback when PWD is not a cordova dir', function() {
+    it('Test 006 : should use cwd as a fallback when PWD is not a cordova dir', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
         removeDir(somedir);
@@ -82,7 +82,7 @@ function removeDir(someDirectory) {
         process.chdir(anotherdir);
         expect(CordovaCheck.findProjectRoot()).toEqual(somedir);
     });
-    it('should ignore platform www/config.xml', function() {
+    it('Test 007 : should ignore platform www/config.xml', function() {
         var somedir = path.join(home,'somedir');
         var anotherdir = path.join(somedir, 'anotherdir');
         removeDir(somedir);

--- a/cordova-common/spec/CordovaLogger.spec.js
+++ b/cordova-common/spec/CordovaLogger.spec.js
@@ -99,7 +99,7 @@ describe('CordovaLogger class', function() {
                 };
 
                 var listenerSpy = jasmine.createSpy('listenerSpy')
-                .andCallFake(function (eventName) {
+                .and.callFake(function (eventName) {
                     eventName = eventNamesExclusions[eventName] || eventName;
                     expect(logger.levels[eventName]).toBeDefined();
                 });
@@ -116,7 +116,7 @@ describe('CordovaLogger class', function() {
                 var spy = jasmine.createSpyObj(name, cursorMethods);
 
                 // Make spy methods chainable, as original Cursor acts
-                cursorMethods.forEach(function (method) { spy[method].andReturn(spy); });
+                cursorMethods.forEach(function (method) { spy[method].and.returnValue(spy); });
 
                 return spy;
             }
@@ -153,7 +153,7 @@ describe('CordovaLogger class', function() {
 
             it('should handle CordovaError instances separately from Error ones', function () {
                 var errorMock = new CordovaError();
-                spyOn(errorMock, 'toString').andReturn('error_message');
+                spyOn(errorMock, 'toString').and.returnValue('error_message');
 
                 logger.setLevel('verbose').log('verbose', errorMock);
                 expect(errorMock.toString).toHaveBeenCalled();

--- a/cordova-common/spec/CordovaLogger.spec.js
+++ b/cordova-common/spec/CordovaLogger.spec.js
@@ -24,11 +24,11 @@ var EventEmitter = require('events').EventEmitter;
 var DEFAULT_LEVELS = ['verbose', 'normal', 'warn', 'info', 'error', 'results'];
 
 describe('CordovaLogger class', function() {
-    it('should be constructable', function () {
+    it('Test 001 : should be constructable', function () {
         expect(new CordovaLogger()).toEqual(jasmine.any(CordovaLogger));
     });
 
-    it('should expose default levels as constants', function () {
+    it('Test 002 : should expose default levels as constants', function () {
         DEFAULT_LEVELS.forEach(function (level) {
             var constant = level.toUpperCase();
             expect(CordovaLogger[constant]).toBeDefined();
@@ -36,7 +36,7 @@ describe('CordovaLogger class', function() {
         });
     });
 
-    it('should return the same instance via "get" method', function () {
+    it('Test 003 : should return the same instance via "get" method', function () {
         expect(CordovaLogger.get()).toBeDefined();
         expect(CordovaLogger.get()).toBe(CordovaLogger.get());
         expect(CordovaLogger.get()).toEqual(jasmine.any(CordovaLogger));
@@ -50,7 +50,7 @@ describe('CordovaLogger class', function() {
             logger = new CordovaLogger();
         });
 
-        it('should have defaults levels', function () {
+        it('Test 004 : should have defaults levels', function () {
             DEFAULT_LEVELS.forEach(function (level) {
                 expect(logger.levels[level]).toBeDefined();
                 expect(logger.levels[level]).toEqual(jasmine.any(Number));
@@ -61,7 +61,7 @@ describe('CordovaLogger class', function() {
         });
 
         describe('addLevel method', function () {
-            it('should add a new level and a corresponding shortcut method', function () {
+            it('Test 005 : should add a new level and a corresponding shortcut method', function () {
                 spyOn(logger, 'log');
                 logger.addLevel('debug', 100000, 'grey');
                 expect(logger.levels.debug).toBe(100000);
@@ -71,7 +71,7 @@ describe('CordovaLogger class', function() {
                 expect(logger.log).toHaveBeenCalledWith('debug', 'debug message');
             });
 
-            it('should not add a shortcut method fi the property with the same name already exists', function () {
+            it('Test 006 : should not add a shortcut method fi the property with the same name already exists', function () {
                 var logMethod = logger.log;
                 logger.addLevel('log', 500);
                 expect(logger.log).toBe(logMethod); // "log" method remains unchanged
@@ -79,19 +79,19 @@ describe('CordovaLogger class', function() {
         });
 
         describe('setLevel method', function () {
-            it('should set logger\'s level to \'NORMAL\' if provided level does not exist', function () {
+            it('Test 007 : should set logger\'s level to \'NORMAL\' if provided level does not exist', function () {
                 logger.setLevel('debug');
                 expect(logger.logLevel).toBe(CordovaLogger.NORMAL); // default value
             });
         });
 
         describe('subscribe method', function () {
-            it('should throw if called without EventEmitter instance', function () {
+            it('Test 008 : should throw if called without EventEmitter instance', function () {
                 expect(function () { logger.subscribe(); }).toThrow();
                 expect(function () { logger.subscribe(123); }).toThrow();
             });
 
-            it('should attach corresponding listeners to supplied emitter', function () {
+            it('Test 009 : should attach corresponding listeners to supplied emitter', function () {
 
                 var eventNamesExclusions = {
                     log: 'normal',
@@ -128,41 +128,41 @@ describe('CordovaLogger class', function() {
                 logger.stderrCursor = new CursorSpy('stderrCursor');
             });
 
-            it('should ignore message if severity is less than logger\'s level', function () {
+            it('Test 010 : should ignore message if severity is less than logger\'s level', function () {
                 logger.setLevel('error').log('verbose', 'some_messgge');
                 expect(logger.stdoutCursor.write).not.toHaveBeenCalled();
                 expect(logger.stderrCursor.write).not.toHaveBeenCalled();
             });
 
-            it('should log everything except error messages to stdout', function () {
+            it('Test 011 : should log everything except error messages to stdout', function () {
                 logger.setLevel('verbose');
                 DEFAULT_LEVELS.forEach(function (level) {
                     logger.log(level, 'message');
                 });
 
                 // Multiply calls number to 2 because 'write' method is get called twice (with message and EOL)
-                expect(logger.stdoutCursor.write.calls.length).toBe((DEFAULT_LEVELS.length - 1) * 2);
-                expect(logger.stderrCursor.write.calls.length).toBe(1 * 2);
+                expect(logger.stdoutCursor.write.calls.count()).toBe((DEFAULT_LEVELS.length - 1) * 2);
+                expect(logger.stderrCursor.write.calls.count()).toBe(1 * 2);
             });
 
-            it('should log Error objects to stderr despite of loglevel', function () {
+            it('Test 012 : should log Error objects to stderr despite of loglevel', function () {
                 logger.setLevel('verbose').log('verbose', new Error());
                 expect(logger.stdoutCursor.write).not.toHaveBeenCalled();
                 expect(logger.stderrCursor.write).toHaveBeenCalled();
             });
 
-            it('should handle CordovaError instances separately from Error ones', function () {
+            it('Test 013 : should handle CordovaError instances separately from Error ones', function () {
                 var errorMock = new CordovaError();
                 spyOn(errorMock, 'toString').and.returnValue('error_message');
 
                 logger.setLevel('verbose').log('verbose', errorMock);
                 expect(errorMock.toString).toHaveBeenCalled();
-                expect(logger.stderrCursor.write.calls[0].args[0]).toBe('Error: error_message');
+                expect(logger.stderrCursor.write.calls.argsFor(0)).toMatch('Error: error_message');
             });
         });
 
         describe('adjustLevel method', function () {
-            it('should properly adjust log level', function () {
+            it('Test 014 : should properly adjust log level', function () {
                 var resetLogLevel = function() {
                     logger.setLevel('normal');
                 };

--- a/cordova-common/spec/FileUpdater.spec.js
+++ b/cordova-common/spec/FileUpdater.spec.js
@@ -129,7 +129,7 @@ describe('FileUpdater class', function() {
     });
 
     describe('updatePathWithStats method', function () {
-        it('should do nothing when a directory exists at source and target', function () {
+        it('Test 001 : should do nothing when a directory exists at source and target', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceDir, mockDirStats(), testTargetDir, mockDirStats(),
                 null, nullLogger);
@@ -137,7 +137,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.mkdirPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
-        it('should create a directory that exists at source and not at target', function () {
+        it('Test 002 : should create a directory that exists at source and not at target', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceDir, mockDirStats(), testTargetDir, null,
                 null, nullLogger);
@@ -146,7 +146,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
         });
-        it('should remove a directory that exists at target and not at source', function () {
+        it('Test 003 : should remove a directory that exists at target and not at source', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceDir, null, testTargetDir, mockDirStats(),
                 null, nullLogger);
@@ -156,7 +156,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths[0]).toBe(testTargetDir);
         });
 
-        it('should copy when a file exists at source and target and times are the same',
+        it('Test 004 : should copy when a file exists at source and target and times are the same',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(now),
@@ -166,7 +166,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should copy when a file exists at source and target and target is older',
+        it('Test 005 : should copy when a file exists at source and target and target is older',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(oneHourAgo),
@@ -176,7 +176,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should do nothing when a file exists at source and target and target is newer',
+        it('Test 006 : should do nothing when a file exists at source and target and target is newer',
                 function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now),
@@ -185,7 +185,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.cpPaths.length).toBe(0);
             expect(mockFs.rmPaths.length).toBe(0);
         });
-        it('should copy when a file exists at source and target and forcing update', function () {
+        it('Test 007 : should copy when a file exists at source and target and forcing update', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(now),
                 { all: true }, nullLogger);
@@ -194,7 +194,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should copy when a file exists at source and target and target is newer ' +
+        it('Test 008 : should copy when a file exists at source and target and target is newer ' +
                 'and forcing update', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(oneHourAgo), testTargetFile, mockFileStats(now),
@@ -204,7 +204,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should copy when a file exists at source and target and source is newer', function () {
+        it('Test 009 : should copy when a file exists at source and target and source is newer', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockFileStats(oneHourAgo),
                 null, nullLogger);
@@ -213,7 +213,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should copy when a file exists at source and not at target', function () {
+        it('Test 010 : should copy when a file exists at source and not at target', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, null,
                 null, nullLogger);
@@ -222,7 +222,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths.length).toBe(0);
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
-        it('should remove when a file exists at target and not at source', function () {
+        it('Test 011 : should remove when a file exists at target and not at source', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, null, testTargetFile, mockFileStats(now),
                 null, nullLogger);
@@ -232,7 +232,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths[0]).toBe(testTargetFile);
         });
 
-        it('should remove and mkdir when source is a directory and target is a file', function () {
+        it('Test 012 : should remove and mkdir when source is a directory and target is a file', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceDir, mockDirStats(), testTargetDir, mockFileStats(now),
                 null, nullLogger);
@@ -243,7 +243,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.rmPaths[0]).toBe(testTargetDir);
             expect(mockFs.mkdirPaths[0]).toBe(testTargetDir);
         });
-        it('should remove and copy when source is a file and target is a directory', function () {
+        it('Test 013 : should remove and copy when source is a file and target is a directory', function () {
             var updated = FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, mockDirStats(),
                 null, nullLogger);
@@ -255,7 +255,7 @@ describe('FileUpdater class', function() {
             expect(mockFs.cpPaths[0]).toEqual([testSourceFile, testTargetFile]);
         });
 
-        it('should join the paths when a rootDir is specified', function () {
+        it('Test 014 : should join the paths when a rootDir is specified', function () {
             FileUpdater.updatePathWithStats(
                 testSourceFile, mockFileStats(now), testTargetFile, null,
                 { rootDir: testRootDir }, nullLogger);
@@ -265,7 +265,7 @@ describe('FileUpdater class', function() {
                 [path.join(testRootDir, testSourceFile), path.join(testRootDir, testTargetFile)]);
         });
 
-        it('should log dir creation', function () {
+        it('Test 015 : should log dir creation', function () {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
@@ -280,7 +280,7 @@ describe('FileUpdater class', function() {
             expect(loggedTarget).toBe(1);
             expect(loggedRoot).toBe(0);
         });
-        it('should log dir removal', function () {
+        it('Test 016 : should log dir removal', function () {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
@@ -295,7 +295,7 @@ describe('FileUpdater class', function() {
             expect(loggedTarget).toBe(1);
             expect(loggedRoot).toBe(0);
         });
-        it('should log file copy', function () {
+        it('Test 017 : should log file copy', function () {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
@@ -310,7 +310,7 @@ describe('FileUpdater class', function() {
             expect(loggedTarget).toBe(1);
             expect(loggedRoot).toBe(0);
         });
-        it('should log file removal', function () {
+        it('Test 018: should log file removal', function () {
             var loggedSource = 0;
             var loggedTarget = 0;
             var loggedRoot = 0;
@@ -330,7 +330,7 @@ describe('FileUpdater class', function() {
     });
 
     describe('mapDirectory method', function () {
-        it('should map an empty directory', function () {
+        it('Test 019 : should map an empty directory', function () {
             mockFs.statMap[path.join(testRootDir, testSourceDir)] = testDirStats;
             mockFs.dirMap[path.join(testRootDir, testSourceDir)] = [];
             var dirMap = FileUpdater.mapDirectory(testRootDir, testSourceDir, ['**'], []);
@@ -338,7 +338,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[''].subDir).toBe(testSourceDir);
             expect(dirMap[''].stats).toBe(testDirStats);
         });
-        it('should map a directory with a file', function () {
+        it('Test 020 : should map a directory with a file', function () {
             mockFs.statMap[path.join(testRootDir, testSourceDir)] = testDirStats;
             mockFs.dirMap[path.join(testRootDir, testSourceDir)] = [testSourceFile];
             mockFs.statMap[path.join(testRootDir, testSourceDir, testSourceFile)] = testFileStats;
@@ -349,7 +349,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
             expect(dirMap[testSourceFile].stats).toBe(testFileStats);
         });
-        it('should map a directory with a subdirectory', function () {
+        it('Test 021 : should map a directory with a subdirectory', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSubDir];
             mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
@@ -361,7 +361,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[testSubDir].subDir).toBe(testSourceDir);
             expect(dirMap[testSubDir].stats).toBe(testDirStats);
         });
-        it('should map a directory with a file in a nested subdirectory', function () {
+        it('Test 022 : should map a directory with a file in a nested subdirectory', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSubDir];
             mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
@@ -388,7 +388,7 @@ describe('FileUpdater class', function() {
                 testFileStats);
         });
 
-        it('should include files that match include globs', function () {
+        it('Test 023 : should include files that match include globs', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSourceFile, testSourceFile2];
             mockFs.statMap[path.join(testSourceDir, testSourceFile)] = testFileStats;
@@ -400,7 +400,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
             expect(dirMap[testSourceFile].stats).toBe(testFileStats);
         });
-        it('should include files in a subdirectory that match include globs', function () {
+        it('Test 024 : should include files in a subdirectory that match include globs', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSubDir];
             mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
@@ -418,7 +418,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[path.join(testSubDir, testSourceFile)].subDir).toBe(testSourceDir);
             expect(dirMap[path.join(testSubDir, testSourceFile)].stats).toBe(testFileStats);
         });
-        it('should exclude paths that match exclude globs', function () {
+        it('Test 025 : should exclude paths that match exclude globs', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSourceFile, testSourceFile2];
             mockFs.statMap[path.join(testSourceDir, testSourceFile)] = testFileStats;
@@ -430,7 +430,7 @@ describe('FileUpdater class', function() {
             expect(dirMap[testSourceFile].subDir).toBe(testSourceDir);
             expect(dirMap[testSourceFile].stats).toBe(testFileStats);
         });
-        it('should exclude paths that match both exclude and include globs', function () {
+        it('Test 026 : should exclude paths that match both exclude and include globs', function () {
             mockFs.statMap[testSourceDir] = testDirStats;
             mockFs.dirMap[testSourceDir] = [testSubDir];
             mockFs.statMap[path.join(testSourceDir, testSubDir)] = testDirStats;
@@ -451,7 +451,7 @@ describe('FileUpdater class', function() {
         var testSourceFileStats = mockFileStats(now);
         var testSourceFileStats2 = mockFileStats(now);
         var testSourceFileStats3 = mockFileStats(now);
-        it('should prepend the target directory on target paths', function () {
+        it('Test 027 : should prepend the target directory on target paths', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
                 [{
                     '': { subDir: testSourceDir, stats: testDirStats },
@@ -474,7 +474,7 @@ describe('FileUpdater class', function() {
                 path.join(testSourceDir, testTargetFile));
             expect(mergedPathMap[testTargetFile].sourceStats).toBe(testSourceFileStats);
         });
-        it('should handle missing source files', function () {
+        it('Test 028 : should handle missing source files', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
                 [{}],
                 {
@@ -488,7 +488,7 @@ describe('FileUpdater class', function() {
             expect(mergedPathMap[testTargetFile].sourcePath).toBeNull();
             expect(mergedPathMap[testTargetFile].sourceStats).toBeNull();
         });
-        it('should handle missing target files', function () {
+        it('Tets 029 : should handle missing target files', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
                 [{
                     testTargetFile: { subDir: testSourceDir, stats: testSourceFileStats },
@@ -503,7 +503,7 @@ describe('FileUpdater class', function() {
                 path.join(testSourceDir, testTargetFile));
             expect(mergedPathMap[testTargetFile].sourceStats).toBe(testSourceFileStats);
         });
-        it('should merge three source maps', function () {
+        it('Test 030 : should merge three source maps', function () {
             var mergedPathMap = FileUpdater.mergePathMaps(
                 [
                     {
@@ -547,7 +547,7 @@ describe('FileUpdater class', function() {
     });
 
     describe('updatePath method', function () {
-        it('should update a path', function () {
+        it('Test 031 : should update a path', function () {
             mockFs.statMap[testRootDir] = testDirStats;
             mockFs.statMap[path.join(testRootDir, testTargetFile)] = testFileStats;
             mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
@@ -562,7 +562,7 @@ describe('FileUpdater class', function() {
             expect(FileUpdater.updatePathWithStatsCalls[0][4]).toEqual(
                 {rootDir: testRootDir, all: true });
         });
-        it('should update a path without a separate root directory', function () {
+        it('Test 032 : should update a path without a separate root directory', function () {
             mockFs.statMap[testTargetFile] = testFileStats;
             mockFs.statMap[testSourceFile] = testFileStats2;
             FileUpdater.updatePathWithStatsResult = false;
@@ -575,7 +575,7 @@ describe('FileUpdater class', function() {
             expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
             expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
-        it('should update a path when the source doesn\'t exist', function () {
+        it('Test 033 : should update a path when the source doesn\'t exist', function () {
             mockFs.statMap[testTargetFile] = testFileStats;
             var updated = FileUpdater.updatePath(null, testTargetFile);
             expect(updated).toBe(true);
@@ -586,7 +586,7 @@ describe('FileUpdater class', function() {
             expect(FileUpdater.updatePathWithStatsCalls[0][3]).toEqual(testFileStats);
             expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
-        it('should update a path when the target doesn\'t exist', function () {
+        it('Test 034 : should update a path when the target doesn\'t exist', function () {
             mockFs.statMap[testSourceFile] = testFileStats2;
             var updated = FileUpdater.updatePath(testSourceFile, testTargetFile);
             expect(updated).toBe(true);
@@ -597,7 +597,7 @@ describe('FileUpdater class', function() {
             expect(FileUpdater.updatePathWithStatsCalls[0][3]).toBeNull();
             expect(FileUpdater.updatePathWithStatsCalls[0][4]).toBeUndefined();
         });
-        it('should create the target\'s parent directory if it doesn\'t exist',
+        it('Test 035 : should create the target\'s parent directory if it doesn\'t exist',
                 function () {
             mockFs.statMap[path.join(testRootDir, testSourceFile)] = testFileStats2;
             var updated = FileUpdater.updatePath(
@@ -615,7 +615,7 @@ describe('FileUpdater class', function() {
     });
 
     describe('mergeAndUpdateDir method', function () {
-        it('should update files from merged source directories', function () {
+        it('Test 036 : should update files from merged source directories', function () {
             mockFs.statMap[testTargetDir] = testDirStats;
             mockFs.dirMap[testTargetDir] = [testSubDir];
             mockFs.statMap[path.join(testTargetDir, testSubDir)] = testDirStats;
@@ -686,7 +686,7 @@ describe('FileUpdater class', function() {
                 null);
         });
 
-        it('should update files from merged source directories - with a rootDir', function () {
+        it('Test 037 : should update files from merged source directories - with a rootDir', function () {
             var rootDir = path.join('Users', 'me');
             mockFs.statMap[rootDir] = testDirStats;
             mockFs.dirMap[rootDir] = [testSourceDir, testSourceDir2, testTargetDir];

--- a/cordova-common/spec/PlatformJson.spec.js
+++ b/cordova-common/spec/PlatformJson.spec.js
@@ -43,7 +43,7 @@ describe('PlatformJson class', function() {
             fakePlugin = jasmine.createSpyObj('fakePlugin', ['getJsModules']);
             fakePlugin.id = 'fakeId';
             fakePlugin.version = '1.0.0';
-            fakePlugin.getJsModules.andReturn([FAKE_MODULE]);
+            fakePlugin.getJsModules.and.returnValue([FAKE_MODULE]);
         });
         
         describe('addPluginMetadata method', function () {

--- a/cordova-common/spec/PlatformJson.spec.js
+++ b/cordova-common/spec/PlatformJson.spec.js
@@ -30,7 +30,7 @@ var FAKE_MODULE = {
 };
 
 describe('PlatformJson class', function() {
-    it('should be constructable', function () {
+    it('Test 001 : should be constructable', function () {
         expect(new PlatformJson()).toEqual(jasmine.any(PlatformJson));
     });
 
@@ -47,19 +47,19 @@ describe('PlatformJson class', function() {
         });
         
         describe('addPluginMetadata method', function () {
-            it('should not throw if root "modules" property is missing', function () {
+            it('Test 002 : should not throw if root "modules" property is missing', function () {
                 expect(function () {
                     platformJson.addPluginMetadata(fakePlugin);
                 }).not.toThrow();
             });
     
-            it('should add each module to "root.modules" array', function () {
+            it('Test 003 : should add each module to "root.modules" array', function () {
                 platformJson.addPluginMetadata(fakePlugin);
                 expect(platformJson.root.modules.length).toBe(1);
                 expect(platformJson.root.modules[0]).toEqual(jasmine.any(ModuleMetadata));
             });
             
-            it('shouldn\'t add module if there is already module with the same file added', function () {
+            it('Test 004 : shouldn\'t add module if there is already module with the same file added', function () {
                 platformJson.root.modules = [{
                     name: 'fakePlugin2',
                     file: 'plugins/fakeId/www/fakeModule.js'
@@ -70,20 +70,20 @@ describe('PlatformJson class', function() {
                 expect(platformJson.root.modules[0].name).toBe('fakePlugin2');
             });
             
-            it('should add entry to plugin_metadata with corresponding version', function () {
+            it('Test 005 : should add entry to plugin_metadata with corresponding version', function () {
                 platformJson.addPluginMetadata(fakePlugin);
                 expect(platformJson.root.plugin_metadata[fakePlugin.id]).toBe(fakePlugin.version);
             });
         });
         
         describe('removePluginMetadata method', function () {
-            it('should not throw if root "modules" property is missing', function () {
+            it('Test 006 : should not throw if root "modules" property is missing', function () {
                 expect(function () {
                     platformJson.removePluginMetadata(fakePlugin);
                 }).not.toThrow();
             });
     
-            it('should remove plugin modules from "root.modules" array based on file path', function () {
+            it('Test 007 : should remove plugin modules from "root.modules" array based on file path', function () {
                 
                 var pluginPaths = [
                     'plugins/fakeId/www/fakeModule.js',
@@ -100,7 +100,7 @@ describe('PlatformJson class', function() {
                 expect(resultantPaths.length).toBe(0);
             });
             
-            it('should remove entry from plugin_metadata with corresponding version', function () {
+            it('Test 008 : should remove entry from plugin_metadata with corresponding version', function () {
                 platformJson.root.plugin_metadata = {};
                 platformJson.root.plugin_metadata[fakePlugin.id] = fakePlugin.version;
                 platformJson.removePluginMetadata(fakePlugin);
@@ -109,7 +109,7 @@ describe('PlatformJson class', function() {
         });
         
         describe('generateMetadata method', function () {
-            it('should generate text metadata containing list of installed modules', function () {
+            it('Test 009 : should generate text metadata containing list of installed modules', function () {
                 var meta = platformJson.addPluginMetadata(fakePlugin).generateMetadata();
                 expect(typeof meta).toBe('string');
                 expect(meta.indexOf(JSON.stringify(platformJson.root.modules, null, 4))).toBeGreaterThan(0);
@@ -121,7 +121,7 @@ describe('PlatformJson class', function() {
 });
 
 describe('ModuleMetadata class', function () {
-    it('should be constructable', function () {
+    it('Test 010 : should be constructable', function () {
         var meta;
         expect(function name(params) {
             meta = new ModuleMetadata('fakePlugin', {src: 'www/fakeModule.js'});
@@ -129,31 +129,31 @@ describe('ModuleMetadata class', function () {
         expect(meta instanceof ModuleMetadata).toBeTruthy();
     });
     
-    it('should throw if either pluginId or jsModule argument isn\'t specified', function () {
+    it('Test 011 : should throw if either pluginId or jsModule argument isn\'t specified', function () {
         expect(ModuleMetadata).toThrow();
         expect(function () { new ModuleMetadata('fakePlugin', {}); }).toThrow();
     });
     
-    it('should guess module id either from name property of from module src', function () {
+    it('Test 012 : should guess module id either from name property of from module src', function () {
         expect(new ModuleMetadata('fakePlugin', {name: 'fakeModule'}).id).toMatch(/fakeModule$/);
         expect(new ModuleMetadata('fakePlugin', {src: 'www/fakeModule.js'}).id).toMatch(/fakeModule$/);
     });
     
-    it('should read "clobbers" property from module', function () {
+    it('Test 013 : should read "clobbers" property from module', function () {
         expect(new ModuleMetadata('fakePlugin', {name: 'fakeModule'}).clobbers).not.toBeDefined();
         var metadata = new ModuleMetadata('fakePlugin', FAKE_MODULE);
         expect(metadata.clobbers).toEqual(jasmine.any(Array));
         expect(metadata.clobbers[0]).toBe(FAKE_MODULE.clobbers[0].target);
     });
     
-    it('should read "merges" property from module', function () {
+    it('Test 014 : should read "merges" property from module', function () {
         expect(new ModuleMetadata('fakePlugin', {name: 'fakeModule'}).merges).not.toBeDefined();
         var metadata = new ModuleMetadata('fakePlugin', FAKE_MODULE);
         expect(metadata.merges).toEqual(jasmine.any(Array));
         expect(metadata.merges[0]).toBe(FAKE_MODULE.merges[0].target);
     });
     
-    it('should read "runs" property from module', function () {
+    it('Test 015 : should read "runs" property from module', function () {
         expect(new ModuleMetadata('fakePlugin', {name: 'fakeModule'}).runs).not.toBeDefined();
         expect(new ModuleMetadata('fakePlugin', FAKE_MODULE).runs).toBe(true);
     });

--- a/cordova-common/spec/PluginInfo/PluginInfo.spec.js
+++ b/cordova-common/spec/PluginInfo/PluginInfo.spec.js
@@ -23,7 +23,7 @@ var PluginInfo = require('../../src/PluginInfo/PluginInfo'),
 var pluginsDir = path.join(__dirname, '../fixtures/plugins');
 
 describe('PluginInfo', function () {
-    it('should read a plugin.xml file', function () {
+    it('Test 001 : should read a plugin.xml file', function () {
         var p, prefs, assets, deps, configFiles, infos, srcFiles;
         var headerFiles, libFiles, resourceFiles;
         expect(function () {
@@ -42,7 +42,7 @@ describe('PluginInfo', function () {
         expect(p.name).toEqual('Child Browser');
         // TODO: Add some expectations for results of getSomething.
     });
-    it('should throw when there is no plugin.xml file', function () {
+    it('Test 002 : should throw when there is no plugin.xml file', function () {
         expect(function () {
             new PluginInfo('/non/existent/dir');
         }).toThrow();

--- a/cordova-common/spec/PluginInfo/PluginInfoProvider.spec.js
+++ b/cordova-common/spec/PluginInfo/PluginInfoProvider.spec.js
@@ -24,7 +24,7 @@ var pluginsDir = path.join(__dirname, '../fixtures/plugins');
 
 describe('PluginInfoProvider', function () {
     describe('getAllWithinSearchPath', function () {
-        it('should load all plugins in a dir', function () {
+        it('Test 001 : should load all plugins in a dir', function () {
             var pluginInfoProvider = new PluginInfoProvider();
             var plugins = pluginInfoProvider.getAllWithinSearchPath(pluginsDir);
             expect(plugins.length).not.toBe(0);

--- a/cordova-common/spec/PluginManager.spec.js
+++ b/cordova-common/spec/PluginManager.spec.js
@@ -17,7 +17,8 @@
     under the License.
 */
 
-require ('promise-matchers');
+// Promise-matchers do not work with jasmine 2.0.
+//require('promise-matchers');
 
 var Q = require('q');
 var fs = require('fs');
@@ -44,11 +45,11 @@ describe('PluginManager class', function() {
         spyOn(shell, 'mkdir');
     });
 
-    it('should be constructable', function () {
+    it('Test 001 : should be constructable', function () {
         expect(new PluginManager(FAKE_PLATFORM, FAKE_LOCATIONS)).toEqual(jasmine.any(PluginManager));
     });
 
-    it('should return new instance for every PluginManager.get call', function () {
+    it('Test 002 : should return new instance for every PluginManager.get call', function () {
         expect(PluginManager.get(FAKE_PLATFORM, FAKE_LOCATIONS)).toEqual(jasmine.any(PluginManager));
         expect(PluginManager.get(FAKE_PLATFORM, FAKE_LOCATIONS))
             .not.toBe(PluginManager.get(FAKE_PLATFORM, FAKE_LOCATIONS));
@@ -64,7 +65,7 @@ describe('PluginManager class', function() {
             FAKE_PROJECT = jasmine.createSpyObj('project', ['getInstaller', 'getUninstaller', 'write']);
             manager = new PluginManager('windows', FAKE_LOCATIONS, FAKE_PROJECT);
             actions = jasmine.createSpyObj('actions', ['createAction', 'push', 'process']);
-            actions.process.andReturn(Q.resolve());
+            actions.process.and.returnValue(Q.resolve());
             PluginManager.__set__('ActionStack', function () { return actions; });
         });
 
@@ -76,20 +77,20 @@ describe('PluginManager class', function() {
             it('should return a promise', function () {
                 expect(Q.isPromise(manager.addPlugin(null, {}))).toBe(true);
             });
-
-            it('should reject if "plugin" parameter is not specified or not a PluginInfo instance', function () {
-                expect(manager.addPlugin(null, {})).toHaveBeenRejected();
-                expect(manager.addPlugin({}, {})).toHaveBeenRejected();
-                expect(manager.addPlugin(new PluginInfo(DUMMY_PLUGIN), {})).not.toHaveBeenRejected();
+            // Promise-matchers do not work with jasmine 2.0.
+            xit('Test 003 : should reject if "plugin" parameter is not specified or not a PluginInfo instance', function (done) {
+                expect(manager.addPlugin(null, {})).toHaveBeenRejected(done);
+                expect(manager.addPlugin({}, {})).toHaveBeenRejected(done);
+                expect(manager.addPlugin(new PluginInfo(DUMMY_PLUGIN), {})).not.toHaveBeenRejected(done);
             });
 
-            it('should iterate through all plugin\'s files and frameworks', function (done) {
+            it('Test 004 : should iterate through all plugin\'s files and frameworks', function (done) {
                 manager.addPlugin(new PluginInfo(DUMMY_PLUGIN), {})
                 .then(function () {
-                    expect(FAKE_PROJECT.getInstaller.calls.length).toBe(16);
-                    expect(FAKE_PROJECT.getUninstaller.calls.length).toBe(16);
+                    expect(FAKE_PROJECT.getInstaller.calls.count()).toBe(16);
+                    expect(FAKE_PROJECT.getUninstaller.calls.count()).toBe(16);
 
-                    expect(actions.push.calls.length).toBe(16);
+                    expect(actions.push.calls.count()).toBe(16);
                     expect(actions.process).toHaveBeenCalled();
                     expect(FAKE_PROJECT.write).toHaveBeenCalled();
                 })
@@ -100,7 +101,7 @@ describe('PluginManager class', function() {
                 });
             });
 
-            it('should save plugin metadata to www directory', function (done) {
+            it('Test 005 : should save plugin metadata to www directory', function (done) {
                 var metadataPath = path.join(manager.locations.www, 'cordova_plugins.js');
                 var platformWwwMetadataPath = path.join(manager.locations.platformWww, 'cordova_plugins.js');
 
@@ -116,7 +117,7 @@ describe('PluginManager class', function() {
                 });
             });
 
-            it('should save plugin metadata to both www ans platform_www directories when options.usePlatformWww is specified', function (done) {
+            it('Test 006 : should save plugin metadata to both www ans platform_www directories when options.usePlatformWww is specified', function (done) {
                 var metadataPath = path.join(manager.locations.www, 'cordova_plugins.js');
                 var platformWwwMetadataPath = path.join(manager.locations.platformWww, 'cordova_plugins.js');
 

--- a/cordova-common/spec/events.spec.js
+++ b/cordova-common/spec/events.spec.js
@@ -23,13 +23,13 @@ describe('forwardEventsTo method', function () {
     afterEach(function() {
         events.forwardEventsTo(null);
     });
-    it('should not go to infinite loop when trying to forward to self', function () {
+    it('Test 001 : should not go to infinite loop when trying to forward to self', function () {
         expect(function() {
             events.forwardEventsTo(events);
             events.emit('log', 'test message');
         }).not.toThrow();
     });
-    it('should reset forwarding after trying to forward to self', function () {
+    it('Test 002 : should reset forwarding after trying to forward to self', function () {
         var EventEmitter = require('events').EventEmitter;
         var anotherEventEmitter = new EventEmitter();
         var logSpy = jasmine.createSpy('logSpy');
@@ -39,7 +39,7 @@ describe('forwardEventsTo method', function () {
         events.emit('log', 'test message #1');
         expect(logSpy).toHaveBeenCalled();
 
-        logSpy.reset();
+        logSpy.calls.reset();
 
         events.forwardEventsTo(events);
         events.emit('log', 'test message #2');

--- a/cordova-common/spec/superspawn.spec.js
+++ b/cordova-common/spec/superspawn.spec.js
@@ -30,12 +30,12 @@ describe('spawn method', function() {
         failSpy = jasmine.createSpy('fail');
     });
 
-    it('should return a promise', function () {
+    it('Test 001 : should return a promise', function () {
         expect(Q.isPromise(superspawn.spawn(LS))).toBe(true);
         expect(Q.isPromise(superspawn.spawn('invalid_command'))).toBe(true);
     });
 
-    it('should notify about stdout "data" events', function (done) {
+    it('Test 002 : should notify about stdout "data" events', function (done) {
         superspawn.spawn(LS, [], {stdio: 'pipe'})
         .progress(progressSpy)
         .fin(function () {
@@ -44,7 +44,7 @@ describe('spawn method', function() {
         });
     });
 
-    it('should notify about stderr "data" events', function (done) {
+    it('Test 003 : should notify about stderr "data" events', function (done) {
         superspawn.spawn(LS, ['doesnt-exist'], {stdio: 'pipe'})
         .progress(progressSpy)
         .fin(function () {

--- a/cordova-common/spec/support/jasmine.json
+++ b/cordova-common/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+    "spec_dir": "spec",
+    "spec_files": [
+    	"**/*[sS]pec.js"
+    ],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+}

--- a/cordova-common/spec/util/xml-helpers.spec.js
+++ b/cordova-common/spec/util/xml-helpers.spec.js
@@ -54,7 +54,7 @@ var TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
 
 describe('xml-helpers', function(){
     describe('parseElementtreeSync', function() {
-        it('should parse xml with a byte order mark', function() {
+        it('Test 001 : should parse xml with a byte order mark', function() {
             var xml_path = path.join(__dirname, '../fixtures/projects/windows/bom_test.xml');
             expect(function() {
                 xml_helpers.parseElementtreeSync(xml_path);
@@ -62,35 +62,35 @@ describe('xml-helpers', function(){
         });
     });
     describe('equalNodes', function() {
-        it('should return false for different tags', function(){
+        it('Test 002 : should return false for different tags', function(){
             expect(xml_helpers.equalNodes(usesNetworkOne, title)).toBe(false);
         });
 
-        it('should return true for identical tags', function(){
+        it('Test 003 : should return true for identical tags', function(){
             expect(xml_helpers.equalNodes(usesNetworkOne, usesNetworkTwo)).toBe(true);
         });
 
-        it('should return false for different attributes', function(){
+        it('Test 004 : should return false for different attributes', function(){
             expect(xml_helpers.equalNodes(usesNetworkOne, usesReceive)).toBe(false);
         });
 
-        it('should distinguish between text', function(){
+        it('Test 005 : should distinguish between text', function(){
             expect(xml_helpers.equalNodes(helloTagOne, goodbyeTag)).toBe(false);
         });
 
-        it('should ignore whitespace in text', function(){
+        it('Test 006 : should ignore whitespace in text', function(){
             expect(xml_helpers.equalNodes(helloTagOne, helloTagTwo)).toBe(true);
         });
 
         describe('should compare children', function(){
-            it('by child quantity', function(){
+            it('Test 007: by child quantity', function(){
                 var one = et.XML('<i><b>o</b></i>'),
                     two = et.XML('<i><b>o</b><u></u></i>');
 
                 expect(xml_helpers.equalNodes(one, two)).toBe(false);
             });
 
-            it('by child equality', function(){
+            it('Test 008 : by child equality', function(){
                 var one = et.XML('<i><b>o</b></i>'),
                     two = et.XML('<i><u></u></i>'),
                     uno = et.XML('<i>\n<b>o</b>\n</i>');
@@ -107,22 +107,22 @@ describe('xml-helpers', function(){
             config_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/projects/android/res/xml/config.xml'));
         });
 
-        it('should remove any children that match the specified selector', function() {
+        it('Test 009 : should remove any children that match the specified selector', function() {
             var children = config_xml.findall('plugins/plugin');
             xml_helpers.pruneXML(config_xml, children, 'plugins');
             expect(config_xml.find('plugins').getchildren().length).toEqual(0);
         });
-        it('should do nothing if the children cannot be found', function() {
+        it('Test 010 : should do nothing if the children cannot be found', function() {
             var children = [title];
             xml_helpers.pruneXML(config_xml, children, 'plugins');
             expect(config_xml.find('plugins').getchildren().length).toEqual(17);
         });
-        it('should be able to handle absolute selectors', function() {
+        it('Test 011 : should be able to handle absolute selectors', function() {
             var children = config_xml.findall('plugins/plugin');
             xml_helpers.pruneXML(config_xml, children, '/cordova/plugins');
             expect(config_xml.find('plugins').getchildren().length).toEqual(0);
         });
-        it('should be able to handle absolute selectors with wildcards', function() {
+        it('Test 012 : should be able to handle absolute selectors with wildcards', function() {
             var children = config_xml.findall('plugins/plugin');
             xml_helpers.pruneXML(config_xml, children, '/*/plugins');
             expect(config_xml.find('plugins').getchildren().length).toEqual(0);
@@ -135,7 +135,7 @@ describe('xml-helpers', function(){
         beforeEach(function() {
             android_manifest_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/projects/android/AndroidManifest.xml'));
         });
-        it('should restore attributes at the specified selector', function() {
+        it('Test 013 : should restore attributes at the specified selector', function() {
             var xml = {
                 oldAttrib: {'android:icon': '@drawable/icon', 'android:label': '@string/app_name', 'android:debuggable': 'false'}
             };
@@ -144,7 +144,7 @@ describe('xml-helpers', function(){
             expect(Object.keys(applicationAttr).length).toEqual(3);
             expect(applicationAttr['android:debuggable']).toEqual('false');
         });
-        it('should do nothing if the old attributes cannot be found', function() {
+        it('Test 014 : should do nothing if the old attributes cannot be found', function() {
             var xml = {
                 notOldAttrib: {'android:icon': '@drawable/icon', 'android:label': '@string/app_name', 'android:debuggable': 'false'}
             };
@@ -153,7 +153,7 @@ describe('xml-helpers', function(){
             expect(Object.keys(applicationAttr).length).toEqual(3);
             expect(applicationAttr['android:debuggable']).toEqual('true');
         });
-        it('should be able to handle absolute selectors', function() {
+        it('Test 015 : should be able to handle absolute selectors', function() {
             var xml = {
                 oldAttrib: {'android:icon': '@drawable/icon', 'android:label': '@string/app_name', 'android:debuggable': 'false'}
             };
@@ -162,7 +162,7 @@ describe('xml-helpers', function(){
             expect(Object.keys(applicationAttr).length).toEqual(3);
             expect(applicationAttr['android:debuggable']).toEqual('false');
         });
-        it('should be able to handle absolute selectors with wildcards', function() {
+        it('Test 016 : should be able to handle absolute selectors with wildcards', function() {
             var xml = {
                 oldAttrib: {'android:name': 'ChildApp', 'android:label': '@string/app_name', 'android:configChanges': 'orientation|keyboardHidden', 'android:enabled': 'true'}
             };
@@ -171,7 +171,7 @@ describe('xml-helpers', function(){
             expect(Object.keys(activityAttr).length).toEqual(4);
             expect(activityAttr['android:enabled']).toEqual('true');
         });
-        it('should be able to handle xpath selectors', function() {
+        it('Test 017 : should be able to handle xpath selectors', function() {
             var xml = {
                 oldAttrib: {'android:name': 'com.phonegap.DroidGap', 'android:label': '@string/app_name', 'android:configChanges': 'orientation|keyboardHidden', 'android:enabled': 'true'}
             };
@@ -190,17 +190,17 @@ describe('xml-helpers', function(){
             plugin_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/plugins/ChildBrowser/plugin.xml'));
         });
 
-        it('should add children to the specified selector', function() {
+        it('Test 018 : should add children to the specified selector', function() {
             var children = plugin_xml.find('config-file').getchildren();
             xml_helpers.graftXML(config_xml, children, 'plugins');
             expect(config_xml.find('plugins').getchildren().length).toEqual(19);
         });
-        it('should be able to handle absolute selectors', function() {
+        it('Test 019 : should be able to handle absolute selectors', function() {
             var children = plugin_xml.find('config-file').getchildren();
             xml_helpers.graftXML(config_xml, children, '/cordova');
             expect(config_xml.findall('access').length).toEqual(3);
         });
-        it('should be able to handle absolute selectors with wildcards', function() {
+        it('Test 020 : should be able to handle absolute selectors with wildcards', function() {
             var children = plugin_xml.find('config-file').getchildren();
             xml_helpers.graftXML(config_xml, children, '/*');
             expect(config_xml.findall('access').length).toEqual(3);
@@ -214,7 +214,7 @@ describe('xml-helpers', function(){
             plugin_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/plugins/org.test.editconfigtest/plugin.xml'));
             android_manifest_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/projects/android/AndroidManifest.xml'));
         });
-        it ('should merge attributes at specified selector', function() {
+        it ('Test 021 : should merge attributes at specified selector', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"merge\"]').getchildren();
             xml_helpers.graftXMLMerge(android_manifest_xml, children, 'application/activity[@android:name=\"com.phonegap.DroidGap\"]', {});
             var activityAttr = android_manifest_xml.find('application/activity[@android:name=\"com.phonegap.DroidGap\"]').attrib;
@@ -222,7 +222,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).toEqual('keyboardHidden');
         });
-        it ('should be able to handle absolute selectors', function() {
+        it ('Test 022 : should be able to handle absolute selectors', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"merge\"]').getchildren();
             xml_helpers.graftXMLMerge(android_manifest_xml, children, '/manifest/application/activity[@android:name=\"com.phonegap.DroidGap\"]', {});
             var activityAttr = android_manifest_xml.find('application/activity[@android:name=\"com.phonegap.DroidGap\"]').attrib;
@@ -230,7 +230,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).toEqual('keyboardHidden');
         });
-        it ('should be able to handle absolute selectors with wildcards', function() {
+        it ('Test 023 : should be able to handle absolute selectors with wildcards', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"merge\"]').getchildren();
             xml_helpers.graftXMLMerge(android_manifest_xml, children, '/*/*/activity[@android:name=\"com.phonegap.DroidGap\"]', {});
             var activityAttr = android_manifest_xml.find('application/activity[@android:name=\"com.phonegap.DroidGap\"]').attrib;
@@ -238,7 +238,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).toEqual('keyboardHidden');
         });
-        it ('should be able to handle xpath selectors', function() {
+        it ('Test 024 : should be able to handle xpath selectors', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"merge\"]').getchildren();
             xml_helpers.graftXMLMerge(android_manifest_xml, children, 'application/activity[@android:name=\"com.phonegap.DroidGap\"]', {});
             var activityAttr = android_manifest_xml.find('application/activity[@android:name=\"com.phonegap.DroidGap\"]').attrib;
@@ -255,7 +255,7 @@ describe('xml-helpers', function(){
             plugin_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/plugins/org.test.editconfigtest/plugin.xml'));
             android_manifest_xml = xml_helpers.parseElementtreeSync(path.join(__dirname, '../fixtures/projects/android/AndroidManifest.xml'));
         });
-        it ('should overwrite attributes at specified selector', function() {
+        it ('Test 025 : should overwrite attributes at specified selector', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"overwrite\"]').getchildren();
             xml_helpers.graftXMLOverwrite(android_manifest_xml, children, 'application/activity', {});
             var activityAttr = android_manifest_xml.find('application/activity').attrib;
@@ -263,7 +263,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).not.toBeDefined();
         });
-        it ('should be able to handle absolute selectors', function() {
+        it ('Test 026 : should be able to handle absolute selectors', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"overwrite\"]').getchildren();
             xml_helpers.graftXMLOverwrite(android_manifest_xml, children, '/manifest/application/activity', {});
             var activityAttr = android_manifest_xml.find('application/activity').attrib;
@@ -271,7 +271,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).not.toBeDefined();
         });
-        it ('should be able to handle absolute selectors with wildcards', function() {
+        it ('Test 027 : should be able to handle absolute selectors with wildcards', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"overwrite\"]').getchildren();
             xml_helpers.graftXMLOverwrite(android_manifest_xml, children, '/*/*/activity', {});
             var activityAttr = android_manifest_xml.find('application/activity').attrib;
@@ -279,7 +279,7 @@ describe('xml-helpers', function(){
             expect(activityAttr['android:enabled']).toEqual('true');
             expect(activityAttr['android:configChanges']).not.toBeDefined();
         });
-        it ('should be able to handle xpath selectors', function() {
+        it ('Test 028 : should be able to handle xpath selectors', function() {
             var children = plugin_xml.find('platform/edit-config[@mode=\"overwrite\"]').getchildren();
             xml_helpers.graftXMLOverwrite(android_manifest_xml, children, 'application/activity[@android:name=\"ChildApp\"]', {});
             var activityAttr = android_manifest_xml.find('application/activity').attrib;
@@ -295,7 +295,7 @@ describe('xml-helpers', function(){
             dstXml = et.XML(TEST_XML);
         });
 
-        it('should merge attributes and text of the root element without clobbering', function () {
+        it('Test 029 : should merge attributes and text of the root element without clobbering', function () {
             var testXml = et.XML('<widget foo="bar" id="NOTANID">TEXT</widget>');
             xml_helpers.mergeXml(testXml, dstXml);
             expect(dstXml.attrib.foo).toEqual('bar');
@@ -303,7 +303,7 @@ describe('xml-helpers', function(){
             expect(dstXml.text).not.toEqual('TEXT');
         });
 
-        it('should merge attributes and text of the root element with clobbering', function () {
+        it('Test 030 : should merge attributes and text of the root element with clobbering', function () {
             var testXml = et.XML('<widget foo="bar" id="NOTANID">TEXT</widget>');
             xml_helpers.mergeXml(testXml, dstXml, 'foo', true);
             expect(dstXml.attrib.foo).toEqual('bar');
@@ -311,7 +311,7 @@ describe('xml-helpers', function(){
             expect(dstXml.text).toEqual('TEXT');
         });
 
-        it('should handle attributes values with quotes correctly', function () {
+        it('Test 031 : should handle attributes values with quotes correctly', function () {
             var testXml = et.XML('<widget><quote foo="some \'quoted\' string" bar="another &quot;quoted&quot; string" baz="&quot;mixed&quot; \'quotes\'" /></widget>');
             xml_helpers.mergeXml(testXml, dstXml);
             expect(dstXml.find('quote')).toBeDefined();
@@ -320,7 +320,7 @@ describe('xml-helpers', function(){
             expect(dstXml.find('quote').attrib.baz).toEqual('"mixed" \'quotes\'');
         });
 
-        it('should not merge platform tags with the wrong platform', function () {
+        it('Test 032 : should not merge platform tags with the wrong platform', function () {
             var testXml = et.XML('<widget><platform name="bar"><testElement testAttrib="value">testTEXT</testElement></platform></widget>'),
                 origCfg = et.tostring(dstXml);
 
@@ -328,7 +328,7 @@ describe('xml-helpers', function(){
             expect(et.tostring(dstXml)).toEqual(origCfg);
         });
 
-        it('should merge platform tags with the correct platform', function () {
+        it('Test 033 : should merge platform tags with the correct platform', function () {
             var testXml = et.XML('<widget><platform name="bar"><testElement testAttrib="value">testTEXT</testElement></platform></widget>'),
                 origCfg = et.tostring(dstXml);
 
@@ -340,7 +340,7 @@ describe('xml-helpers', function(){
             expect(testElement.text).toEqual('testTEXT');
         });
 
-        it('should merge singleton children without clobber', function () {
+        it('Test 034 : should merge singleton children without clobber', function () {
             var testXml = et.XML('<widget><author testAttrib="value" href="http://www.nowhere.com">SUPER_AUTHOR</author></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml);
@@ -353,7 +353,7 @@ describe('xml-helpers', function(){
             expect(testElements[0].text).toContain('Apache Cordova Team');
         });
 
-        it('should merge singleton name without clobber', function () {
+        it('Test 035 : should merge singleton name without clobber', function () {
             var testXml = et.XML('<widget><name>SUPER_NAME</name></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml);
@@ -363,7 +363,7 @@ describe('xml-helpers', function(){
             expect(testElements[0].text).toContain('Hello Cordova');
         });
 
-        it('should clobber singleton children with clobber', function () {
+        it('Test 036 : should clobber singleton children with clobber', function () {
             var testXml = et.XML('<widget><author testAttrib="value" href="http://www.nowhere.com">SUPER_AUTHOR</author></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml, '', true);
@@ -376,7 +376,7 @@ describe('xml-helpers', function(){
             expect(testElements[0].text).toEqual('SUPER_AUTHOR');
         });
 
-        it('should merge singleton name with clobber', function () {
+        it('Test 037 : should merge singleton name with clobber', function () {
             var testXml = et.XML('<widget><name>SUPER_NAME</name></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml, '', true);
@@ -386,7 +386,7 @@ describe('xml-helpers', function(){
             expect(testElements[0].text).toContain('SUPER_NAME');
         });
 
-        it('should append non singelton children', function () {
+        it('Test 038 : should append non singelton children', function () {
             var testXml = et.XML('<widget><preference num="1"/> <preference num="2"/></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml, '', true);
@@ -394,7 +394,7 @@ describe('xml-helpers', function(){
             expect(testElements.length).toEqual(4);
         });
 
-        it('should handle namespaced elements', function () {
+        it('Test 039 : should handle namespaced elements', function () {
             var testXml = et.XML('<widget><foo:bar testAttrib="value">testText</foo:bar></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml, 'foo', true);
@@ -404,7 +404,7 @@ describe('xml-helpers', function(){
             expect(testElement.text).toEqual('testText');
         });
 
-        it('should not append duplicate non singelton children', function () {
+        it('Test 040 : should not append duplicate non singelton children', function () {
             var testXml = et.XML('<widget><preference name="fullscreen" value="true"/></widget>');
 
             xml_helpers.mergeXml(testXml, dstXml, '', true);
@@ -412,7 +412,7 @@ describe('xml-helpers', function(){
             expect(testElements.length).toEqual(2);
         });
 
-        it('should not skip partial duplicate non singelton children', function () {
+        it('Test 041 : should not skip partial duplicate non singelton children', function () {
             //remove access tags from dstXML
             var testElements = dstXml.findall('access');
             for(var i = 0; i < testElements.length; i++) {
@@ -433,7 +433,7 @@ describe('xml-helpers', function(){
 
         });
 
-        it('should remove duplicate preferences (by name attribute value)', function () {
+        it('Test 042 : should remove duplicate preferences (by name attribute value)', function () {
             var testXml = et.XML(
                 '<?xml version="1.0" encoding="UTF-8"?>\n' +
                 '<widget xmlns     = "http://www.w3.org/ns/widgets"\n' +
@@ -454,7 +454,7 @@ describe('xml-helpers', function(){
             expect(testElements.length).toEqual(1);
         });
 
-        it('should merge preferences, with platform preferences written last', function () {
+        it('Test 043 : should merge preferences, with platform preferences written last', function () {
             var testXml = et.XML(
                 '<?xml version="1.0" encoding="UTF-8"?>\n' +
                 '<widget xmlns     = "http://www.w3.org/ns/widgets"\n' +

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -56,9 +56,9 @@
     "test-ios": "npm run test && npm run jasmine-ios",
     "ci": "npm run jshint && npm run cover && codecov",
     "jshint": "jshint src spec-cordova spec-plugman",
-    "jasmine": "jasmine-node --captureExceptions --color spec-plugman spec-cordova",
-    "jasmine-ios": "jasmine-node --captureExceptions --color spec-cordova/platform.spec.ios.js --matchall",
-    "cover": "istanbul cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
+    "jasmine": "jasmine --captureExceptions --color",
+    "jasmine-ios": "jasmine --captureExceptions --color spec-cordova/platform.spec.ios.js --matchall",
+    "cover": "istanbul cover --root src --print detail jasmine"
   },
   "contributors": [
     {

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "aliasify": "^1.7.2",
     "cordova-common": "1.5.x",
-    "cordova-fetch": "^1.0.1",
     "cordova-create": "^1.0.1",
+    "cordova-fetch": "^1.0.1",
     "cordova-js": "4.2.0",
     "cordova-registry-mapper": "1.x",
     "cordova-serve": "^1.0.0",
@@ -47,7 +47,7 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "istanbul": "^0.3.4",
-    "jasmine-node": "1.14.5",
+    "jasmine": "^2.5.2",
     "jshint": "2.5.8",
     "rewire": "2.1.3"
   },

--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -104,7 +104,7 @@ describe('HooksRunner', function() {
 
         // The config.json in the fixture project points at fake "local" paths.
         // Since it's not a URL, the lazy-loader will just return the junk path.
-        spyOn(superspawn, 'spawn').andCallFake(function(cmd, args) {
+        spyOn(superspawn, 'spawn').and.callFake(function(cmd, args) {
             if (cmd.match(/create\b/)) {
                 // This is a call to the bin/create script, so do the copy ourselves.
                 shell.cp('-R', path.join(__dirname, 'fixtures', 'platforms', 'android'), path.join(project, 'platforms'));
@@ -160,7 +160,7 @@ describe('HooksRunner', function() {
             var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
             removeFileIfExists(hooksOrderFile);
 
-            fire = spyOn(HooksRunner.prototype, 'fire').andCallThrough();
+            fire = spyOn(HooksRunner.prototype, 'fire').and.callThrough();
         });
 
         // helper methods
@@ -522,7 +522,7 @@ describe('HooksRunner', function() {
         });
 
         describe('module-level hooks (event handlers)', function() {
-            var handler = jasmine.createSpy().andReturn(Q());
+            var handler = jasmine.createSpy().and.returnValue(Q());
             var test_event = 'before_build';
 
             afterEach(function () {

--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -444,7 +444,7 @@ describe('HooksRunner', function() {
                         // Delete unique ids to allow comparing PluginInfo
                         delete androidPluginOpts.plugin.pluginInfo._et;
 
-                        fire.calls.forEach(function(call) {
+                        fire.calls.all().forEach(function(call) {
                             if(call.args[1] && call.args[1].plugin) {
                                 // Delete unique ids to allow comparing PluginInfo
                                 delete call.args[1].plugin.pluginInfo._et;

--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -81,19 +81,19 @@ describe('HooksRunner', function() {
         process.chdir(path.join(__dirname, '..'));  // Non e2e tests assume CWD is repo root.
     });
 
-    it('should throw if provided directory is not a cordova project', function() {
+    it('Test 001 : should throw if provided directory is not a cordova project', function() {
         expect(function() {
             new HooksRunner(tmpDir);
         }).toThrow();
     });
 
-    it('should not throw if provided directory is a cordova project', function() {
+    it('Test 002 : should not throw if provided directory is a cordova project', function() {
         expect(function () {
             new HooksRunner(project);
         }).not.toThrow();
     });
 
-    it('should init test fixtures', function(done) {
+    it('Test 003 : should init test fixtures', function(done) {
         hooksRunner = new HooksRunner(project);
 
         // Now we load the config.json in the newly created project and edit the target platform's lib entry
@@ -243,7 +243,7 @@ describe('HooksRunner', function() {
         }
 
         describe('application hooks', function() {
-            it('should execute hook scripts serially', function (done) {
+            it('Test 004 : should execute hook scripts serially', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -259,7 +259,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should execute hook scripts serially from .cordova/hooks/hook_type and hooks/hook_type directories', function (done) {
+            it('Test 005 : should execute hook scripts serially from .cordova/hooks/hook_type and hooks/hook_type directories', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -278,7 +278,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should execute hook scripts serially from config.xml', function (done) {
+            it('Test 006 : should execute hook scripts serially from config.xml', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -297,7 +297,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should execute hook scripts serially from config.xml including platform scripts', function (done) {
+            it('Test 007 : should execute hook scripts serially from config.xml including platform scripts', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -316,7 +316,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should filter hook scripts from config.xml by platform', function (done) {
+            it('Test 008 : should filter hook scripts from config.xml by platform', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -345,7 +345,7 @@ describe('HooksRunner', function() {
         });
 
         describe('plugin hooks', function() {
-            it('should execute hook scripts serially from plugin.xml', function (done) {
+            it('Test 009 : should execute hook scripts serially from plugin.xml', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -364,7 +364,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should execute hook scripts serially from plugin.xml including platform scripts', function (done) {
+            it('Test 010 : should execute hook scripts serially from plugin.xml including platform scripts', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -383,7 +383,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should filter hook scripts from plugin.xml by platform', function (done) {
+            it('Test 011 : should filter hook scripts from plugin.xml by platform', function (done) {
                 var test_event = 'before_build';
                 var projectRoot = cordovaUtil.isCordova();
                 var hooksOrderFile = path.join(projectRoot, 'hooks_order.txt');
@@ -410,7 +410,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should run before_plugin_uninstall, before_plugin_install, after_plugin_install hooks for a plugin being installed with correct opts.plugin context', function (done) {
+            it('Test 012 : should run before_plugin_uninstall, before_plugin_install, after_plugin_install hooks for a plugin being installed with correct opts.plugin context', function (done) {
                 var projectRoot = cordovaUtil.isCordova();
 
                 // remove plugin
@@ -467,7 +467,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should not execute the designated hook when --nohooks option specifies the exact hook name', function (done) {
+            it('Test 013 : should not execute the designated hook when --nohooks option specifies the exact hook name', function (done) {
                 var test_event = 'before_build';
                 hookOptions.nohooks = ['before_build'];
 
@@ -481,7 +481,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should not execute a set of matched hooks when --nohooks option specifies the hook pattern.', function (done) {
+            it('Test 014 : should not execute a set of matched hooks when --nohooks option specifies the hook pattern.', function (done) {
                 var test_events = ['before_build', 'after_plugin_add', 'before_platform_rm', 'before_prepare'];
                 hookOptions.nohooks = ['before*'];
 
@@ -502,7 +502,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should not execute all hooks when --nohooks option specifies .', function (done) {
+            it('Test 015 : should not execute all hooks when --nohooks option specifies .', function (done) {
                 var test_events = ['before_build', 'after_plugin_add', 'before_platform_rm', 'before_prepare'];
                 hookOptions.nohooks = ['.'];
 
@@ -527,10 +527,10 @@ describe('HooksRunner', function() {
 
             afterEach(function () {
                 cordova.removeAllListeners(test_event);
-                handler.reset();
+                handler.calls.reset();
             });
 
-            it('should fire handlers using cordova.on', function(done) {
+            it('Test 016 : should fire handlers using cordova.on', function(done) {
                 cordova.on(test_event, handler);
                 hooksRunner.fire(test_event, hookOptions).then(function () {
                     expect(handler).toHaveBeenCalled();
@@ -539,7 +539,7 @@ describe('HooksRunner', function() {
                 }).fin(done);
             });
 
-            it('should pass the project root folder as parameter into the module-level handlers', function (done) {
+            it('Test 017 : should pass the project root folder as parameter into the module-level handlers', function (done) {
                 cordova.on(test_event, handler);
                 hooksRunner.fire(test_event, hookOptions).then(function () {
                     expect(handler).toHaveBeenCalledWith(hookOptions);
@@ -549,7 +549,7 @@ describe('HooksRunner', function() {
                 }).fin(done);
             });
 
-            it('should be able to stop listening to events using cordova.off', function(done) {
+            it('Test 018 : should be able to stop listening to events using cordova.off', function(done) {
                 cordova.on(test_event, handler);
                 cordova.off(test_event, handler);
                 hooksRunner.fire(test_event, hookOptions).then(function () {
@@ -560,7 +560,7 @@ describe('HooksRunner', function() {
                 }).fin(done);
             });
 
-            it('should execute event listeners serially', function(done) {
+            it('Test 019 : should execute event listeners serially', function(done) {
                 var h1_fired = false;
                 var h1 = function() {
                     expect(h2_fired).toBe(false);
@@ -592,7 +592,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should allow for hook to opt into asynchronous execution and block further hooks from firing using the done callback', function(done) {
+            it('Test 020 : should allow for hook to opt into asynchronous execution and block further hooks from firing using the done callback', function(done) {
                 var h1_fired = false;
                 var h1 = function () {
                     h1_fired = true;
@@ -615,7 +615,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should pass data object that fire calls into async handlers', function(done) {
+            it('Test 021 : should pass data object that fire calls into async handlers', function(done) {
                 var async = function (opts) {
                     expect(opts).toEqual(hookOptions);
                     return Q();
@@ -626,7 +626,7 @@ describe('HooksRunner', function() {
                 });
             });
 
-            it('should pass data object that fire calls into sync handlers', function(done) {
+            it('Test 022 : should pass data object that fire calls into sync handlers', function(done) {
                 var async = function (opts) {
                     expect(opts).toEqual(hookOptions);
                 };
@@ -634,7 +634,7 @@ describe('HooksRunner', function() {
                 hooksRunner.fire(test_event, hookOptions).fin(done);
             });
 
-            it('should error if any script exits with non-zero code', function(done) {
+            it('Test 023 : should error if any script exits with non-zero code', function(done) {
                 hooksRunner.fire('fail', hookOptions).then(function () {
                     expect('the call').toBe('a failure');
                 }, function (err) {
@@ -643,7 +643,7 @@ describe('HooksRunner', function() {
             });
         });
 
-        it('should not error if the hook is unrecognized', function(done) {
+        it('Test 024 :should not error if the hook is unrecognized', function(done) {
             hooksRunner.fire('CLEAN YOUR SHORTS GODDAMNIT LIKE A BIG BOY!', hookOptions).fail(function (err) {
                 expect('Call with unrecognized hook ').toBe('successful.\n' + err);
             }).fin(done);
@@ -651,7 +651,7 @@ describe('HooksRunner', function() {
     });
 
     // Cleanup. Must be the last spec. Is there a better place for final cleanup in Jasmine?
-    it('should not fail during cleanup', function () {
+    it('Test 025 : should not fail during cleanup', function () {
         process.chdir(path.join(__dirname, '..'));  // Non e2e tests assume CWD is repo root.
         if (ext == 'sh') {
             shell.rm('-rf', tmpDir);

--- a/cordova-lib/spec-cordova/build.spec.js
+++ b/cordova-lib/spec-cordova/build.spec.js
@@ -30,16 +30,16 @@ describe('build command', function() {
     var prepare_spy, compile_spy;
 
     beforeEach(function() {
-        is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
-        prepare_spy = spyOn(cordova.raw, 'prepare').andReturn(Q());
-        compile_spy = spyOn(cordova.raw, 'compile').andReturn(Q());
+        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
+        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        list_platforms = spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
+        prepare_spy = spyOn(cordova.raw, 'prepare').and.returnValue(Q());
+        compile_spy = spyOn(cordova.raw, 'compile').and.returnValue(Q());
     });
     describe('failure', function() {
         it('should not run inside a project with no platforms', function(done) {
-            list_platforms.andReturn([]);
+            list_platforms.and.returnValue([]);
             cordova.raw.build()
             .then(function() {
                 expect('this call').toBe('fail');
@@ -51,7 +51,7 @@ describe('build command', function() {
         });
 
         it('should not run outside of a Cordova-based project', function(done) {
-            is_cordova.andReturn(false);
+            is_cordova.and.returnValue(false);
 
             cordova.raw.build()
             .then(function() {
@@ -67,7 +67,7 @@ describe('build command', function() {
     describe('success', function() {
         it('should run inside a Cordova-based project with at least one added platform and call both prepare and compile', function(done) {
             cordova.raw.build(['android','ios']).then(function() {
-                var opts = {verbose: false, platforms: ['android', 'ios'], options: []};
+                var opts = Object({ platforms: [ 'android', 'ios' ], verbose: false, options: Object({  }) })
                 expect(prepare_spy).toHaveBeenCalledWith(opts);
                 expect(compile_spy).toHaveBeenCalledWith(opts);
                 done();
@@ -116,7 +116,7 @@ describe('build command', function() {
 
         describe('with no platforms added', function() {
             it('should not fire the hooker', function(done) {
-                list_platforms.andReturn([]);
+                list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.build).then(function() {
                     expect('this call').toBe('fail');
                 }, function(err) {

--- a/cordova-lib/spec-cordova/build.spec.js
+++ b/cordova-lib/spec-cordova/build.spec.js
@@ -38,7 +38,7 @@ describe('build command', function() {
         compile_spy = spyOn(cordova.raw, 'compile').and.returnValue(Q());
     });
     describe('failure', function() {
-        it('should not run inside a project with no platforms', function(done) {
+        it('Test 001 : should not run inside a project with no platforms', function(done) {
             list_platforms.and.returnValue([]);
             cordova.raw.build()
             .then(function() {
@@ -50,7 +50,7 @@ describe('build command', function() {
             }).fin(done);
         });
 
-        it('should not run outside of a Cordova-based project', function(done) {
+        it('Test 002 : should not run outside of a Cordova-based project', function(done) {
             is_cordova.and.returnValue(false);
 
             cordova.raw.build()
@@ -65,15 +65,15 @@ describe('build command', function() {
     });
 
     describe('success', function() {
-        it('should run inside a Cordova-based project with at least one added platform and call both prepare and compile', function(done) {
+        it('Test 003 : should run inside a Cordova-based project with at least one added platform and call both prepare and compile', function(done) {
             cordova.raw.build(['android','ios']).then(function() {
-                var opts = Object({ platforms: [ 'android', 'ios' ], verbose: false, options: Object({  }) })
+                var opts = Object({ platforms: [ 'android', 'ios' ], verbose: false, options: Object({  }) });
                 expect(prepare_spy).toHaveBeenCalledWith(opts);
                 expect(compile_spy).toHaveBeenCalledWith(opts);
                 done();
             });
         });
-        it('should pass down options', function(done) {
+        it('Test 004 : should pass down options', function(done) {
             cordova.raw.build({platforms: ['android'], options: {release: true}}).then(function() {
                 var opts = {platforms: ['android'], options: {release: true}, verbose: false};
                 expect(prepare_spy).toHaveBeenCalledWith(opts);
@@ -82,7 +82,7 @@ describe('build command', function() {
             });
         });
 
-        it('should convert options from old format and warn user about this', function (done) {
+        it('Test 005 : should convert options from old format and warn user about this', function (done) {
             function warnSpy(message) {
                 expect(message).toMatch('The format of cordova.raw.* methods "options" argument was changed');
             }
@@ -100,22 +100,22 @@ describe('build command', function() {
 
     describe('hooks', function() {
         describe('when platforms are added', function() {
-            it('should fire before hooks through the hooker module', function(done) {
+            it('Test 006 : should fire before hooks through the hooker module', function(done) {
                 cordova.raw.build(['android', 'ios']).then(function() {
-                    expect(fire).toHaveBeenCalledWith('before_build', {verbose: false, platforms:['android', 'ios'], options: []});
+                    expect(fire.calls.argsFor(0)).toEqual(['before_build', {verbose: false, platforms:['android', 'ios'] , options: {}}]);
                     done();
                 });
             });
-            it('should fire after hooks through the hooker module', function(done) {
+            it('Test 007 : should fire after hooks through the hooker module', function(done) {
                 cordova.raw.build('android').then(function() {
-                     expect(fire).toHaveBeenCalledWith('after_build', {verbose: false, platforms:['android'], options: []});
+                     expect(fire.calls.argsFor(1)).toEqual([ 'after_build', { platforms: [ 'android' ], verbose: false, options: {} } ]);
                      done();
                 });
             });
         });
 
         describe('with no platforms added', function() {
-            it('should not fire the hooker', function(done) {
+            it('Test 008 : should not fire the hooker', function(done) {
                 list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.build).then(function() {
                     expect('this call').toBe('fail');

--- a/cordova-lib/spec-cordova/compile.spec.js
+++ b/cordova-lib/spec-cordova/compile.spec.js
@@ -30,17 +30,17 @@ describe('compile command', function() {
     var project_dir = '/some/path';
 
     beforeEach(function() {
-        is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
-        platformApi = { build: jasmine.createSpy('build').andReturn(Q()) };
-        getPlatformApi = spyOn(platforms, 'getPlatformApi').andReturn(platformApi);
+        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
+        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        list_platforms= spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
+        platformApi = { build: jasmine.createSpy('build').and.returnValue(Q())};
+        getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
         fail = function (err) { expect(err.stack).not.toBeDefined(); };
     });
     describe('failure', function() {
         it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
-            list_platforms.andReturn([]);
+            list_platforms.and.returnValue([]);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
             .then(success, function(result) {
@@ -53,7 +53,7 @@ describe('compile command', function() {
             });
         });
         it('should not run outside of a Cordova-based project', function(done) {
-            is_cordova.andReturn(false);
+            is_cordova.and.returnValue(false);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
             .then(success, function(result) {
@@ -126,7 +126,7 @@ describe('compile command', function() {
 
         describe('with no platforms added', function() {
             it('should not fire the hooker', function(done) {
-                list_platforms.andReturn([]);
+                list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.compile).then(function() {
                     expect('this call').toBe('fail');
                 }, function(err) {

--- a/cordova-lib/spec-cordova/compile.spec.js
+++ b/cordova-lib/spec-cordova/compile.spec.js
@@ -39,7 +39,7 @@ describe('compile command', function() {
         fail = function (err) { expect(err.stack).not.toBeDefined(); };
     });
     describe('failure', function() {
-        it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
+        it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
             list_platforms.and.returnValue([]);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
@@ -52,7 +52,7 @@ describe('compile command', function() {
                 done();
             });
         });
-        it('should not run outside of a Cordova-based project', function(done) {
+        it('Test 002 : should not run outside of a Cordova-based project', function(done) {
             is_cordova.and.returnValue(false);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
@@ -67,7 +67,7 @@ describe('compile command', function() {
     });
 
     describe('success', function() {
-        it('should run inside a Cordova-based project with at least one added platform and shell out to build', function(done) {
+        it('Test 003 : should run inside a Cordova-based project with at least one added platform and shell out to build', function(done) {
             cordova.raw.compile(['android','ios']).then(function() {
                 expect(getPlatformApi).toHaveBeenCalledWith('android');
                 expect(getPlatformApi).toHaveBeenCalledWith('ios');
@@ -77,7 +77,7 @@ describe('compile command', function() {
             .fin(done);
         });
 
-        it('should pass down optional parameters', function (done) {
+        it('Test 004 : should pass down optional parameters', function (done) {
             cordova.raw.compile({platforms:['blackberry10'], options:{release: true}}).then(function () {
                 expect(getPlatformApi).toHaveBeenCalledWith('blackberry10');
                 expect(platformApi.build).toHaveBeenCalledWith({release: true});
@@ -86,7 +86,7 @@ describe('compile command', function() {
             .fin(done);
         });
 
-        it('should convert options from old format and warn user about this', function (done) {
+        it('Test 005 : should convert options from old format and warn user about this', function (done) {
             function warnSpy(message) {
                 expect(message).toMatch('The format of cordova.raw.* methods "options" argument was changed');
             }
@@ -106,18 +106,18 @@ describe('compile command', function() {
 
     describe('hooks', function() {
         describe('when platforms are added', function() {
-            it('should fire before hooks through the hooker module', function(done) {
+            it('Test 006 : should fire before hooks through the hooker module', function(done) {
                 cordova.raw.compile(['android', 'ios']).then(function() {
-                    expect(fire).toHaveBeenCalledWith('before_compile', {verbose: false, platforms:['android', 'ios'], options: []});
+                    expect(fire.calls.argsFor(0)).toEqual(['before_compile', {verbose: false, platforms:['android', 'ios'] , options: {}}]);
                     done();
                 })
                 .fail(fail)
                 .fin(done);
             });
-            it('should fire after hooks through the hooker module', function(done) {
+            it('Test 007 : should fire after hooks through the hooker module', function(done) {
                 cordova.raw.compile('android').then(function() {
-                     expect(fire).toHaveBeenCalledWith('after_compile', {verbose: false, platforms:['android'], options: []});
-                     done();
+                    expect(fire.calls.argsFor(1)).toEqual(['after_compile', {verbose: false, platforms:['android'] , options: {}}]);
+                    done();
                 })
                 .fail(fail)
                 .fin(done);
@@ -125,7 +125,7 @@ describe('compile command', function() {
         });
 
         describe('with no platforms added', function() {
-            it('should not fire the hooker', function(done) {
+            it('Test 008 : should not fire the hooker', function(done) {
                 list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.compile).then(function() {
                     expect('this call').toBe('fail');

--- a/cordova-lib/spec-cordova/create.spec.js
+++ b/cordova-lib/spec-cordova/create.spec.js
@@ -38,7 +38,7 @@ var configBasic = {
     }
 };
 
-describe('cordova create checks for valid-identifier', function(done) {
+describe('cordova create checks for valid-identifier', function() {
     it('should reject reserved words from start of id', function(done) {
         cordova.raw.create('projectPath', 'int.bob', 'appName', {}, events)
         .fail(function(err) {

--- a/cordova-lib/spec-cordova/create.spec.js
+++ b/cordova-lib/spec-cordova/create.spec.js
@@ -39,7 +39,7 @@ var configBasic = {
 };
 
 describe('cordova create checks for valid-identifier', function() {
-    it('should reject reserved words from start of id', function(done) {
+    it('Test 001 : should reject reserved words from start of id', function(done) {
         cordova.raw.create('projectPath', 'int.bob', 'appName', {}, events)
         .fail(function(err) {
             expect(err.message).toBe('App id contains a reserved word, or is not a valid identifier.');
@@ -47,7 +47,7 @@ describe('cordova create checks for valid-identifier', function() {
         .fin(done);
     });
     
-    it('should reject reserved words from end of id', function(done) {
+    it('Test 002 : should reject reserved words from end of id', function(done) {
         cordova.raw.create('projectPath', 'bob.class', 'appName', {}, events)
         .fail(function(err) {
             expect(err.message).toBe('App id contains a reserved word, or is not a valid identifier.');
@@ -94,7 +94,7 @@ describe('create basic test (see more in cordova-create)', function() {
     var results;
     events.on('results', function(res) { results = res; });
 
-    it('should successfully run', function(done) {
+    it('Test 003 : should successfully run', function(done) {
         // Call cordova create with no args, should return help.
         Q()
             .then(function() {

--- a/cordova-lib/spec-cordova/emulate.spec.js
+++ b/cordova-lib/spec-cordova/emulate.spec.js
@@ -30,21 +30,22 @@ describe('emulate command', function() {
     var prepare_spy, platformApi, getPlatformApi;
 
     beforeEach(function() {
-        is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
-        prepare_spy = spyOn(cordova.raw, 'prepare').andReturn(Q());
+        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
+        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        list_platforms = spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
+        prepare_spy = spyOn(cordova.raw, 'prepare').and.returnValue(Q());
         fail = function (err) { expect(err.stack).not.toBeDefined(); };
         platformApi = {
-            run: jasmine.createSpy('run').andReturn(Q()),
-            build: jasmine.createSpy('build').andReturn(Q())
+            run: jasmine.createSpy('run').and.returnValue(Q()),
+            build: jasmine.createSpy('build').and.returnValue(Q())
         };
-        getPlatformApi = spyOn(platforms, 'getPlatformApi').andReturn(platformApi);
+        
+        getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
     });
     describe('failure', function() {
         it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
-            list_platforms.andReturn([]);
+            list_platforms.and.returnValue([]);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
             .then(success, function(result) {
@@ -57,7 +58,7 @@ describe('emulate command', function() {
             });
         });
         it('should not run outside of a Cordova-based project', function(done) {
-            is_cordova.andReturn(false);
+            is_cordova.and.returnValue(false);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
             .then(success, function(result) {
@@ -113,7 +114,7 @@ describe('emulate command', function() {
             var originalBuildSpy;
             beforeEach(function() {
                 originalBuildSpy = platformApi.build;
-                platformApi.build = jasmine.createSpy('build').andCallFake(function(opts) {
+                platformApi.build = jasmine.createSpy('build').and.callFake(function(opts) {
                     opts.couldBeModified = 'insideBuild';
                     return Q();
                 });
@@ -179,7 +180,7 @@ describe('emulate command', function() {
 
         describe('with no platforms added', function() {
             it('should not fire the hooker', function(done) {
-                list_platforms.andReturn([]);
+                list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.emulate).then(function() {
                     expect('this call').toBe('fail');
                 }, function(err) {

--- a/cordova-lib/spec-cordova/emulate.spec.js
+++ b/cordova-lib/spec-cordova/emulate.spec.js
@@ -44,7 +44,7 @@ describe('emulate command', function() {
         getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
     });
     describe('failure', function() {
-        it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
+        it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
             list_platforms.and.returnValue([]);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
@@ -57,7 +57,7 @@ describe('emulate command', function() {
                 done();
             });
         });
-        it('should not run outside of a Cordova-based project', function(done) {
+        it('Test 002 : should not run outside of a Cordova-based project', function(done) {
             is_cordova.and.returnValue(false);
             var success = jasmine.createSpy('success');
             cordova.raw.compile()
@@ -72,7 +72,7 @@ describe('emulate command', function() {
     });
 
     describe('success', function() {
-        it('should run inside a Cordova-based project with at least one added platform and call prepare and shell out to the emulate script', function(done) {
+        it('Test 003 : should run inside a Cordova-based project with at least one added platform and call prepare and shell out to the emulate script', function(done) {
             cordova.raw.emulate(['android','ios']).then(function(err) {
                 expect(prepare_spy).toHaveBeenCalledWith(jasmine.objectContaining({platforms: ['android', 'ios']}));
                 expect(getPlatformApi).toHaveBeenCalledWith('android');
@@ -83,7 +83,7 @@ describe('emulate command', function() {
             .fail(fail)
             .fin(done);
         });
-        it('should pass down options', function(done) {
+        it('Test 004 : should pass down options', function(done) {
             cordova.raw.emulate({platforms: ['ios'], options: {optionTastic: true }}).then(function(err) {
                 expect(prepare_spy).toHaveBeenCalledWith(jasmine.objectContaining({platforms: ['ios']}));
                 expect(getPlatformApi).toHaveBeenCalledWith('ios');
@@ -93,7 +93,7 @@ describe('emulate command', function() {
             .fail(fail)
             .fin(done);
         });
-        it('should convert options from old format and warn user about this', function (done) {
+        it('Test 005 : should convert options from old format and warn user about this', function (done) {
             function warnSpy(message) {
                 expect(message).toMatch('The format of cordova.raw.* methods "options" argument was changed');
             }
@@ -122,7 +122,7 @@ describe('emulate command', function() {
             afterEach(function() {
                 platformApi.build = originalBuildSpy;
             });
-            it('should leave parameters unchanged', function(done) {
+            it('Test 006 : should leave parameters unchanged', function(done) {
                 cordova.raw.run({platforms: ['blackberry10'], options:{password: '1q1q'}}).then(function() {
                     expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q', 'couldBeModified': 'insideBuild' }, verbose: false });
                     expect(platformApi.build).toHaveBeenCalledWith({password: '1q1q', 'couldBeModified': 'insideBuild'});
@@ -133,7 +133,7 @@ describe('emulate command', function() {
             });
         });
 
-        it('should call platform\'s build method', function (done) {
+        it('Test 007 : should call platform\'s build method', function (done) {
             cordova.raw.emulate({platforms: ['blackberry10']})
             .then(function() {
                 expect(prepare_spy).toHaveBeenCalled();
@@ -145,7 +145,7 @@ describe('emulate command', function() {
             .fin(done);
         });
 
-        it('should not call build if --nobuild option is passed', function (done) {
+        it('Test 008 : should not call build if --nobuild option is passed', function (done) {
             cordova.raw.emulate({platforms: ['blackberry10'], options: { nobuild: true }})
             .then(function() {
                 expect(prepare_spy).toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('emulate command', function() {
 
     describe('hooks', function() {
         describe('when platforms are added', function() {
-            it('should fire before hooks through the hooker module', function(done) {
+            it('Test 009 : should fire before hooks through the hooker module', function(done) {
                 cordova.raw.emulate(['android', 'ios']).then(function() {
                     expect(fire).toHaveBeenCalledWith('before_emulate',
                         jasmine.objectContaining({verbose: false, platforms:['android', 'ios'], options: jasmine.any(Object)}));
@@ -168,7 +168,7 @@ describe('emulate command', function() {
                 .fail(fail)
                 .fin(done);
             });
-            it('should fire after hooks through the hooker module', function(done) {
+            it('Test 010 : should fire after hooks through the hooker module', function(done) {
                 cordova.raw.emulate('android').then(function() {
                      expect(fire).toHaveBeenCalledWith('after_emulate',
                         jasmine.objectContaining({verbose: false, platforms:['android'], options: jasmine.any(Object)}));
@@ -179,7 +179,7 @@ describe('emulate command', function() {
         });
 
         describe('with no platforms added', function() {
-            it('should not fire the hooker', function(done) {
+            it('Test 011 : should not fire the hooker', function(done) {
                 list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.emulate).then(function() {
                     expect('this call').toBe('fail');

--- a/cordova-lib/spec-cordova/helpers.js
+++ b/cordova-lib/spec-cordova/helpers.js
@@ -150,14 +150,21 @@ module.exports.writeConfigContent = function (appPath, configContent) {
 beforeEach(function () {
     jasmine.addMatchers({
         'toExist': function () {
-            var notText = this.isNot ? ' not' : '';
-            var self = this;
+            return {
+                compare: function(actual, expected) {
+                    var result = {};
 
-            this.message = function () {
-                return 'Expected file ' + self.actual + notText + ' to exist.';
-            };
+                    result.pass = fs.existsSync(actual);
 
-            return fs.existsSync(this.actual);
+                    if(result.pass) {
+                        result.message = "expected " + actual + " to not exist";
+                    } else {
+                        result.message = "expected " + actual + " to exist";
+                    }
+
+                    return result;
+                }
+            }
         }
     });
 });

--- a/cordova-lib/spec-cordova/helpers.js
+++ b/cordova-lib/spec-cordova/helpers.js
@@ -148,7 +148,7 @@ module.exports.writeConfigContent = function (appPath, configContent) {
 
 // Add the toExist matcher.
 beforeEach(function () {
-    this.addMatchers({
+    jasmine.addMatchers({
         'toExist': function () {
             var notText = this.isNot ? ' not' : '';
             var self = this;
@@ -161,4 +161,3 @@ beforeEach(function () {
         }
     });
 });
-

--- a/cordova-lib/spec-cordova/helpers.js
+++ b/cordova-lib/spec-cordova/helpers.js
@@ -157,14 +157,14 @@ beforeEach(function () {
                     result.pass = fs.existsSync(actual);
 
                     if(result.pass) {
-                        result.message = "expected " + actual + " to not exist";
+                        result.message = 'expected ' + actual + ' to not exist';
                     } else {
-                        result.message = "expected " + actual + " to exist";
+                        result.message = 'expected ' + actual + ' to exist';
                     }
 
                     return result;
                 }
-            }
+            };
         }
     });
 });

--- a/cordova-lib/spec-cordova/lazy_load.spec.js
+++ b/cordova-lib/spec-cordova/lazy_load.spec.js
@@ -55,14 +55,14 @@ describe('lazy_load module', function() {
         afterEach(function () {
             platforms.android.version = version;
         });
-        it('should throw if platform is not a stock cordova platform', function(done) {
+        it('Test 001: should throw if platform is not a stock cordova platform', function(done) {
             lazy_load.cordova('atari').then(function() {
                 expect('this call').toEqual('to fail');
             }, function(err) {
                 expect('' + err).toContain('Cordova library "atari" not recognized.');
             }).fin(done);
         });
-        it('should invoke lazy_load.custom with appropriate url, platform, and version as specified in platforms manifest', function(done) {
+        it('Test 002 : should invoke lazy_load.custom with appropriate url, platform, and version as specified in platforms manifest', function(done) {
             lazy_load.cordova('android').then(function(dir) {
                 expect(cachePackage).toHaveBeenCalled();
                 expect(dir).toBeDefined();
@@ -82,7 +82,7 @@ describe('lazy_load module', function() {
             fire = spyOn(HooksRunner, 'fire').and.returnValue(Q());
         });
 
-        it('should callback with no errors and not fire event hooks if library already exists', function(done) {
+        it('Test 003 : should callback with no errors and not fire event hooks if library already exists', function(done) {
             exists.and.returnValue(true);
             var mock_platforms = {
                 'platform X': {
@@ -97,7 +97,7 @@ describe('lazy_load module', function() {
                 expect(err).not.toBeDefined();
             }).fin(done);
         });
-        it('should callback with no errors and fire event hooks even if library already exists if the lib url is a local dir', function(done) {
+        it('Test 004 : should callback with no errors and fire event hooks even if library already exists if the lib url is a local dir', function(done) {
             exists.and.returnValue(true);
             var mock_platforms = {
                 'platform X': {
@@ -125,8 +125,8 @@ describe('lazy_load module', function() {
                 };
             beforeEach(function() {
                 events = {};
-                fakeRequest.on.reset();
-                fakeRequest.pipe.reset();
+                fakeRequest.on.calls.reset();
+                fakeRequest.pipe.calls.reset();
                 req = spyOn(request, 'get').and.callFake(function() {
                     // Fire the 'end' event shortly.
                     setTimeout(function() {
@@ -138,7 +138,7 @@ describe('lazy_load module', function() {
                 spyOn(npm.config, 'get').and.returnValue(null);
             });
 
-            it('should call request with appropriate url params', function(done) {
+            it('Test 005 : should call request with appropriate url params', function(done) {
                 var url = 'https://github.com/apache/someplugin';
                 var with_android_platform = {
                     'android': {
@@ -155,7 +155,7 @@ describe('lazy_load module', function() {
                     expect(err).not.toBeDefined();
                 }).fin(done);
             });
-            it('should take into account https-proxy npm configuration var if exists for https:// calls', function(done) {
+            it('Test 006 : should take into account https-proxy npm configuration var if exists for https:// calls', function(done) {
                 var proxy = 'https://somelocalproxy.com';
                 npm.config.get.and.returnValue(proxy);
                 var url = 'https://github.com/apache/someplugin';
@@ -175,7 +175,7 @@ describe('lazy_load module', function() {
                     expect(err).not.toBeDefined();
                 }).fin(done);
             });
-            it('should take into account proxy npm config var if exists for http:// calls', function(done) {
+            it('Test 007 : should take into account proxy npm config var if exists for http:// calls', function(done) {
                 var proxy = 'http://somelocalproxy.com';
                 npm.config.get.and.returnValue(proxy);
                 var url = 'http://github.com/apache/someplugin';
@@ -198,7 +198,7 @@ describe('lazy_load module', function() {
         });
 
         describe('local paths for libraries', function() {
-            it('should return the local path, no symlink', function(done) {
+            it('Test 009 : should return the local path, no symlink', function(done) {
                 var mock_platforms = {
                     'X': {
                         id: 'id',
@@ -212,7 +212,7 @@ describe('lazy_load module', function() {
                     expect(err).toBeUndefined();
                 }).fin(done);
             });
-            it('should not file download hook', function(done) {
+            it('Test 010 : should not file download hook', function(done) {
                 var mock_platforms = {
                     'X': {
                         id: 'id',
@@ -235,7 +235,7 @@ describe('lazy_load module', function() {
             cordova = spyOn(lazy_load, 'cordova').and.returnValue(Q());
             custom = spyOn(lazy_load, 'custom').and.returnValue(Q());
         });
-        it('should invoke custom if a custom lib is specified', function(done) {
+        it('Test 011 : should invoke custom if a custom lib is specified', function(done) {
             read = spyOn(config, 'read').and.returnValue({
                 lib:{
                     maybe:{
@@ -260,7 +260,7 @@ describe('lazy_load module', function() {
                 expect(err).toBeUndefined();
             }).fin(done);
         });
-        it('should invoke cordova if no custom lib is specified', function(done) {
+        it('Test 012 : should invoke cordova if no custom lib is specified', function(done) {
             lazy_load.based_on_config('yup', 'ios').then(function() {
                 expect(cordova).toHaveBeenCalled();
             }, function(err) {

--- a/cordova-lib/spec-cordova/lazy_load.spec.js
+++ b/cordova-lib/spec-cordova/lazy_load.spec.js
@@ -34,8 +34,8 @@ var lazy_load = require('../src/cordova/lazy_load'),
 describe('lazy_load module', function() {
     var custom_path, cachePackage, fakeLazyLoad;
     beforeEach(function() {
-        custom_path = spyOn(config, 'has_custom_path').andReturn(false);
-        cachePackage = spyOn(npmHelper, 'cachePackage').andReturn(Q(path.join('lib', 'dir')));
+        custom_path = spyOn(config, 'has_custom_path').and.returnValue(false);
+        cachePackage = spyOn(npmHelper, 'cachePackage').and.returnValue(Q(path.join('lib', 'dir')));
         fakeLazyLoad = function (id, platform, version) {
             if (platform == 'wp7' || platform == 'wp8') {
                 return Q(path.join('lib', 'wp', id, version, platform));
@@ -48,7 +48,7 @@ describe('lazy_load module', function() {
         var custom,
             version;
         beforeEach(function() {
-            custom = spyOn(lazy_load, 'custom').andReturn(Q(path.join('lib','dir')));
+            custom = spyOn(lazy_load, 'custom').and.returnValue(Q(path.join('lib','dir')));
             version = platforms.android.version;
             platforms.android.version = '3.14.15.9265';
         });
@@ -77,13 +77,13 @@ describe('lazy_load module', function() {
             spyOn(shell, 'mkdir');
             rm = spyOn(shell, 'rm');
             mv = spyOn(shell, 'mv');
-            exists = spyOn(fs, 'existsSync').andReturn(false);
-            readdir = spyOn(fs, 'readdirSync').andReturn(['somefile.txt']);
-            fire = spyOn(HooksRunner, 'fire').andReturn(Q());
+            exists = spyOn(fs, 'existsSync').and.returnValue(false);
+            readdir = spyOn(fs, 'readdirSync').and.returnValue(['somefile.txt']);
+            fire = spyOn(HooksRunner, 'fire').and.returnValue(Q());
         });
 
         it('should callback with no errors and not fire event hooks if library already exists', function(done) {
-            exists.andReturn(true);
+            exists.and.returnValue(true);
             var mock_platforms = {
                 'platform X': {
                     id: 'some id',
@@ -98,7 +98,7 @@ describe('lazy_load module', function() {
             }).fin(done);
         });
         it('should callback with no errors and fire event hooks even if library already exists if the lib url is a local dir', function(done) {
-            exists.andReturn(true);
+            exists.and.returnValue(true);
             var mock_platforms = {
                 'platform X': {
                     id: 'some id',
@@ -117,25 +117,25 @@ describe('lazy_load module', function() {
             var req,
                 events = {},
                 fakeRequest = {
-                    on: jasmine.createSpy().andCallFake(function(event, cb) {
+                    on: jasmine.createSpy().and.callFake(function(event, cb) {
                         events[event] = cb;
                         return fakeRequest;
                     }),
-                    pipe: jasmine.createSpy().andCallFake(function() { return fakeRequest; })
+                    pipe: jasmine.createSpy().and.callFake(function() { return fakeRequest; })
                 };
             beforeEach(function() {
                 events = {};
                 fakeRequest.on.reset();
                 fakeRequest.pipe.reset();
-                req = spyOn(request, 'get').andCallFake(function() {
+                req = spyOn(request, 'get').and.callFake(function() {
                     // Fire the 'end' event shortly.
                     setTimeout(function() {
                         events['end']();
                     }, 10);
                     return fakeRequest;
                 });
-                spyOn(npm, 'load').andCallFake(function(cb) { cb(); });
-                spyOn(npm.config, 'get').andReturn(null);
+                spyOn(npm, 'load').and.callFake(function(cb) { cb(); });
+                spyOn(npm.config, 'get').and.returnValue(null);
             });
 
             it('should call request with appropriate url params', function(done) {
@@ -157,7 +157,7 @@ describe('lazy_load module', function() {
             });
             it('should take into account https-proxy npm configuration var if exists for https:// calls', function(done) {
                 var proxy = 'https://somelocalproxy.com';
-                npm.config.get.andReturn(proxy);
+                npm.config.get.and.returnValue(proxy);
                 var url = 'https://github.com/apache/someplugin';
                 var with_android_platform = {
                     'android': {
@@ -177,7 +177,7 @@ describe('lazy_load module', function() {
             });
             it('should take into account proxy npm config var if exists for http:// calls', function(done) {
                 var proxy = 'http://somelocalproxy.com';
-                npm.config.get.andReturn(proxy);
+                npm.config.get.and.returnValue(proxy);
                 var url = 'http://github.com/apache/someplugin';
                 var with_android_platform = {
                     'android': {
@@ -232,11 +232,11 @@ describe('lazy_load module', function() {
     describe('based_on_config method', function() {
         var cordova, custom, read;
         beforeEach(function() {
-            cordova = spyOn(lazy_load, 'cordova').andReturn(Q());
-            custom = spyOn(lazy_load, 'custom').andReturn(Q());
+            cordova = spyOn(lazy_load, 'cordova').and.returnValue(Q());
+            custom = spyOn(lazy_load, 'custom').and.returnValue(Q());
         });
         it('should invoke custom if a custom lib is specified', function(done) {
-            read = spyOn(config, 'read').andReturn({
+            read = spyOn(config, 'read').and.returnValue({
                 lib:{
                     maybe:{
                         url:'you or eye?',
@@ -246,8 +246,8 @@ describe('lazy_load module', function() {
                 }
             });
             var p = '/some/random/custom/path';
-            custom_path.andReturn(p);
-            custom.andCallFake(function (platforms, platform) {
+            custom_path.and.returnValue(p);
+            custom.and.callFake(function (platforms, platform) {
                 expect(platform).toEqual('maybe');
                 expect(platforms[platform].url).toEqual('you or eye?');
                 expect(platforms[platform].id).toEqual('eye dee');

--- a/cordova-lib/spec-cordova/metadata/android_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/android_parser.spec.js
@@ -52,8 +52,8 @@ describe('android project parser', function() {
     var android_proj = path.join(proj, 'platforms', 'android');
     var exists;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        spyOn(config, 'has_custom_path').andReturn(false);
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        spyOn(config, 'has_custom_path').and.returnValue(false);
     });
 
     function errorWrapper(p, done, post) {
@@ -64,7 +64,7 @@ describe('android project parser', function() {
 
     describe('constructions', function() {
         it('should throw if provided directory does not contain an AndroidManifest.xml', function() {
-            exists.andReturn(false);
+            exists.and.returnValue(false);
             expect(function() {
                 new androidParser(android_proj);
             }).toThrow();
@@ -98,11 +98,11 @@ describe('android project parser', function() {
             p = new androidParser(android_proj);
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
-            is_cordova = spyOn(util, 'isCordova').andReturn(android_proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(android_proj);
             write = spyOn(fs, 'writeFileSync');
             read = spyOn(fs, 'readFileSync');
             mkdir = spyOn(shell, 'mkdir');
-            spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
+            spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function(path) {
                 if (/strings/.exec(path)) {
                     return stringsRoot = new et.ElementTree(et.XML(STRINGS_XML));
                 } else if (/AndroidManifest/.exec(path)) {
@@ -116,45 +116,45 @@ describe('android project parser', function() {
 
         describe('update_from_config method', function() {
             beforeEach(function() {
-                spyOn(fs, 'readdirSync').andReturn([ path.join(android_proj, 'src', 'android_pkg', 'MyApp.java') ]);
+                spyOn(fs, 'readdirSync').and.returnValue([ path.join(android_proj, 'src', 'android_pkg', 'MyApp.java') ]);
                 cfg.name = function() { return 'testname'; };
                 cfg.packageName = function() { return 'testpkg'; };
                 cfg.version = function() { return 'one point oh'; };
-                read.andReturn('package org.cordova.somepackage; public class MyApp extends CordovaActivity { }');
+                read.and.returnValue('package org.cordova.somepackage; public class MyApp extends CordovaActivity { }');
             });
 
             it('should write out the orientation preference value', function() {
-                getOrientation.andCallThrough();
+                getOrientation.and.callThrough();
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('landscape');
             });
             it('should handle no orientation', function() {
-                getOrientation.andReturn('');
+                getOrientation.and.returnValue('');
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toBeUndefined();
             });
             it('should handle default orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_DEFAULT);
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toBeUndefined();
             });
             it('should handle portrait orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_PORTRAIT);
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('portrait');
             });
             it('should handle landscape orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_LANDSCAPE);
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('landscape');
             });
             it('should handle sensorLandscape orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_SENSOR_LANDSCAPE);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_SENSOR_LANDSCAPE);
                 p.update_from_config(cfg2);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('sensorLandscape');
             });
             it('should handle custom orientation', function() {
-                getOrientation.andReturn('some-custom-orientation');
+                getOrientation.and.returnValue('some-custom-orientation');
                 p.update_from_config(cfg);
                 expect(manifestRoot.getroot().find('./application/activity').attrib['android:screenOrientation']).toEqual('some-custom-orientation');
             });
@@ -196,7 +196,7 @@ describe('android project parser', function() {
         });
         describe('update_overrides method', function() {
             it('should do nothing if merges directory does not exist', function() {
-                exists.andReturn(false);
+                exists.and.returnValue(false);
                 p.update_overrides();
                 expect(cp).not.toHaveBeenCalled();
             });
@@ -219,7 +219,7 @@ describe('android project parser', function() {
             });
             it('should throw if update_from_config throws', function(done) {
                 var err = new Error('uh oh!');
-                config.andCallFake(function() { throw err; });
+                config.and.callFake(function() { throw err; });
                 errorWrapper(p.update_project({}), done, function(err) {
                     expect(err).toEqual(err);
                 });

--- a/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/blackberry_parser.spec.js
@@ -52,10 +52,10 @@ describe('blackberry10 project parser', function() {
     var proj = '/some/path';
     var exists, custom;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
         spyOn(ConfigParser.prototype, 'write');
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function() {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function() {
             return new et.ElementTree(et.XML(TEST_XML));
         });
     });
@@ -74,7 +74,7 @@ describe('blackberry10 project parser', function() {
 
     describe('constructions', function() {
         it('should throw an exception with a path that is not a native blackberry project', function() {
-            exists.andReturn(false);
+            exists.and.returnValue(false);
             expect(function() {
                 new blackberryParser(proj);
             }).toThrow();
@@ -104,7 +104,7 @@ describe('blackberry10 project parser', function() {
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
             mkdir = spyOn(shell, 'mkdir');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             write = spyOn(fs, 'writeFileSync');
             read = spyOn(fs, 'readFileSync');
         });
@@ -165,7 +165,7 @@ describe('blackberry10 project parser', function() {
         });
         describe('update_overrides method', function() {
             it('should do nothing if merges directory does not exist', function() {
-                exists.andReturn(false);
+                exists.and.returnValue(false);
                 p.update_overrides();
                 expect(cp).not.toHaveBeenCalled();
             });
@@ -181,7 +181,7 @@ describe('blackberry10 project parser', function() {
                 www = spyOn(p, 'update_www');
                 overrides = spyOn(p, 'update_overrides');
                 svn = spyOn(util, 'deleteSvnFolders');
-                parse = spyOn(JSON, 'parse').andReturn({blackberry:{qnx:{}}});
+                parse = spyOn(JSON, 'parse').and.returnValue({blackberry:{qnx:{}}});
             });
             it('should call update_from_config', function(done) {
                 wrapper(p.update_project(), done, function() {
@@ -190,7 +190,7 @@ describe('blackberry10 project parser', function() {
             });
             it('should throw if update_from_config throws', function(done) {
                 var err = new Error('uh oh!');
-                config.andCallFake(function() { throw err; });
+                config.and.callFake(function() { throw err; });
                 errorWrapper(p.update_project({}), done, function(e) {
                     expect(e).toEqual(err);
                 });

--- a/cordova-lib/spec-cordova/metadata/browser_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/browser_parser.spec.js
@@ -30,7 +30,7 @@ describe('browser project parser', function() {
     var exists, origDirExists;
 
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
         origDirExists = browserParser.__get__('dirExists');
         browserParser.__set__('dirExists', function () {
             return true;
@@ -67,7 +67,7 @@ describe('browser project parser', function() {
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
             mkdir = spyOn(shell, 'mkdir');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
         });
 
         describe('www_dir method', function() {
@@ -92,7 +92,7 @@ describe('browser project parser', function() {
 
         describe('update_overrides method', function() {
             it('should do nothing if merges directory does not exist', function() {
-                exists.andReturn(false);
+                exists.and.returnValue(false);
                 p.update_overrides();
                 expect(cp).not.toHaveBeenCalled();
             });

--- a/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/firefoxos_parser.spec.js
@@ -43,11 +43,11 @@ describe('firefoxos project parser', function() {
     var proj = path.join('some', 'path');
     var exists, exec, custom;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        exec = spyOn(shell, 'exec').andCallFake(function(cmd, opts, cb) {
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        exec = spyOn(shell, 'exec').and.callFake(function(cmd, opts, cb) {
             cb(0, '');
         });
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
     });
 
     describe('constructions', function() {
@@ -77,11 +77,11 @@ describe('firefoxos project parser', function() {
             p = new firefoxosParser(ff_proj);
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             write = spyOn(fs, 'writeFileSync');
             read = spyOn(fs, 'readFileSync');
 
-            spyOn(JSON, 'parse').andCallFake(function (path) {
+            spyOn(JSON, 'parse').and.callFake(function (path) {
                 if (/manifest.webapp$/.exec(path)) {
                     return manifestJson = _.extend({}, MANIFEST_JSON);
                 } else {
@@ -96,39 +96,39 @@ describe('firefoxos project parser', function() {
                 cfg.name = function() { return 'testname'; };
                 cfg.packageName = function() { return 'testpkg'; };
                 cfg.version = function() { return '1.0'; };
-                read.andReturn(p.manifest_path);
+                read.and.returnValue(p.manifest_path);
             });
             it('should write manifest.webapp', function() {
                 p.update_from_config(cfg);
-                expect(write.mostRecentCall.args[0]).toEqual(p.manifest_path);
+                expect(write.calls.mostRecent().args[0]).toEqual(p.manifest_path);
             });
             it('should write out the orientation preference value', function() {
-                getOrientation.andCallThrough();
+                getOrientation.and.callThrough();
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toEqual([ 'portrait' ]);
             });
             it('should handle no orientation', function () {
-                getOrientation.andReturn('');
+                getOrientation.and.returnValue('');
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toBeUndefined();
             });
             it('should handle default orientation', function () {
-                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_DEFAULT);
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toBeUndefined();
             });
             it('should handle portrait orientation', function () {
-                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_PORTRAIT);
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toEqual([ 'portrait' ]);
             });
             it('should handle landscape orientation', function () {
-                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_LANDSCAPE);
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toEqual([ 'landscape' ]);
             });
             it('should handle custom orientation', function () {
-                getOrientation.andReturn('some-custom-orientation');
+                getOrientation.and.returnValue('some-custom-orientation');
                 p.update_from_config(cfg);
                 expect(manifestJson.orientation).toEqual([ 'some-custom-orientation' ]);
             });

--- a/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/ios_parser.spec.js
@@ -41,7 +41,7 @@ var cfg2 = new ConfigParser(path.join(__dirname, '..', 'test-config-2.xml'));
 describe('ios project parser', function () {
     var custom;
     beforeEach(function() {
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
         shell.mkdir('-p', ios_proj);
         shell.cp('-rf', iosProjectFixture + '/*', ios_proj);
     });
@@ -90,7 +90,7 @@ describe('ios project parser', function () {
         var p, is_cordova, getOrientation;
         beforeEach(function() {
             p = new iosParser(ios_proj);
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             getOrientation = spyOn(p.helper, 'getOrientation');
         });
 
@@ -101,13 +101,13 @@ describe('ios project parser', function () {
             var xcOrig = xcode.project;
             beforeEach(function() {
                 mv = spyOn(shell, 'mv');
-                plist_parse = spyOn(plist, 'parse').andReturn({
+                plist_parse = spyOn(plist, 'parse').and.returnValue({
                 });
-                plist_build = spyOn(plist, 'build').andReturn('');
+                plist_build = spyOn(plist, 'build').and.returnValue('');
                 xc = spyOn(xcode, 'project')
-                .andCallFake(function (pbxproj) {
+                .and.callFake(function (pbxproj) {
                     var xc = new xcOrig(pbxproj);
-                    update_name = spyOn(xc, 'updateProductName').andCallThrough();
+                    update_name = spyOn(xc, 'updateProductName').and.callThrough();
                     return xc;
                 });
                 cfg.name = function() { return 'testname'; };
@@ -144,7 +144,7 @@ describe('ios project parser', function () {
                 });
             });
             it('should write out the orientation preference value', function(done) {
-                getOrientation.andCallThrough();
+                getOrientation.and.callThrough();
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ]);
                     expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ]);
@@ -152,7 +152,7 @@ describe('ios project parser', function () {
                 });
             });
             it('should handle no orientation', function(done) {
-                getOrientation.andReturn('');
+                getOrientation.and.returnValue('');
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
                     expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toBeUndefined();
@@ -160,7 +160,7 @@ describe('ios project parser', function () {
                 });
             });
             it('should handle default orientation', function(done) {
-                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_DEFAULT);
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
                     expect(plist_build.mostRecentCall.args[0]['UISupportedInterfaceOrientations~ipad']).toBeUndefined();
@@ -168,28 +168,28 @@ describe('ios project parser', function () {
                 });
             });
             it('should handle portrait orientation', function(done) {
-                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_PORTRAIT);
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown' ]);
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'UIInterfaceOrientationPortrait' ]);
                 });
             });
             it('should handle landscape orientation', function(done) {
-                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_LANDSCAPE);
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'UIInterfaceOrientationLandscapeLeft' ]);
                 });
             });
             it('should handle all orientation on ios', function(done) {
-                getOrientation.andReturn(p.helper.ORIENTATION_ALL);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_ALL);
                 wrapper(p.update_from_config(cfg2), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toEqual([ 'UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown', 'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight' ]);
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'UIInterfaceOrientationPortrait' ]);
                 });
             });
             it('should handle custom orientation', function(done) {
-                getOrientation.andReturn('some-custom-orientation');
+                getOrientation.and.returnValue('some-custom-orientation');
                 wrapper(p.update_from_config(cfg), done, function() {
                     expect(plist_build.mostRecentCall.args[0].UISupportedInterfaceOrientations).toBeUndefined();
                     expect(plist_build.mostRecentCall.args[0].UIInterfaceOrientation).toEqual([ 'some-custom-orientation' ]);
@@ -429,8 +429,8 @@ describe('ios project parser', function () {
             var cp, rm;
 
             beforeEach(function () {
-                rm = spyOn(shell, 'rm').andCallThrough();
-                cp = spyOn(shell, 'cp').andCallThrough();
+                rm = spyOn(shell, 'rm').and.callThrough();
+                cp = spyOn(shell, 'cp').and.callThrough();
             });
 
             it('should rm project-level www and cp in platform agnostic www', function() {
@@ -442,20 +442,20 @@ describe('ios project parser', function () {
         describe('update_overrides method', function() {
             var exists, rm, cp;
             beforeEach(function() {
-                exists = spyOn(fs, 'existsSync').andCallThrough();
-                rm = spyOn(shell, 'rm').andCallThrough();
-                cp = spyOn(shell, 'cp').andCallThrough();
+                exists = spyOn(fs, 'existsSync').and.callThrough();
+                rm = spyOn(shell, 'rm').and.callThrough();
+                cp = spyOn(shell, 'cp').and.callThrough();
             });
             it('should do nothing if merges directory does not exist', function() {
-                cp.reset();
-                exists.andReturn(false);
+                cp.calls.reset();
+                exists.and.returnValue(false);
                 p.update_overrides();
                 expect(cp).not.toHaveBeenCalled();
             });
             it('should copy merges path into www', function() {
-                cp.andCallFake(function(){});
-                cp.reset();
-                exists.andReturn(true);
+                cp.and.callFake(function(){});
+                cp.calls.reset();
+                exists.and.returnValue(true);
                 p.update_overrides();
                 expect(cp).toHaveBeenCalled();
             });
@@ -463,7 +463,7 @@ describe('ios project parser', function () {
         describe('update_project method', function() {
             var config, www, overrides, svn;
             beforeEach(function() {
-                config = spyOn(p, 'update_from_config').andReturn(Q());
+                config = spyOn(p, 'update_from_config').and.returnValue(Q());
                 www = spyOn(p, 'update_www');
                 overrides = spyOn(p, 'update_overrides');
                 svn = spyOn(util, 'deleteSvnFolders');
@@ -475,7 +475,7 @@ describe('ios project parser', function () {
             });
             it('should throw if update_from_config errors', function(done) {
                 var e = new Error('uh oh!');
-                config.andReturn(Q.reject(e));
+                config.and.returnValue(Q.reject(e));
                 errorWrapper(p.update_project({}), done, function(err) {
                     expect(err).toEqual(e);
                 });

--- a/cordova-lib/spec-cordova/metadata/parserhelper/preferences.spec.js
+++ b/cordova-lib/spec-cordova/metadata/parserhelper/preferences.spec.js
@@ -105,13 +105,13 @@ describe('preferences', function() {
                 var configXml, configParser;
                 
                 configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><preference name="orientation" value="all" /></widget>';
-                readFile.andReturn(configXml);
+                readFile.and.returnValue(configXml);
                 configParser = new ConfigParser(xml);
 
                 expect(preferences.getOrientation(configParser, 'ios')).toEqual('all');
                 
                 configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><preference name="orientation" value="sensorLandscape" /></widget>';
-                readFile.andReturn(configXml);
+                readFile.and.returnValue(configXml);
                 configParser = new ConfigParser(xml);
                 
                 expect(preferences.getOrientation(configParser, 'android')).toEqual('sensorLandscape');
@@ -119,14 +119,14 @@ describe('preferences', function() {
             
             it('should handle no orientation', function() {
                 var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget></widget>';
-                readFile.andReturn(configXml);
+                readFile.and.returnValue(configXml);
                 var configParser = new ConfigParser(xml);
                 expect(preferences.getOrientation(configParser)).toEqual('');
                 expect(emit).not.toHaveBeenCalled();
             });
             it('should handle invalid global orientation', function() {
                 var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><preference name="orientation" value="foobar" /></widget>';
-                readFile.andReturn(configXml);
+                readFile.and.returnValue(configXml);
                 var configParser = new ConfigParser(xml);
                 expect(preferences.getOrientation(configParser)).toEqual('default');
                 expect(emit).toHaveBeenCalledWith('warn', 'Unsupported global orientation: foobar');
@@ -135,7 +135,7 @@ describe('preferences', function() {
             
             it('should handle custom platform-specific orientation', function() {
                 var configXml = '<?xml version="1.0" encoding="UTF-8"?><widget><platform name="some-platform"><preference name="orientation" value="foobar" /></platform></widget>';
-                readFile.andReturn(configXml);
+                readFile.and.returnValue(configXml);
                 var configParser = new ConfigParser(xml);
                 expect(preferences.getOrientation(configParser, 'some-platform')).toEqual('foobar');
             });

--- a/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/webos_parser.spec.js
@@ -29,11 +29,11 @@ describe('webos project parser', function() {
     var proj = path.join('some', 'path');
     var exists, exec, custom;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        exec = spyOn(shell, 'exec').andCallFake(function(cmd, opts, cb) {
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        exec = spyOn(shell, 'exec').and.callFake(function(cmd, opts, cb) {
             cb(0, '');
         });
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
     });
 
     describe('constructions', function() {
@@ -52,9 +52,9 @@ describe('webos project parser', function() {
             p = new webosParser(wos_proj);
             cp = spyOn(shell, 'cp');
             rm = spyOn(shell, 'rm');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             write = spyOn(fs, 'writeFileSync');
-            read = spyOn(fs, 'readFileSync').andReturn('');
+            read = spyOn(fs, 'readFileSync').and.returnValue('');
         });
 
         describe('update_from_config method', function() {

--- a/cordova-lib/spec-cordova/metadata/windows_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/windows_parser.spec.js
@@ -41,13 +41,13 @@ describe('windows project parser', function() {
     var exists, exec, custom, readdir, config_read;
     var winXml;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        exec = spyOn(child_process, 'exec').andCallFake(function(cmd, opts, cb) {
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        exec = spyOn(child_process, 'exec').and.callFake(function(cmd, opts, cb) {
             if (!cb) cb = opts;
             cb(null, '', '');
         });
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
-        config_read = spyOn(config, 'read').andCallFake(function() {
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
+        config_read = spyOn(config, 'read').and.callFake(function() {
             return custom() ? {
                 lib: {
                     windows: {
@@ -57,9 +57,9 @@ describe('windows project parser', function() {
             }
             : ({});
         });
-        readdir = spyOn(fs, 'readdirSync').andReturn(['TestApp.projitems']);
+        readdir = spyOn(fs, 'readdirSync').and.returnValue(['TestApp.projitems']);
         winXml = null;
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function(path) {
             return winXml = new et.ElementTree(et.XML('<foo><Application/><Identity/><VisualElements><a/></VisualElements><Capabilities><a/></Capabilities></foo>'));
         });
     });
@@ -78,7 +78,7 @@ describe('windows project parser', function() {
 
     describe('constructions', function() {
         it('should throw if provided directory does not contain a projitems file', function() {
-            readdir.andReturn([]);
+            readdir.and.returnValue([]);
             expect(function() {
                 new windowsParser(proj);
             }).toThrow();
@@ -108,9 +108,9 @@ describe('windows project parser', function() {
             rm = spyOn(shell, 'rm');
             mv = spyOn(shell, 'mv');
             mkdir = spyOn(shell, 'mkdir');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             write = spyOn(fs, 'writeFileSync');
-            read = spyOn(fs, 'readFileSync').andReturn('');
+            read = spyOn(fs, 'readFileSync').and.returnValue('');
         });
 
         describe('update_from_config method', function() {
@@ -142,10 +142,10 @@ describe('windows project parser', function() {
             beforeEach(function() {
                 config = spyOn(parser, 'update_from_config');
                 www = spyOn(parser, 'update_www');
-                shellls = spyOn(shell, 'ls').andReturn([]);
+                shellls = spyOn(shell, 'ls').and.returnValue([]);
                 svn = spyOn(util, 'deleteSvnFolders');
-                exists.andReturn(false);
-                fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
+                exists.and.returnValue(false);
+                fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
             });
             it('should call update_from_config', function() {
                 parser.update_project();
@@ -153,7 +153,7 @@ describe('windows project parser', function() {
             });
             it('should throw if update_from_config throws', function(done) {
                 var err = new Error('uh oh!');
-                config.andCallFake(function() { throw err; });
+                config.and.callFake(function() { throw err; });
                 errorWrapper(parser.update_project({}), done, function(err) {
                     expect(err).toEqual(err);
                 });

--- a/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
+++ b/cordova-lib/spec-cordova/metadata/wp8_parser.spec.js
@@ -57,12 +57,12 @@ describe('wp8 project parser', function() {
     var exists, exec, custom, readdir, config_read;
     var manifestXml, projXml, mainPageXamlXml;
     beforeEach(function() {
-        exists = spyOn(fs, 'existsSync').andReturn(true);
-        exec = spyOn(child_process, 'exec').andCallFake(function(cmd, opts, cb) {
+        exists = spyOn(fs, 'existsSync').and.returnValue(true);
+        exec = spyOn(child_process, 'exec').and.callFake(function(cmd, opts, cb) {
             (cb || opts)(0, '', '');
         });
-        custom = spyOn(config, 'has_custom_path').andReturn(false);
-        config_read = spyOn(config, 'read').andCallFake(function() {
+        custom = spyOn(config, 'has_custom_path').and.returnValue(false);
+        config_read = spyOn(config, 'read').and.callFake(function() {
             return custom() ? {
                 lib: {
                     wp8: {
@@ -72,9 +72,9 @@ describe('wp8 project parser', function() {
             }
             : ({});
         });
-        readdir = spyOn(fs, 'readdirSync').andReturn(['test.csproj']);
+        readdir = spyOn(fs, 'readdirSync').and.returnValue(['test.csproj']);
         projXml = manifestXml = mainPageXamlXml = null;
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function(path) {
             if (/WMAppManifest.xml$/.exec(path)) {
                 return manifestXml = new et.ElementTree(et.XML(MANIFEST_XML));
             } else if (/csproj$/.exec(path)) {
@@ -103,7 +103,7 @@ describe('wp8 project parser', function() {
 
     describe('constructions', function() {
         it('should throw if provided directory does not contain a csproj file', function() {
-            readdir.andReturn([]);
+            readdir.and.returnValue([]);
             expect(function() {
                 new wp8Parser(proj);
             }).toThrow();
@@ -134,9 +134,9 @@ describe('wp8 project parser', function() {
             rm = spyOn(shell, 'rm');
             mv = spyOn(shell, 'mv');
             mkdir = spyOn(shell, 'mkdir');
-            is_cordova = spyOn(util, 'isCordova').andReturn(proj);
+            is_cordova = spyOn(util, 'isCordova').and.returnValue(proj);
             write = spyOn(fs, 'writeFileSync');
-            read = spyOn(fs, 'readFileSync').andReturn('');
+            read = spyOn(fs, 'readFileSync').and.returnValue('');
             getOrientation = spyOn(p.helper, 'getOrientation');
         });
 
@@ -146,7 +146,7 @@ describe('wp8 project parser', function() {
                 cfg.content = function() { return 'index.html'; };
                 cfg.packageName = function() { return 'testpkg'; };
                 cfg.version = function() { return 'one point oh'; };
-                readdir.andReturn(['test.sln']);
+                readdir.and.returnValue(['test.sln']);
             });
 
             it('should write out the app name to wmappmanifest.xml', function() {
@@ -165,37 +165,37 @@ describe('wp8 project parser', function() {
                 expect(appEl.attrib.Version).toEqual('one point oh');
             });
             it('should write out the orientation preference value', function() {
-                getOrientation.andCallThrough();
+                getOrientation.and.callThrough();
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
             });
             it('should handle no orientation', function() {
-                getOrientation.andReturn('');
+                getOrientation.and.returnValue('');
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toBeUndefined();
             });
             it('should handle default orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_DEFAULT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_DEFAULT);
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toBeUndefined();
             });
             it('should handle portrait orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_PORTRAIT);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_PORTRAIT);
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('portrait');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('portrait');
             });
             it('should handle landscape orientation', function() {
-                getOrientation.andReturn(p.helper.ORIENTATION_LANDSCAPE);
+                getOrientation.and.returnValue(p.helper.ORIENTATION_LANDSCAPE);
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toEqual('landscape');
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('landscape');
             });
             it('should handle custom orientation', function() {
-                getOrientation.andReturn('some-custom-orientation');
+                getOrientation.and.returnValue('some-custom-orientation');
                 p.update_from_config(cfg);
                 expect(mainPageXamlXml.getroot().attrib['SupportedOrientations']).toBeUndefined();
                 expect(mainPageXamlXml.getroot().attrib['Orientation']).toEqual('some-custom-orientation');
@@ -228,8 +228,8 @@ describe('wp8 project parser', function() {
                 config = spyOn(p, 'update_from_config');
                 www = spyOn(p, 'update_www');
                 svn = spyOn(util, 'deleteSvnFolders');
-                exists.andReturn(false);
-                fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
+                exists.and.returnValue(false);
+                fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
             });
             it('should call update_from_config', function(done) {
                 wrapper(p.update_project(), done, function() {
@@ -238,7 +238,7 @@ describe('wp8 project parser', function() {
             });
             it('should throw if update_from_config throws', function(done) {
                 var err = new Error('uh oh!');
-                config.andCallFake(function() { throw err; });
+                config.and.callFake(function() { throw err; });
                 errorWrapper(p.update_project({}), done, function(e) {
                     expect(e).toEqual(err);
                 });

--- a/cordova-lib/spec-cordova/platform.spec.ios.js
+++ b/cordova-lib/spec-cordova/platform.spec.ios.js
@@ -44,7 +44,7 @@ describe('cocoapod plugin add and rm end-to-end', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('installs and uninstalls plugin depending on new pod and existing pod', function(done) {
+    it('Test 001 : installs and uninstalls plugin depending on new pod and existing pod', function(done) {
 
         cordova.raw.create('hello4')
         .then(function() {

--- a/cordova-lib/spec-cordova/platform.spec.js
+++ b/cordova-lib/spec-cordova/platform.spec.js
@@ -57,7 +57,7 @@ describe('platform end-to-end', function () {
 
         // The config.json in the fixture project points at fake "local" paths.
         // Since it's not a URL, the lazy-loader will just return the junk path.
-        spyOn(superspawn, 'spawn').andCallFake(function(cmd, args) {
+        spyOn(superspawn, 'spawn').and.callFake(function(cmd, args) {
             if (cmd.match(/create\b/)) {
                 // This is a call to the bin/create script, so do the copy ourselves.
                 shell.cp('-R', path.join(__dirname, 'fixtures', 'platforms', 'android'), path.join(project, 'platforms'));
@@ -148,8 +148,8 @@ describe('platform end-to-end', function () {
     it('should call prepare after plugins were installed into platform', function(done) {
         var order = '';
         var fail = jasmine.createSpy(fail);
-        spyOn(plugman.raw, 'install').andCallFake(function() { order += 'I'; });
-        spyOn(cordova.raw, 'prepare').andCallFake(function() { order += 'P'; });
+        spyOn(plugman.raw, 'install').and.callFake(function() { order += 'I'; });
+        spyOn(cordova.raw, 'prepare').and.callFake(function() { order += 'P'; });
 
         cordova.raw.plugin('add', path.join(pluginsDir, 'test'))
         .then(function() {

--- a/cordova-lib/spec-cordova/platform.spec.js
+++ b/cordova-lib/spec-cordova/platform.spec.js
@@ -97,7 +97,7 @@ describe('platform end-to-end', function () {
     // They should run the appropriate hooks.
     // They should fail when not inside a Cordova project.
     // These tests deliberately have no beforeEach and afterEach that are cleaning things up.
-    it('should successfully run', function(done) {
+    it('Test 001 : should successfully run', function(done) {
 
         // Check there are no platforms yet.
         emptyPlatformList().then(function() {
@@ -127,7 +127,7 @@ describe('platform end-to-end', function () {
         }).fin(done);
     });
 
-    it('should install plugins correctly while adding platform', function(done) {
+    it('Test 002 : should install plugins correctly while adding platform', function(done) {
 
         cordova.raw.plugin('add', path.join(pluginsDir, 'test'))
         .then(function() {
@@ -145,7 +145,7 @@ describe('platform end-to-end', function () {
         .fin(done);
     });
 
-    it('should call prepare after plugins were installed into platform', function(done) {
+    it('Test 003 : should call prepare after plugins were installed into platform', function(done) {
         var order = '';
         var fail = jasmine.createSpy(fail);
         spyOn(plugman.raw, 'install').and.callFake(function() { order += 'I'; });
@@ -177,7 +177,7 @@ describe('add function', function () {
         };
     });
 
-    it('throws if the target list is empty', function (done) {
+    it('Test 004 : throws if the target list is empty', function (done) {
         var targets = [];
         platform.add(hooksRunnerMock, projectRoot, targets, opts).fail(function (error) {
             expect(error.message).toBe('No platform specified. Please specify a platform to add. See `cordova platform list`.');
@@ -185,7 +185,7 @@ describe('add function', function () {
         });
     });
 
-    it('throws if the target list is undefined or null', function (done) {
+    it('Test 005 : throws if the target list is undefined or null', function (done) {
 
         // case 1 : target list undefined
         var targets; // = undefined;
@@ -217,7 +217,7 @@ describe('platform add plugin rm end-to-end', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should remove dependency when removing parent plugin', function(done) {
+    it('Test 006 : should remove dependency when removing parent plugin', function(done) {
 
         cordova.raw.create('hello')
         .then(function() {
@@ -230,7 +230,7 @@ describe('platform add plugin rm end-to-end', function () {
         .then(function() {
             expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
             expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-            return cordova.raw.platform('add', 'android@latest');
+            return cordova.raw.platform('add', 'android');
         })
         .then(function() {
             expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
@@ -246,7 +246,7 @@ describe('platform add plugin rm end-to-end', function () {
             expect(err).toBeUndefined();
         })
         .fin(done);
-    }, 20000);
+    }, 100000);
 });
 
 describe('platform add and remove --fetch', function () {
@@ -265,7 +265,7 @@ describe('platform add and remove --fetch', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should add and remove platform from node_modules directory', function(done) {
+    it('Test 007 : should add and remove platform from node_modules directory', function(done) {
 
         cordova.raw.create('helloFetch')
         .then(function() {
@@ -298,7 +298,7 @@ describe('platform add and remove --fetch', function () {
             expect(err).toBeUndefined();
         })
         .fin(done);
-    }, 40000);
+    }, 100000);
 });
 
 describe('plugin add and rm end-to-end --fetch', function () {
@@ -316,7 +316,7 @@ describe('plugin add and rm end-to-end --fetch', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should remove dependency when removing parent plugin', function(done) {
+    it('Test 008 : should remove dependency when removing parent plugin', function(done) {
 
         cordova.raw.create('hello3')
         .then(function() {
@@ -354,5 +354,5 @@ describe('plugin add and rm end-to-end --fetch', function () {
             expect(err).toBeUndefined();
         })
         .fin(done);
-    }, 60000);
+    }, 100000);
 });

--- a/cordova-lib/spec-cordova/platforms/PlatformApiPoly.spec.js
+++ b/cordova-lib/spec-cordova/platforms/PlatformApiPoly.spec.js
@@ -71,7 +71,7 @@ describe('PlatformApi polyfill', function () {
 
     beforeEach(function () {
         var originalParseElementtreeSync = xmlHelpers.parseElementtreeSync;
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function (configPath) {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function (configPath) {
             return /config\.xml$/.test(configPath) ? new et.ElementTree(et.XML(TEST_XML)) :
                 originalParseElementtreeSync(configPath);
         });
@@ -117,7 +117,7 @@ describe('PlatformApi polyfill', function () {
         var FAKE_PROJECT, FAKE_CONFIG, OPTIONS, getPlatformApi, fail, success;
 
         beforeEach(function () {
-            getPlatformApi = spyOn(knownPlatforms, 'getPlatformApi').andReturn(platformApi);
+            getPlatformApi = spyOn(knownPlatforms, 'getPlatformApi').and.returnValue(platformApi);
 
             spyOn(shell, 'cp');
             spyOn(shell, 'rm');
@@ -136,7 +136,7 @@ describe('PlatformApi polyfill', function () {
             var spawn;
 
             beforeEach(function () {
-                spawn = spyOn(superspawn, 'spawn').andReturn(Q());
+                spawn = spyOn(superspawn, 'spawn').and.returnValue(Q());
             });
 
             it('should create/update platform through running platforms\' scripts', function (done) {
@@ -144,7 +144,7 @@ describe('PlatformApi polyfill', function () {
                        PlatformApiPoly.updatePlatform(PLATFORM_ROOT, OPTIONS)])
                 .then(function () {
                     expect(spawn).toHaveBeenCalled();
-                    expect(spawn.calls.length).toBe(2);
+                    expect(spawn.calls.count()).toBe(2);
                 }).fail(function (err) {
                     expect(err).not.toBeDefined();
                 }).fin(done);
@@ -155,11 +155,11 @@ describe('PlatformApi polyfill', function () {
                        PlatformApiPoly.updatePlatform(PLATFORM_ROOT, OPTIONS)])
                 .then(function () {
                     expect(spawn).toHaveBeenCalled();
-                    expect(spawn.calls.length).toBe(2);
-                    expect(spawn.calls[0].args[0]).toBe(path.join(PLATFORM_LIB, 'bin/create'));
-                    expect(spawn.calls[0].args[1]).toContain(PLATFORM_ROOT);
-                    expect(spawn.calls[1].args[0]).toBe(path.join(PLATFORM_LIB, 'bin/update'));
-                    expect(spawn.calls[1].args[1]).toContain(PLATFORM_ROOT);
+                    expect(spawn.calls.count()).toBe(2);
+                    expect(spawn.calls.argsFor(0)[0]).toBe(path.join(PLATFORM_LIB, 'bin/create'));
+                    expect(spawn.calls.argsFor(0)[1]).toContain(PLATFORM_ROOT);
+                    expect(spawn.calls.argsFor(1)[0]).toBe(path.join(PLATFORM_LIB, 'bin/update'));
+                    expect(spawn.calls.argsFor(1)[1]).toContain(PLATFORM_ROOT);
                 }).fail(function (err) {
                     expect(err).not.toBeDefined();
                 }).fin(done);
@@ -170,7 +170,7 @@ describe('PlatformApi polyfill', function () {
                        PlatformApiPoly.updatePlatform(PLATFORM_ROOT, OPTIONS)])
                 .then(function () {
                     expect(shell.cp).toHaveBeenCalled();
-                    expect(shell.cp.calls.length).toBe(2);
+                    expect(shell.cp.calls.count()).toBe(2);
                 }).fail(fail)
                 .fin(function () {
                     expect(fail).not.toHaveBeenCalled();
@@ -195,7 +195,7 @@ describe('PlatformApi polyfill', function () {
         describe('prepare method', function () {
             beforeEach(function () {
                 spyOn(platformApi._parser, 'update_www');
-                spyOn(platformApi._parser, 'update_project').andReturn(Q());
+                spyOn(platformApi._parser, 'update_project').and.returnValue(Q());
             });
 
             it('should return promise', function (done) {
@@ -225,7 +225,7 @@ describe('PlatformApi polyfill', function () {
 
             beforeEach(function () {
                 plugin = new PluginInfo(DUMMY_PLUGIN);
-                actionsProcess = spyOn(ActionStack.prototype, 'process').andCallThrough();
+                actionsProcess = spyOn(ActionStack.prototype, 'process').and.callThrough();
             });
 
             it('should return promise', function (done) {
@@ -289,7 +289,7 @@ describe('PlatformApi polyfill', function () {
                 Q.all(ops)
                 .then(function () {
                     expect(spawnSpy).toHaveBeenCalled();
-                    expect(spawnSpy.calls.length).toEqual(3);
+                    expect(spawnSpy.calls.count()).toEqual(3);
                 }).fin(done);
             });
 
@@ -302,7 +302,7 @@ describe('PlatformApi polyfill', function () {
                     archs: ['arm', 'x86'],
                     buildConfig: '/some/path'
                 };
-                spawnSpy.andReturn(Q());
+                spawnSpy.and.returnValue(Q());
                 platformApi.build(options)
                 .then(function () {
                     ['--release', '--nobuild', '--device', '--target=' + options.target, '--archs=arm,x86', '--buildConfig='  +options.buildConfig]

--- a/cordova-lib/spec-cordova/platforms/platforms.spec.js
+++ b/cordova-lib/spec-cordova/platforms/platforms.spec.js
@@ -42,7 +42,7 @@ describe('getPlatformApi method', function () {
     beforeEach(function () {
         // reset api cache after each spec
         platforms.__set__('cachedApis', {});
-        isCordova = spyOn(util, 'isCordova').andReturn(CORDOVA_ROOT);
+        isCordova = spyOn(util, 'isCordova').and.returnValue(CORDOVA_ROOT);
     });
 
     it('should return PlatformApi class defined by platform', function () {
@@ -78,7 +78,7 @@ describe('getPlatformApi method', function () {
     });
 
     it('should throw if called outside of cordova project w/out platformRoot param', function () {
-        isCordova.andReturn(false);
+        isCordova.and.returnValue(false);
         expect(function () { platforms.getPlatformApi('windows'); }).toThrow();
     });
 

--- a/cordova-lib/spec-cordova/plugin.spec.js
+++ b/cordova-lib/spec-cordova/plugin.spec.js
@@ -146,7 +146,7 @@ describe('plugin end-to-end', function() {
         expect(errorHandler.errorCallback).not.toHaveBeenCalled();
     });
 
-    it('should successfully add and remove a plugin with no options', function(done) {
+    it('Test 001 : should successfully add and remove a plugin with no options', function(done) {
         addPlugin(path.join(pluginsDir, 'fake1'), pluginId, {}, done)
         .then(function() {
             return removePlugin(pluginId);
@@ -158,11 +158,11 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should run prepare after plugin installation/removal by default', function(done) {
+    it('Test 002 : should run prepare after plugin installation/removal by default', function(done) {
         addPlugin(path.join(pluginsDir, 'fake1'), pluginId, {})
         .then(function() {
             expect(prepare.preparePlatforms).toHaveBeenCalled();
-            prepare.preparePlatforms.reset();
+            prepare.preparePlatforms.calls.reset();
             return removePlugin(pluginId);
         })
         .then(function () {
@@ -175,7 +175,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should not run prepare after plugin installation/removal if platform return non-falsy value', function(done) {
+    it('Test 003 : should not run prepare after plugin installation/removal if platform return non-falsy value', function(done) {
         setupPlatformApiSpies();
         addPlugin(path.join(pluginsDir, 'fake1'), pluginId, {})
         .then(function() {
@@ -192,7 +192,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should successfully add a plugin using relative path when running from subdir inside of project', function(done) {
+    it('Test 004 : should successfully add a plugin using relative path when running from subdir inside of project', function(done) {
         // Copy plugin to subdir inside of the project. This is required since path.relative
         // returns an absolute path when source and dest are on different drives
         var plugindir = path.join(project, 'custom-plugins/some-plugin-inside-subfolder');
@@ -216,7 +216,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should respect preference default values', function (done) {    
+    it('Test 005 : should respect preference default values', function (done) {    
        addPlugin(path.join(pluginsDir, org_test_defaultvariables), org_test_defaultvariables, {cli_variables: { REQUIRED:'NO', REQUIRED_ANDROID:'NO'}}, done)
        .then(function() {
             var platformJsonPath = path.join(project, 'plugins', helpers.testPlatform + '.json');
@@ -236,7 +236,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should successfully add a plugin when specifying CLI variables', function(done) {
+    it('Test 006 : should successfully add a plugin when specifying CLI variables', function(done) {
         addPlugin(path.join(pluginsDir, org_test_defaultvariables), org_test_defaultvariables, {cli_variables: { REQUIRED:'yes', REQUIRED_ANDROID:'yes'}}, done)
         .fail(function(err) {
             console.error(err);
@@ -245,15 +245,14 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should not check npm info when using the searchpath flag', function(done) {
+    it('Test 007 : should not check npm info when using the searchpath flag', function(done) {
         mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
         spyOn(registry, 'info');
-        addPlugin(npmInfoTestPlugin, npmInfoTestPlugin, {searchpath: pluginsDir}, done)
+        return addPlugin(npmInfoTestPlugin, npmInfoTestPlugin, {searchpath: pluginsDir}, done)
         .then(function() {
             expect(registry.info).not.toHaveBeenCalled();
-
-            var fetchOptions = plugman.raw.fetch.mostRecentCall.args[2];
-            expect(fetchOptions.searchpath).toExist();
+            var fetchOptions = plugman.raw.fetch.calls.mostRecent().args[2];
+            expect(fetchOptions.searchpath[0]).toExist();
         })
         .fail(function(err) {
             console.error(err);
@@ -262,7 +261,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should not check npm info when using the noregistry flag', function(done) {
+    it('Test 008 : should not check npm info when using the noregistry flag', function(done) {
         mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
 
         spyOn(registry, 'info');
@@ -270,7 +269,7 @@ describe('plugin end-to-end', function() {
         .then(function() {
             expect(registry.info).not.toHaveBeenCalled();
 
-            var fetchOptions = plugman.raw.fetch.mostRecentCall.args[2];
+            var fetchOptions = plugman.raw.fetch.calls.mostRecent().args[2];
             expect(fetchOptions.noregistry).toBeTruthy();
         })
         .fail(function(err) {
@@ -280,7 +279,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should not check npm info when fetching from a Git repository', function(done) {
+    it('Test 009 : should not check npm info when fetching from a Git repository', function(done) {
         spyOn(registry, 'info');
         addPlugin(testGitPluginRepository, testGitPluginId, {}, done)
         .then(function() {
@@ -293,7 +292,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should select the plugin version based on npm info when fetching from npm', function(done) {
+    it('Test 010 : should select the plugin version based on npm info when fetching from npm', function(done) {
         mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
 
         spyOn(registry, 'info').and.callThrough();
@@ -301,7 +300,7 @@ describe('plugin end-to-end', function() {
         .then(function() {
             expect(registry.info).toHaveBeenCalled();
 
-            var fetchTarget = plugman.raw.fetch.mostRecentCall.args[0];
+            var fetchTarget = plugman.raw.fetch.calls.mostRecent().args[0];
             expect(fetchTarget).toEqual(npmInfoTestPlugin + '@' + npmInfoTestPluginVersion);
         })
         .fail(function(err) {
@@ -311,7 +310,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should handle scoped npm packages', function(done) {
+    it('Test 011 : should handle scoped npm packages', function(done) {
         var scopedPackage = '@testscope/' + npmInfoTestPlugin;
         mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
 
@@ -323,7 +322,7 @@ describe('plugin end-to-end', function() {
 
             expect(registry.info).toHaveBeenCalledWith([scopedPackage]);
 
-            var fetchTarget = plugman.raw.fetch.mostRecentCall.args[0];
+            var fetchTarget = plugman.raw.fetch.calls.mostRecent().args[0];
             expect(fetchTarget).toEqual(scopedPackage);
         })
         .fail(function(err) {
@@ -333,7 +332,7 @@ describe('plugin end-to-end', function() {
         .fin(done);
     }, 30000);
 
-    it('should handle scoped npm packages with given version tags', function(done) {
+    it('Test 012 : should handle scoped npm packages with given version tags', function(done) {
         var scopedPackage = '@testscope/' + npmInfoTestPlugin + '@latest';
         mockPluginFetch(npmInfoTestPlugin, path.join(pluginsDir, npmInfoTestPlugin));
 
@@ -342,7 +341,7 @@ describe('plugin end-to-end', function() {
         .then(function() {
             expect(registry.info).not.toHaveBeenCalled();
 
-            var fetchTarget = plugman.raw.fetch.mostRecentCall.args[0];
+            var fetchTarget = plugman.raw.fetch.calls.mostRecent().args[0];
             expect(fetchTarget).toEqual(scopedPackage);
         })
         .fail(function(err) {

--- a/cordova-lib/spec-cordova/plugin.spec.js
+++ b/cordova-lib/spec-cordova/plugin.spec.js
@@ -83,7 +83,6 @@ function removePlugin(id) {
 var errorHandler = {
     errorCallback: function(error) {
         // We want the error to be printed by jasmine
-        console.log(error);
         expect(error).toBeUndefined();
     }
 };
@@ -152,7 +151,6 @@ describe('plugin end-to-end', function() {
             return removePlugin(pluginId);
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -169,7 +167,6 @@ describe('plugin end-to-end', function() {
             expect(prepare.preparePlatforms).toHaveBeenCalled();
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -186,7 +183,6 @@ describe('plugin end-to-end', function() {
             expect(prepare.preparePlatforms).not.toHaveBeenCalled();
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -210,7 +206,6 @@ describe('plugin end-to-end', function() {
             return removePlugin(pluginId);
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -230,7 +225,6 @@ describe('plugin end-to-end', function() {
             return removePlugin(org_test_defaultvariables);
        })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -239,7 +233,6 @@ describe('plugin end-to-end', function() {
     it('Test 006 : should successfully add a plugin when specifying CLI variables', function(done) {
         addPlugin(path.join(pluginsDir, org_test_defaultvariables), org_test_defaultvariables, {cli_variables: { REQUIRED:'yes', REQUIRED_ANDROID:'yes'}}, done)
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -255,7 +248,6 @@ describe('plugin end-to-end', function() {
             expect(fetchOptions.searchpath[0]).toExist();
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -273,7 +265,6 @@ describe('plugin end-to-end', function() {
             expect(fetchOptions.noregistry).toBeTruthy();
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -286,7 +277,6 @@ describe('plugin end-to-end', function() {
             expect(registry.info).not.toHaveBeenCalled();
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -304,7 +294,6 @@ describe('plugin end-to-end', function() {
             expect(fetchTarget).toEqual(npmInfoTestPlugin + '@' + npmInfoTestPluginVersion);
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -326,7 +315,6 @@ describe('plugin end-to-end', function() {
             expect(fetchTarget).toEqual(scopedPackage);
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);
@@ -345,7 +333,6 @@ describe('plugin end-to-end', function() {
             expect(fetchTarget).toEqual(scopedPackage);
         })
         .fail(function(err) {
-            console.error(err);
             expect(err).toBeUndefined();
         })
         .fin(done);

--- a/cordova-lib/spec-cordova/plugin_fetch.spec.js
+++ b/cordova-lib/spec-cordova/plugin_fetch.spec.js
@@ -89,11 +89,11 @@ function checkUnmetRequirements(requirements) {
             });
         }
     });
-
     expect(reqWarnings.length).toEqual(requirements.length);
 
+
     requirements.forEach(function(requirement) {
-        expect(reqWarnings).toContain(function(extractedWarning) {
+        expect(reqWarnings).toContainArray(function(extractedWarning) {
             return  extractedWarning.dependency === requirement.dependency.trim() &&
                     extractedWarning.installed  === requirement.installed.trim() &&
                     extractedWarning.required   === requirement.required.trim();
@@ -156,19 +156,22 @@ function removeTestProject() {
 
 describe('plugin fetching version selection', function() {
     createTestProject();
-
     beforeEach(function() {
-        // Adding a matcher for checking the array of warning messages so that
-        // we can have meanigful error messages. Expected is passed because
-        // Jasmine will print it out if the matcher fails
         jasmine.addMatchers({
-            toContain: function(check, expected) {
-                for(var i = 0; i < this.actual.length; i++) {
-                    if (check(this.actual[i])) {
-                        return true;
+            'toContainArray': function() {
+                return {
+                    compare: function(actual, expected) {
+                        var result = {};
+                        result.pass = false;
+                        for(var i = 0; i < actual.length; i++) {
+                            if (expected(actual[i])) {
+                                result.pass = true;
+                                break;
+                            }
+                        }
+                        return result;
                     }
-                }
-                return false;
+                };
             }
         });
 
@@ -191,8 +194,7 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('6.0.0')
         ]);
         testEngineWithProject(after, testEngine, '1.3.0');
-        done();
-    });
+    }, 6000);
 
     it('Test 002 : should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function(done) {
         var testEngine = {
@@ -209,7 +211,6 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('6.0.0')
         ]);
         testEngineWithProject(after, testEngine, null);
-        done();
     });
 
     it('Test 003 : should apply upper bound engine constraints when there are unspecified constraints above the upper bound', function(done) {
@@ -223,7 +224,7 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('~5.0.0')
         ]);
         testEngineWithProject(after, testEngine, '1.7.1');
-        done();
+
     });
 
     it('Test 004 : should handle the case where there are no constraints for earliest releases', function(done) {
@@ -235,7 +236,7 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('~5.0.0')
         ]);
         testEngineWithProject(after, testEngine, '0.7.0');
-        done();
+
     });
 
     it('Test 005 : should handle the case where the lowest version is unsatisfied', function(done) {
@@ -247,7 +248,7 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('~5.0.0')
         ]);
         testEngineWithProject(after, testEngine, null);
-        done();
+
     });
 
     it('Test 006 : should handle upperbounds if no single version constraints are given', function(done) {
@@ -258,7 +259,7 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
-        done();
+
     });
 
     it('Test 007 : should apply upper bounds greater than highest version', function(done) {
@@ -272,7 +273,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, null);
-        done();
+
     });
 
     it('Test 008 : should treat empty constraints as satisfied', function(done) {
@@ -286,7 +287,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '1.0.0');
-        done();
+
     });
 
     it('Test 009 : should ignore an empty cordovaDependencies entry', function(done) {
@@ -295,7 +296,7 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, null);
-        done();
+
     });
 
     it('Test 010 : should ignore a badly formatted semver range', function(done) {
@@ -306,7 +307,7 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
-        done();
+
     });
 
     it('Test 011 : should respect unreleased versions in constraints', function(done) {
@@ -321,7 +322,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '1.1.0');
-        done();
+
     });
 
     it('Test 012 : should respect plugin constraints', function(done) {
@@ -336,7 +337,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '2.0.0');
-        done();
+
     });
 
     it('Test 013 : should respect cordova constraints', function(done) {
@@ -351,7 +352,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '1.1.0');
-        done();
+
     });
 
     it('Test 014 : should not include pre-release versions', function(done) {
@@ -366,7 +367,7 @@ describe('plugin fetching version selection', function() {
 
         // Should not return 2.0.0-rc.2
         testEngineWithProject(after, testEngine, '1.7.1');
-        done();
+
     });
 
     it('Test 015 : should not fail if there is no engine in the npm info', function(done) {
@@ -397,7 +398,7 @@ describe('plugin fetching version selection', function() {
             expect(toFetch).toBe(null);
         })
         .fail(getVersionErrorCallback).fin(after);
-        done();
+
     });
 
     it('Test 017 : should handle extra whitespace', function(done) {
@@ -412,7 +413,7 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '1.7.1');
-        done();
+
     });
 
     it('Test 018 : should ignore badly typed version requirement entries', function(done) {
@@ -425,7 +426,7 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
-        done();
+
     });
 
     it('Test 019 : should ignore badly typed constraint entries', function(done) {
@@ -441,7 +442,7 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
-        done();
+
     });
 
     it('Test 020 : should ignore bad semver versions', function(done) {
@@ -451,7 +452,7 @@ describe('plugin fetching version selection', function() {
             '^1.1.2'        : { 'cordova-android': '3.1.0' },
             '<=1.3.0'       : { 'cordova-android': '3.1.0' },
             '1.0'           : { 'cordova-android': '3.1.0' },
-            2               : { 'cordova-android': '3.1.0' }
+            '2'               : { 'cordova-android': '3.1.0' }
         };
 
         var after = getWarningCheckCallback(done, [
@@ -459,7 +460,6 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, null);
-        done();
     });
 
     it('Test 021 : should not fail if there are bad semver versions', function(done) {
@@ -470,7 +470,7 @@ describe('plugin fetching version selection', function() {
             '1.0.0'         : { 'cordova-android': '~3'    },   // Good semver
             '2.0.0'         : { 'cordova-android': '5.1.0' },   // Good semver
             '1.0'           : { 'cordova-android': '3.1.0' },
-            2               : { 'cordova-android': '3.1.0' }
+            '2'               : { 'cordova-android': '3.1.0' }
         };
 
         var after = getWarningCheckCallback(done, [
@@ -478,7 +478,6 @@ describe('plugin fetching version selection', function() {
         ]);
 
         testEngineWithProject(after, testEngine, '1.7.1');
-        done();
     });
 
     it('Test 022 : should properly warn about multiple unmet requirements', function(done) {
@@ -494,8 +493,8 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('>5.1.0'),
             getPluginRequirement('3.1.0')
         ]);
+
         testEngineWithProject(after, testEngine, '1.3.0');
-        done();
     });
 
     it('Test 023 : should properly warn about both unmet latest and upper bound requirements', function(done) {
@@ -511,8 +510,8 @@ describe('plugin fetching version selection', function() {
             getPlatformRequirement('>5.1.0 AND >7.1.0'),
             getPluginRequirement('3.1.0')
         ]);
+
         testEngineWithProject(after, testEngine, null);
-        done();
     });
 
     it('Test 024 : should not warn about versions past latest', function(done) {
@@ -527,8 +526,8 @@ describe('plugin fetching version selection', function() {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('>5.1.0')
         ]);
+
         testEngineWithProject(after, testEngine, '1.3.0');
-        done();
     });
 
     it('Test 025 : clean up after plugin fetch spec', function() {

--- a/cordova-lib/spec-cordova/plugin_fetch.spec.js
+++ b/cordova-lib/spec-cordova/plugin_fetch.spec.js
@@ -154,14 +154,14 @@ function removeTestProject() {
     shell.rm('-rf', tempDir);
 }
 
-describe('plugin fetching version selection', function(done) {
+describe('plugin fetching version selection', function() {
     createTestProject();
 
     beforeEach(function() {
         // Adding a matcher for checking the array of warning messages so that
         // we can have meanigful error messages. Expected is passed because
         // Jasmine will print it out if the matcher fails
-        this.addMatchers({
+        jasmine.addMatchers({
             toContain: function(check, expected) {
                 for(var i = 0; i < this.actual.length; i++) {
                     if (check(this.actual[i])) {
@@ -190,8 +190,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('6.0.0')
         ]);
-
         testEngineWithProject(after, testEngine, '1.3.0');
+        done();
     });
 
     it('should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function(done) {
@@ -208,8 +208,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('6.0.0')
         ]);
-
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should apply upper bound engine constraints when there are unspecified constraints above the upper bound', function(done) {
@@ -222,8 +222,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('~5.0.0')
         ]);
-
         testEngineWithProject(after, testEngine, '1.7.1');
+        done();
     });
 
     it('should handle the case where there are no constraints for earliest releases', function(done) {
@@ -234,8 +234,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('~5.0.0')
         ]);
-
         testEngineWithProject(after, testEngine, '0.7.0');
+        done();
     });
 
     it('should handle the case where the lowest version is unsatisfied', function(done) {
@@ -246,8 +246,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('~5.0.0')
         ]);
-
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should handle upperbounds if no single version constraints are given', function(done) {
@@ -258,6 +258,7 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
+        done();
     });
 
     it('should apply upper bounds greater than highest version', function(done) {
@@ -271,6 +272,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should treat empty constraints as satisfied', function(done) {
@@ -284,6 +286,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '1.0.0');
+        done();
     });
 
     it('should ignore an empty cordovaDependencies entry', function(done) {
@@ -292,6 +295,7 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should ignore a badly formatted semver range', function(done) {
@@ -302,6 +306,7 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
+        done();
     });
 
     it('should respect unreleased versions in constraints', function(done) {
@@ -316,6 +321,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '1.1.0');
+        done();
     });
 
     it('should respect plugin constraints', function(done) {
@@ -330,6 +336,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '2.0.0');
+        done();
     });
 
     it('should respect cordova constraints', function(done) {
@@ -344,6 +351,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '1.1.0');
+        done();
     });
 
     it('should not include pre-release versions', function(done) {
@@ -358,6 +366,7 @@ describe('plugin fetching version selection', function(done) {
 
         // Should not return 2.0.0-rc.2
         testEngineWithProject(after, testEngine, '1.7.1');
+        done();
     });
 
     it('should not fail if there is no engine in the npm info', function(done) {
@@ -388,6 +397,7 @@ describe('plugin fetching version selection', function(done) {
             expect(toFetch).toBe(null);
         })
         .fail(getVersionErrorCallback).fin(after);
+        done();
     });
 
     it('should handle extra whitespace', function(done) {
@@ -402,6 +412,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '1.7.1');
+        done();
     });
 
     it('should ignore badly typed version requirement entries', function(done) {
@@ -414,6 +425,7 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
+        done();
     });
 
     it('should ignore badly typed constraint entries', function(done) {
@@ -429,6 +441,7 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         testEngineWithProject(after, testEngine, '2.3.0');
+        done();
     });
 
     it('should ignore bad semver versions', function(done) {
@@ -446,6 +459,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should not fail if there are bad semver versions', function(done) {
@@ -464,6 +478,7 @@ describe('plugin fetching version selection', function(done) {
         ]);
 
         testEngineWithProject(after, testEngine, '1.7.1');
+        done();
     });
 
     it('should properly warn about multiple unmet requirements', function(done) {
@@ -479,8 +494,8 @@ describe('plugin fetching version selection', function(done) {
             getPlatformRequirement('>5.1.0'),
             getPluginRequirement('3.1.0')
         ]);
-
         testEngineWithProject(after, testEngine, '1.3.0');
+        done();
     });
 
     it('should properly warn about both unmet latest and upper bound requirements', function(done) {
@@ -496,8 +511,8 @@ describe('plugin fetching version selection', function(done) {
             getPlatformRequirement('>5.1.0 AND >7.1.0'),
             getPluginRequirement('3.1.0')
         ]);
-
         testEngineWithProject(after, testEngine, null);
+        done();
     });
 
     it('should not warn about versions past latest', function(done) {
@@ -512,8 +527,8 @@ describe('plugin fetching version selection', function(done) {
         var after = getWarningCheckCallback(done, [
             getPlatformRequirement('>5.1.0')
         ]);
-
         testEngineWithProject(after, testEngine, '1.3.0');
+        done();
     });
 
     it('clean up after plugin fetch spec', function() {

--- a/cordova-lib/spec-cordova/plugin_fetch.spec.js
+++ b/cordova-lib/spec-cordova/plugin_fetch.spec.js
@@ -176,7 +176,7 @@ describe('plugin fetching version selection', function() {
         getVersionErrorCallback = jasmine.createSpy('unexpectedPluginFetchErrorCallback');
     });
 
-    it('should handle a mix of upper bounds and single versions', function(done) {
+    it('Test 001 : should handle a mix of upper bounds and single versions', function(done) {
         var testEngine = {
             '0.0.0' : { 'cordova-android': '1.0.0' },
             '0.0.2' : { 'cordova-android': '>1.0.0' },
@@ -194,7 +194,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function(done) {
+    it('Test 002 : should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function(done) {
         var testEngine = {
             '1.0.0' : { 'cordova-android': '>2.0.0' },
             '1.7.0' : { 'cordova-android': '>4.0.0' },
@@ -212,7 +212,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should apply upper bound engine constraints when there are unspecified constraints above the upper bound', function(done) {
+    it('Test 003 : should apply upper bound engine constraints when there are unspecified constraints above the upper bound', function(done) {
         var testEngine = {
             '0.0.0' : {},
             '2.0.0' : { 'cordova-android': '~5.0.0' },
@@ -226,7 +226,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should handle the case where there are no constraints for earliest releases', function(done) {
+    it('Test 004 : should handle the case where there are no constraints for earliest releases', function(done) {
         var testEngine = {
             '1.0.0' : { 'cordova-android': '~5.0.0' }
         };
@@ -238,7 +238,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should handle the case where the lowest version is unsatisfied', function(done) {
+    it('Test 005 : should handle the case where the lowest version is unsatisfied', function(done) {
         var testEngine = {
             '0.0.2' : { 'cordova-android': '~5.0.0' }
         };
@@ -250,7 +250,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should handle upperbounds if no single version constraints are given', function(done) {
+    it('Test 006 : should handle upperbounds if no single version constraints are given', function(done) {
         var testEngine = {
             '<1.0.0': { 'cordova-android': '<2.0.0' }
         };
@@ -261,7 +261,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should apply upper bounds greater than highest version', function(done) {
+    it('Test 007 : should apply upper bounds greater than highest version', function(done) {
         var testEngine = {
             '0.0.0' : {},
             '<5.0.0': { 'cordova-android': '<2.0.0' }
@@ -275,7 +275,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should treat empty constraints as satisfied', function(done) {
+    it('Test 008 : should treat empty constraints as satisfied', function(done) {
         var testEngine = {
             '1.0.0' : {},
             '1.1.0' : { 'cordova-android': '>5.0.0' }
@@ -289,7 +289,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should ignore an empty cordovaDependencies entry', function(done) {
+    it('Test 009 : should ignore an empty cordovaDependencies entry', function(done) {
         var testEngine = {};
 
         var after = getWarningCheckCallback(done, []);
@@ -298,7 +298,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should ignore a badly formatted semver range', function(done) {
+    it('Test 010 : should ignore a badly formatted semver range', function(done) {
         var testEngine = {
             '1.1.3' : { 'cordova-android': 'badSemverRange' }
         };
@@ -309,7 +309,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should respect unreleased versions in constraints', function(done) {
+    it('Test 011 : should respect unreleased versions in constraints', function(done) {
         var testEngine = {
             '1.0.0' : { 'cordova-android': '3.1.0' },
             '1.1.2' : { 'cordova-android': '6.0.0' },
@@ -324,7 +324,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should respect plugin constraints', function(done) {
+    it('Test 012 : should respect plugin constraints', function(done) {
         var testEngine = {
             '0.0.0' : { 'ca.filmaj.AndroidPlugin': '1.2.0' },
             '1.1.3' : { 'ca.filmaj.AndroidPlugin': '<5.0.0 || >2.3.0' },
@@ -339,7 +339,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should respect cordova constraints', function(done) {
+    it('Test 013 : should respect cordova constraints', function(done) {
         var testEngine = {
             '0.0.0' : { 'cordova': '>1.0.0' },
             '1.1.3' : { 'cordova': '<3.0.0 || >4.0.0' },
@@ -354,7 +354,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should not include pre-release versions', function(done) {
+    it('Test 014 : should not include pre-release versions', function(done) {
         var testEngine = {
             '0.0.0' : {},
             '2.0.0' : { 'cordova-android': '>5.0.0' }
@@ -369,7 +369,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should not fail if there is no engine in the npm info', function(done) {
+    it('Test 015 : should not fail if there is no engine in the npm info', function(done) {
         plugin.getFetchVersion(project, {
                 version: '2.3.0',
                 name: 'test-plugin',
@@ -381,7 +381,7 @@ describe('plugin fetching version selection', function() {
         .fail(getVersionErrorCallback).fin(done);
     });
 
-    it('should not fail if there is no cordovaDependencies in the engines', function(done) {
+    it('Test 016 : should not fail if there is no cordovaDependencies in the engines', function(done) {
         var after = getWarningCheckCallback(done, []);
 
         plugin.getFetchVersion(project, {
@@ -400,7 +400,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should handle extra whitespace', function(done) {
+    it('Test 017 : should handle extra whitespace', function(done) {
         var testEngine = {
             '  1.0.0    '   : {},
             '2.0.0   '      : { ' cordova-android': '~5.0.0   ' },
@@ -415,7 +415,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should ignore badly typed version requirement entries', function(done) {
+    it('Test 018 : should ignore badly typed version requirement entries', function(done) {
         var testEngine = {
             '1.1.0' : ['cordova', '5.0.0'],
             '1.3.0' : undefined,
@@ -428,7 +428,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should ignore badly typed constraint entries', function(done) {
+    it('Test 019 : should ignore badly typed constraint entries', function(done) {
         var testEngine = {
             '0.0.2' : { 'cordova': 1 },
             '0.7.0' : { 'cordova': {}},
@@ -444,7 +444,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should ignore bad semver versions', function(done) {
+    it('Test 020 : should ignore bad semver versions', function(done) {
         var testEngine = {
             '0.0.0'         : { 'cordova-android': '5.0.0' },
             'notAVersion'   : { 'cordova-android': '3.1.0' },
@@ -462,7 +462,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should not fail if there are bad semver versions', function(done) {
+    it('Test 021 : should not fail if there are bad semver versions', function(done) {
         var testEngine = {
             'notAVersion'   : { 'cordova-android': '3.1.0' },
             '^1.1.2'        : { 'cordova-android': '3.1.0' },
@@ -481,7 +481,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should properly warn about multiple unmet requirements', function(done) {
+    it('Test 022 : should properly warn about multiple unmet requirements', function(done) {
         var testEngine = {
             '1.7.0' : {
                 'cordova-android'           : '>5.1.0',
@@ -498,7 +498,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should properly warn about both unmet latest and upper bound requirements', function(done) {
+    it('Test 023 : should properly warn about both unmet latest and upper bound requirements', function(done) {
         var testEngine = {
             '1.7.0' : { 'cordova-android': '>5.1.0' },
             '<5.0.0': {
@@ -515,7 +515,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('should not warn about versions past latest', function(done) {
+    it('Test 024 : should not warn about versions past latest', function(done) {
         var testEngine = {
             '1.7.0' : { 'cordova-android': '>5.1.0' },
             '7.0.0': {
@@ -531,7 +531,7 @@ describe('plugin fetching version selection', function() {
         done();
     });
 
-    it('clean up after plugin fetch spec', function() {
+    it('Test 025 : clean up after plugin fetch spec', function() {
         removeTestProject();
     });
 });

--- a/cordova-lib/spec-cordova/plugin_package_parse.spec.js
+++ b/cordova-lib/spec-cordova/plugin_package_parse.spec.js
@@ -29,21 +29,21 @@ describe('methods for parsing npm plugin packages', function() {
         expect(parsedSpec.package).toEqual(scope ? scope + id : id);
     }
 
-    it('should handle package names with no scope or version', function() {
+    it('Test 001 : should handle package names with no scope or version', function() {
         checkPluginSpecParsing('test-plugin', null, 'test-plugin', null);
     });
-    it('should handle package names with a version', function() {
+    it('Test 002 : should handle package names with a version', function() {
         checkPluginSpecParsing('test-plugin@1.0.0', null, 'test-plugin', '1.0.0');
         checkPluginSpecParsing('test-plugin@latest', null, 'test-plugin', 'latest');
     });
-    it('should handle package names with a scope', function() {
+    it('Test 003 : should handle package names with a scope', function() {
         checkPluginSpecParsing('@test/test-plugin', '@test/', 'test-plugin', null);
     });
-    it('should handle package names with a scope and a version', function() {
+    it('Test 004 : should handle package names with a scope and a version', function() {
         checkPluginSpecParsing('@test/test-plugin@1.0.0', '@test/', 'test-plugin', '1.0.0');
         checkPluginSpecParsing('@test/test-plugin@latest', '@test/', 'test-plugin', 'latest');
     });
-    it('should handle invalid package specs', function() {
+    it('Test 005 : should handle invalid package specs', function() {
         checkPluginSpecParsing('@nonsense', null, null, null);
         checkPluginSpecParsing('@/nonsense', null, null, null);
         checkPluginSpecParsing('@', null, null, null);

--- a/cordova-lib/spec-cordova/plugin_parser.spec.js
+++ b/cordova-lib/spec-cordova/plugin_parser.spec.js
@@ -26,7 +26,7 @@ var xml_contents = fs.readFileSync(xml, 'utf-8');
 describe('plugin.xml parser', function () {
     var readfile;
     beforeEach(function() {
-        readfile = spyOn(fs, 'readFileSync').andReturn(xml_contents);
+        readfile = spyOn(fs, 'readFileSync').and.returnValue(xml_contents);
     });
 
     it('should read a proper plugin.xml file', function() {
@@ -43,4 +43,3 @@ describe('plugin.xml parser', function () {
         expect(cfg.platforms.indexOf('ios') > -1).toBe(true);
     });
 });
-

--- a/cordova-lib/spec-cordova/plugin_parser.spec.js
+++ b/cordova-lib/spec-cordova/plugin_parser.spec.js
@@ -29,7 +29,7 @@ describe('plugin.xml parser', function () {
         readfile = spyOn(fs, 'readFileSync').and.returnValue(xml_contents);
     });
 
-    it('should read a proper plugin.xml file', function() {
+    it('Test 001 : should read a proper plugin.xml file', function() {
         var cfg;
         expect(function () {
             cfg = new plugin_parser(xml);
@@ -37,7 +37,7 @@ describe('plugin.xml parser', function () {
         expect(cfg).toBeDefined();
         expect(cfg.doc).toBeDefined();
     });
-    it('should be able to figure out which platforms the plugin supports', function() {
+    it('Test 002 : should be able to figure out which platforms the plugin supports', function() {
         var cfg = new plugin_parser(xml);
         expect(cfg.platforms.length).toBe(1);
         expect(cfg.platforms.indexOf('ios') > -1).toBe(true);

--- a/cordova-lib/spec-cordova/prepare.spec.js
+++ b/cordova-lib/spec-cordova/prepare.spec.js
@@ -64,37 +64,37 @@ describe('prepare command', function() {
         load, platformApi, getPlatformApi;
 
     beforeEach(function () {
-        getPlatformApi = spyOn(platforms, 'getPlatformApi').andCallFake(function (platform, rootDir) {
+        getPlatformApi = spyOn(platforms, 'getPlatformApi').and.callFake(function (platform, rootDir) {
             return {
-                prepare: jasmine.createSpy('prepare').andReturn(Q()),
-                getPlatformInfo: jasmine.createSpy('getPlatformInfo').andReturn({
+                prepare: jasmine.createSpy('prepare').and.returnValue(Q()),
+                getPlatformInfo: jasmine.createSpy('getPlatformInfo').and.returnValue({
                     locations: {
                         www: path.join(project_dir, 'platforms', platform, 'www')
                     }
                 }),
             };
         });
-        is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
+        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
+        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        list_platforms = spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
 
-        find_plugins = spyOn(util, 'findPlugins').andReturn([]);
-        spyOn(PlatformJson, 'load').andReturn(new PlatformJson(null, null, {}));
+        find_plugins = spyOn(util, 'findPlugins').and.returnValue([]);
+        spyOn(PlatformJson, 'load').and.returnValue(new PlatformJson(null, null, {}));
         spyOn(PlatformJson.prototype, 'save');
-        load = spyOn(lazy_load, 'based_on_config').andReturn(Q());
-        cp = spyOn(shell, 'cp').andReturn(true);
+        load = spyOn(lazy_load, 'based_on_config').and.returnValue(Q());
+        cp = spyOn(shell, 'cp').and.returnValue(true);
         mkdir = spyOn(shell, 'mkdir');
         spyOn(ConfigParser.prototype, 'write');
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function() {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function() {
             return new et.ElementTree(et.XML(TEST_XML));
         });
     });
 
     describe('failure', function() {
         it('should not run outside of a cordova-based project by calling util.isCordova', function(done) {
-            is_cordova.andReturn(false);
-            cd_project_root.andCallThrough();  // undo spy here because prepare depends on cdprojectRoot for isCordova check
+            is_cordova.and.returnValue(false);
+            cd_project_root.and.callThrough();  // undo spy here because prepare depends on cdprojectRoot for isCordova check
             prepare().then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
@@ -102,7 +102,7 @@ describe('prepare command', function() {
             }).fin(done);
         });
         it('should not run inside a cordova-based project with no platforms', function(done) {
-            list_platforms.andReturn([]);
+            list_platforms.and.returnValue([]);
             prepare().then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
@@ -152,7 +152,7 @@ describe('prepare command', function() {
 
         describe('with no platforms added', function() {
             beforeEach(function() {
-                list_platforms.andReturn([]);
+                list_platforms.and.returnValue([]);
             });
             it('should not fire the hooker', function(done) {
                 Q().then(prepare).then(function() {

--- a/cordova-lib/spec-cordova/prepare.spec.js
+++ b/cordova-lib/spec-cordova/prepare.spec.js
@@ -154,17 +154,17 @@ describe('prepare command', function() {
                         save: false,
                         fetch: false,
                         paths:
-                         [ '/some/path/platforms/ios/www',
-                           '/some/path/platforms/osx/www',
-                           '/some/path/platforms/android/www',
-                           '/some/path/platforms/ubuntu/www',
-                           '/some/path/platforms/amazon-fireos/www',
-                           '/some/path/platforms/wp8/www',
-                           '/some/path/platforms/blackberry10/www',
-                           '/some/path/platforms/firefoxos/www',
-                           '/some/path/platforms/windows/www',
-                           '/some/path/platforms/webos/www',
-                           '/some/path/platforms/browser/www' ],
+                         [ path.join('/','some','path','platforms','ios','www'),
+                           path.join('/','some','path','platforms','osx','www'),
+                           path.join('/','some','path','platforms','android','www'),
+                           path.join('/','some','path','platforms','ubuntu','www'),
+                           path.join('/','some','path','platforms','amazon-fireos','www'),
+                           path.join('/','some','path','platforms','wp8','www'),
+                           path.join('/','some','path','platforms','blackberry10','www'),
+                           path.join('/','some','path','platforms','firefoxos','www'),
+                           path.join('/','some','path','platforms','windows','www'),
+                           path.join('/','some','path','platforms','webos','www'),
+                           path.join('/','some','path','platforms','browser','www') ],
                         searchpath: undefined } ]);
                 }, function(err) {
                     expect(err).toBeUndefined();
@@ -172,7 +172,7 @@ describe('prepare command', function() {
             });
             it('Test 006 : should fire after hooks through the hooker module, and pass in platforms and paths as data object', function(done) {
                 prepare('android').then(function() {
-                    expect(fire.calls.argsFor(1)).toEqual([ 'after_prepare',{ platforms: [ 'android' ],verbose: false,options: {},paths: [ '/some/path/platforms/android/www' ],searchpath: undefined } ]);
+                    expect(fire.calls.argsFor(1)).toEqual([ 'after_prepare',{ platforms: [ 'android' ],verbose: false,options: {},paths: [ path.join( '/','some','path', 'platforms', 'android', 'www' ) ],searchpath: undefined } ]);
                 }, function(err) {
                     expect(err).toBeUndefined('Exception while running `prepare android`:\n' + err.stack);
                 }).fin(done);

--- a/cordova-lib/spec-cordova/project-metadata-apis.spec.js
+++ b/cordova-lib/spec-cordova/project-metadata-apis.spec.js
@@ -23,7 +23,7 @@ var cordova = require('../src/cordova/cordova'),
 describe('retrieval of project metadata', function () {
     var projectRoot = path.resolve(__dirname, 'Projects/ProjectMetadata');
 
-    it('retrieve platforms saved in config.xml', function (done) {
+    it('Test 001 : retrieve platforms saved in config.xml', function (done) {
         var androidVersion = '3.7.1';
         var browserSrc = 'https://github.com/apache/cordova-browser.git';
 
@@ -45,7 +45,7 @@ describe('retrieval of project metadata', function () {
             }).finally(done);
     });
 
-    it('retrieve plugins saved in config.xml', function (done) {
+    it('Test 002 : retrieve plugins saved in config.xml', function (done) {
         var deviceId = 'org.apache.cordova.device';
         var deviceVersion = '0.3.0';
 

--- a/cordova-lib/spec-cordova/run.spec.js
+++ b/cordova-lib/spec-cordova/run.spec.js
@@ -30,20 +30,20 @@ describe('run command', function() {
     var prepare_spy;
 
     beforeEach(function() {
-        is_cordova = spyOn(util, 'isCordova').andReturn(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').andReturn(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').andReturn(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').andReturn(Q());
-        prepare_spy = spyOn(cordova.raw, 'prepare').andReturn(Q());
+        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
+        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        list_platforms = spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Q());
+        prepare_spy = spyOn(cordova.raw, 'prepare').and.returnValue(Q());
         platformApi = {
-            run: jasmine.createSpy('run').andReturn(Q()),
-            build: jasmine.createSpy('build').andReturn(Q())
+            run: jasmine.createSpy('run').and.returnValue(Q()),
+            build: jasmine.createSpy('build').and.returnValue(Q())
         };
-        getPlatformApi = spyOn(platforms, 'getPlatformApi').andReturn(platformApi);
+        getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
     });
     describe('failure', function() {
         it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
-            list_platforms.andReturn([]);
+            list_platforms.and.returnValue([]);
             Q().then(cordova.raw.run).then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
@@ -52,8 +52,8 @@ describe('run command', function() {
         });
         it('should not run outside of a Cordova-based project', function(done) {
             var msg = 'Dummy message about not being in a cordova dir.';
-            cd_project_root.andThrow(new Error(msg));
-            is_cordova.andReturn(false);
+            cd_project_root.and.throwError(new Error(msg));
+            is_cordova.and.returnValue(false);
             Q().then(cordova.raw.run).then(function() {
                 expect('this call').toBe('fail');
             }, function(err) {
@@ -136,7 +136,7 @@ describe('run command', function() {
             var originalBuildSpy;
             beforeEach(function() {
                 originalBuildSpy = platformApi.build;
-                platformApi.build = jasmine.createSpy('build').andCallFake(function(opts) {
+                platformApi.build = jasmine.createSpy('build').and.callFake(function(opts) {
                     opts.couldBeModified = 'insideBuild';
                     return Q();
                 });
@@ -176,7 +176,7 @@ describe('run command', function() {
 
         describe('with no platforms added', function() {
             it('should not fire the hooker', function(done) {
-                list_platforms.andReturn([]);
+                list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.run).then(function() {
                     expect('this call').toBe('fail');
                 }, function(err) {

--- a/cordova-lib/spec-cordova/run.spec.js
+++ b/cordova-lib/spec-cordova/run.spec.js
@@ -42,7 +42,7 @@ describe('run command', function() {
         getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
     });
     describe('failure', function() {
-        it('should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
+        it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function(done) {
             list_platforms.and.returnValue([]);
             Q().then(cordova.raw.run).then(function() {
                 expect('this call').toBe('fail');
@@ -50,7 +50,7 @@ describe('run command', function() {
                 expect(err.message).toEqual('No platforms added to this project. Please use `cordova platform add <platform>`.');
             }).fin(done);
         });
-        it('should not run outside of a Cordova-based project', function(done) {
+        it('Test 002 : should not run outside of a Cordova-based project', function(done) {
             var msg = 'Dummy message about not being in a cordova dir.';
             cd_project_root.and.throwError(new Error(msg));
             is_cordova.and.returnValue(false);
@@ -63,14 +63,14 @@ describe('run command', function() {
     });
 
     describe('success', function() {
-        it('should call prepare before actually run platform ', function(done) {
+        it('Test 003 : should call prepare before actually run platform ', function(done) {
             cordova.raw.run(['android','ios']).then(function() {
-                expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'android', 'ios' ], verbose: false, options: [] });
+                expect(prepare_spy.calls.argsFor(0)).toEqual([ { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
             }, function(err) {
                 expect(err).toBeUndefined();
             }).fin(done);
         });
-        it('should get PlatformApi instance for each platform and call its\' run method', function(done) {
+        it('Test 004 : should get PlatformApi instance for each platform and call its\' run method', function(done) {
             cordova.raw.run(['android','ios']).then(function() {
                 expect(getPlatformApi).toHaveBeenCalledWith('android');
                 expect(getPlatformApi).toHaveBeenCalledWith('ios');
@@ -80,7 +80,7 @@ describe('run command', function() {
                 expect(err).toBeUndefined();
             }).fin(done);
         });
-        it('should pass down parameters', function(done) {
+        it('Test 005 : should pass down parameters', function(done) {
             cordova.raw.run({platforms: ['blackberry10'], options:{password: '1q1q'}}).then(function() {
                 expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q' }, verbose: false });
                 expect(platformApi.build).toHaveBeenCalledWith({password: '1q1q'});
@@ -89,7 +89,7 @@ describe('run command', function() {
                 expect(err).toBeUndefined();
             }).fin(done);
         });
-        it('should convert parameters from old format and warn user about this', function (done) {
+        it('Test 006 : should convert parameters from old format and warn user about this', function (done) {
             function warnSpy(message) {
                 expect(message).toMatch('The format of cordova.raw.* methods "options" argument was changed');
             }
@@ -108,7 +108,7 @@ describe('run command', function() {
             });
         });
 
-        it('should call platform\'s build method', function (done) {
+        it('Test 007 : should call platform\'s build method', function (done) {
             cordova.raw.run({platforms: ['blackberry10']})
             .then(function() {
                 expect(prepare_spy).toHaveBeenCalled();
@@ -120,7 +120,7 @@ describe('run command', function() {
             .fin(done);
         });
 
-        it('should not call build if --nobuild option is passed', function (done) {
+        it('Test 008 : should not call build if --nobuild option is passed', function (done) {
             cordova.raw.run({platforms: ['blackberry10'], options: { nobuild: true }})
             .then(function() {
                 expect(prepare_spy).toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe('run command', function() {
             afterEach(function() {
                 platformApi.build = originalBuildSpy;
             });
-            it('should leave parameters unchanged', function(done) {
+            it('Test 009 : should leave parameters unchanged', function(done) {
                 cordova.raw.run({platforms: ['blackberry10'], options:{password: '1q1q'}}).then(function() {
                     expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q', 'couldBeModified': 'insideBuild' }, verbose: false });
                     expect(platformApi.build).toHaveBeenCalledWith({password: '1q1q', 'couldBeModified': 'insideBuild'});
@@ -158,16 +158,16 @@ describe('run command', function() {
 
     describe('hooks', function() {
         describe('when platforms are added', function() {
-            it('should fire before hooks through the hooker module', function(done) {
+            it('Test 010 : should fire before hooks through the hooker module', function(done) {
                 cordova.raw.run(['android', 'ios']).then(function() {
-                    expect(fire).toHaveBeenCalledWith('before_run', {verbose: false, platforms:['android', 'ios'], options: []});
+                    expect(fire.calls.argsFor(0)).toEqual([ 'before_run', { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
                 }, function(err) {
                     expect(err).toBeUndefined();
                 }).fin(done);
             });
-            it('should fire after hooks through the hooker module', function(done) {
+            it('Test 011 : should fire after hooks through the hooker module', function(done) {
                 cordova.raw.run('android').then(function() {
-                     expect(fire).toHaveBeenCalledWith('after_run', {verbose: false, platforms:['android'], options: []});
+                    expect(fire.calls.argsFor(2)).toEqual([ 'after_run', { platforms: [ 'android' ], verbose: false, options: {} } ]);
                 }, function(err) {
                     expect(err).toBeUndefined();
                 }).fin(done);
@@ -175,7 +175,7 @@ describe('run command', function() {
         });
 
         describe('with no platforms added', function() {
-            it('should not fire the hooker', function(done) {
+            it('Test 012 : should not fire the hooker', function(done) {
                 list_platforms.and.returnValue([]);
                 Q().then(cordova.raw.run).then(function() {
                     expect('this call').toBe('fail');

--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -85,12 +85,12 @@ describe('(save flag)', function () {
      */
     function redirectRegistryCalls(id) {
         var originalFetch = registry.fetch;
-        spyOn(registry, 'fetch').andCallFake(function(package) {
+        spyOn(registry, 'fetch').and.callFake(function(package) {
             return originalFetch([id]);
         });
 
         var originalInfo = registry.info;
-        spyOn(registry, 'info').andCallFake(function(package) {
+        spyOn(registry, 'info').and.callFake(function(package) {
             return originalInfo([id]);
         });
     }
@@ -101,13 +101,13 @@ describe('(save flag)', function () {
         shell.mkdir(tempPath);
 
         //jasmine mocks
-        spyOn(util, 'isCordova').andReturn(appPath);
-        spyOn(util, 'cdProjectRoot').andReturn(appPath);
-        spyOn(cordova.raw, 'prepare').andReturn(Q());
-        spyOn(prepare, 'preparePlatforms').andReturn(Q());
+        spyOn(util, 'isCordova').and.returnValue(appPath);
+        spyOn(util, 'cdProjectRoot').and.returnValue(appPath);
+        spyOn(cordova.raw, 'prepare').and.returnValue(Q());
+        spyOn(prepare, 'preparePlatforms').and.returnValue(Q());
 
-        spyOn(PlatformApi, 'createPlatform').andReturn(Q());
-        spyOn(PlatformApi, 'updatePlatform').andReturn(Q());
+        spyOn(PlatformApi, 'createPlatform').and.returnValue(Q());
+        spyOn(PlatformApi, 'updatePlatform').and.returnValue(Q());
 
         //rewire mocks
         revertInstallPluginsForNewPlatform = platform.__set__('installPluginsForNewPlatform', function () { return Q(); });
@@ -314,7 +314,7 @@ describe('(save flag)', function () {
             platform('add', platformName + '@' + platformVersionNew)
             .then(function () {
                 var fsExistsSync = fs.existsSync.bind(fs);
-                spyOn(fs, 'existsSync').andCallFake(function (somePath) {
+                spyOn(fs, 'existsSync').and.callFake(function (somePath) {
                     return (somePath === path.join(appPath, 'platforms', platformName)) || fsExistsSync(somePath);
                 });
 
@@ -342,7 +342,7 @@ describe('(save flag)', function () {
             .then(function () {
                 revertDownloadPlatform();
                 var fsExistsSync = fs.existsSync.bind(fs);
-                spyOn(fs, 'existsSync').andCallFake(function (somePath) {
+                spyOn(fs, 'existsSync').and.callFake(function (somePath) {
                     return (somePath === path.join(appPath, 'platforms', platformName)) || fsExistsSync(somePath);
                 });
                 mockDownloadPlatform(platformLocalPathNew, platformVersionNew);
@@ -680,7 +680,7 @@ describe('(save flag)', function () {
         });
 
         it('spec.25 should install plugins already added to the project into platform when restoring it', function (done) {
-            var fail = jasmine.createSpy('fail').andCallFake(function (err) {
+            var fail = jasmine.createSpy('fail').and.callFake(function (err) {
                 console.log(err.message);
             });
 

--- a/cordova-lib/spec-cordova/save.spec.js
+++ b/cordova-lib/spec-cordova/save.spec.js
@@ -135,7 +135,7 @@ describe('(save flag)', function () {
     }
 
     describe('preparing fixtures', function () {
-        it('cloning "old" platform', function (done) {
+        it('Test 001 : cloning "old" platform', function (done) {
             shell.rm('-rf', platformLocalPathOld);
             gitClone(platformGitUrl, platformLocalPathOld, platformVersionOld, function (err) {
                 expect(err).toBe(0);
@@ -143,7 +143,7 @@ describe('(save flag)', function () {
             });
         }, BIG_TIMEOUT);
 
-        it('cloning "new" platform', function (done) {
+        it('Test 002 : cloning "new" platform', function (done) {
             shell.rm('-rf', platformLocalPathNew);
             gitClone(platformGitUrl, platformLocalPathNew, platformVersionNew, function (err) {
                 expect(err).toBe(0);
@@ -151,7 +151,7 @@ describe('(save flag)', function () {
             });
         }, BIG_TIMEOUT);
 
-        it('cloning "newer" platform', function (done) {
+        it('Test 003 : cloning "newer" platform', function (done) {
             shell.rm('-rf', platformLocalPathNewer);
             gitClone(platformGitUrl, platformLocalPathNewer, platformVersionNewer, function (err) {
                 expect(err).toBe(0);
@@ -161,7 +161,7 @@ describe('(save flag)', function () {
     });
 
     describe('platform add --save', function () {
-        it('spec.1 should support custom tgz files', function (done) {
+        it('Test 004 : spec.1 should support custom tgz files', function (done) {
             helpers.removeEngine(appPath, platformName);
             platform('add', platformName + '@' + platformTgzUrl, { 'save': true })
             .then(function () {
@@ -174,7 +174,7 @@ describe('(save flag)', function () {
             });
         }, BIG_TIMEOUT);
 
-        it('spec.2 should save platform to config', function (done) {
+        it('Test 005 : spec.2 should save platform to config', function (done) {
             helpers.removeEngine(appPath, platformName);
             mockDownloadPlatform(platformLocalPathNew, platformVersionNew);
 
@@ -191,7 +191,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.3 should overwrite platform in config, spec = version', function (done) {
+        it('Test 006 : spec.3 should overwrite platform in config, spec = version', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformVersionOld);
             mockDownloadPlatform(platformLocalPathOld, platformVersionOld);
 
@@ -208,7 +208,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.4 should overwrite platform in config, spec = path', function (done) {
+        it('Test 007 : spec.4 should overwrite platform in config, spec = path', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
             mockDownloadPlatform(platformLocalPathNewer, platformVersionNewer);
 
@@ -225,7 +225,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.5 should fail and should not update config if invalid version is specified', function (done) {
+        it('Test 008 : spec.5 should fail and should not update config if invalid version is specified', function (done) {
             helpers.removeEngine(appPath, platformName);
 
             platform('add', platformName + '@3.969.696', { 'save': true })
@@ -239,7 +239,7 @@ describe('(save flag)', function () {
             });
         });
 
-        it('spec.6 should save local path as spec if added using only local path', function (done) {
+        it('Test 009 : spec.6 should save local path as spec if added using only local path', function (done) {
             helpers.removeEngine(appPath, platformName);
 
             platform('add', platformLocalPathNewer, { 'save': true })
@@ -253,7 +253,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.7 should save git url with git ref properly', function (done) {
+        it('Test 010 : spec.7 should save git url with git ref properly', function (done) {
             var platformUrl = platformGitUrl + '#' + platformGitRef;
             helpers.removeEngine(appPath, platformName);
             mockDownloadPlatform(platformLocalPathNew, platformVersionNew);
@@ -273,7 +273,7 @@ describe('(save flag)', function () {
     });
 
     describe('platform remove --save', function () {
-        it('spec.8 should not update config if there is no engine in it', function (done) {
+        it('Test 011 : spec.8 should not update config if there is no engine in it', function (done) {
             helpers.removeEngine(appPath, platformName);
 
             platform('add', platformLocalPathNewer)
@@ -289,7 +289,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.9 should remove engine from config', function (done) {
+        it('Test 012 : spec.9 should remove engine from config', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
 
             platform('add', platformLocalPathNewer)
@@ -307,7 +307,7 @@ describe('(save flag)', function () {
     });
 
     describe('platform update --save', function () {
-        it('spec.10 should update config with new spec', function (done) {
+        it('Test 013 : spec.10 should update config with new spec', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformVersionNew);
             mockDownloadPlatform(platformLocalPathNew, platformVersionNew);
 
@@ -334,7 +334,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.11 should update spec with git url when updating using git url', function (done) {
+        it('Test 014 : spec.11 should update spec with git url when updating using git url', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformVersionNew);
             mockDownloadPlatform(platformLocalPathOld, platformVersionOld);
 
@@ -364,7 +364,7 @@ describe('(save flag)', function () {
     });
 
     describe('plugin add --save', function () {
-        it('spec.12 should save plugin to config', function (done) {
+        it('Test 015 : spec.12 should save plugin to config', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', pluginName, { 'save': true });
@@ -378,7 +378,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.13 should create new plugin tag in config with old plugin id when downgrading from plugin with new id', function (done) {
+        it('Test 016 : spec.13 should create new plugin tag in config with old plugin id when downgrading from plugin with new id', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 helpers.setPluginSpec(appPath, pluginName, pluginOldVersion);
@@ -393,7 +393,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.14 should save variables', function (done) {
+        it('Test 017 : spec.14 should save variables', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', variablePluginUrl, {
@@ -414,7 +414,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.14.1 should restore plugin with variables', function (done) {
+        it('Test 018 : spec.14.1 should restore plugin with variables', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', variablePluginUrl, {
@@ -441,7 +441,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.15 save git url as spec', function (done) {
+        it('Test 019 : spec.15 save git url as spec', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', pluginGitUrl, { 'save': true });
@@ -455,7 +455,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.16 should save local directory as spec', function (done) {
+        it('Test 020 : spec.16 should save local directory as spec', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', localPluginPath, { 'save': true });
@@ -469,7 +469,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.16.1 save scoped registry packages as spec', function (done) {
+        it('Test 021 : spec.16.1 save scoped registry packages as spec', function (done) {
             redirectRegistryCalls(pluginName + '@' + pluginVersion);
             var scopedPackage = '@test-scope/' + pluginName;
 
@@ -489,7 +489,7 @@ describe('(save flag)', function () {
     });
 
     describe('plugin remove --save', function () {
-        it('spec.17 should not add plugin to config', function (done) {
+        it('Test 022 : spec.17 should not add plugin to config', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', pluginName);
@@ -505,7 +505,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.18 should remove plugin from config', function (done) {
+        it('Test 023 : spec.18 should remove plugin from config', function (done) {
             platform('add', platformLocalPathNewer)
             .then(function () {
                 return cordova.raw.plugin('add', pluginName);
@@ -524,7 +524,7 @@ describe('(save flag)', function () {
     });
 
     describe('platform save', function () {
-        it('spec.19 should not update config when there are no platforms installed', function (done) {
+        it('Test 024 : spec.19 should not update config when there are no platforms installed', function (done) {
             var configContent = helpers.getConfigContent(appPath);
             platform('save')
             .then(function () {
@@ -537,7 +537,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.20 should add platform to config', function (done) {
+        it('Test 025 : spec.20 should add platform to config', function (done) {
             mockDownloadPlatform(platformLocalPathNew, platformVersionNew);
 
             platform('add', platformName + '@' + platformVersionNew)
@@ -557,7 +557,7 @@ describe('(save flag)', function () {
     });
 
     describe('plugin save', function () {
-        it('spec.21 should not update config when there are no plugins installed', function (done) {
+        it('Test 026: spec.21 should not update config when there are no plugins installed', function (done) {
             var configContent = helpers.getConfigContent(appPath);
             cordova.raw.plugin('save')
             .finally(function () {
@@ -566,7 +566,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.22 should update config with plugins: one with version, one with local folder and another one vith git url', function (done) {
+        it('Test 027 : spec.22 should update config with plugins: one with version, one with local folder and another one vith git url', function (done) {
             cordova.raw.plugin('add', pluginName + '@' + pluginVersion)
             .then(function () {
                 return cordova.raw.plugin('add', gitPluginUrl);
@@ -586,7 +586,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.22.1 should update config with a spec that includes the scope for scoped plugins', function (done) {
+        it('Test 028 : spec.22.1 should update config with a spec that includes the scope for scoped plugins', function (done) {
             // Fetching globalization rather than console to avoid conflicts with earlier tests
             redirectRegistryCalls(pluginName2 + '@' + pluginVersion2);
             var scopedPackage = '@test-scope/' + pluginName2;
@@ -611,7 +611,7 @@ describe('(save flag)', function () {
             PlatformApi.createPlatform = createPlatformOrig;
         });
 
-        it('spec.23 should restore all platforms and plugins', function (done) {
+        it('Test 029 : spec.23 should restore all platforms and plugins', function (done) {
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
             helpers.setPluginSpec(appPath, localPluginName, localPluginPath);
             prepare()
@@ -626,7 +626,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.23.1 should restore scoped plugins', function (done) {
+        it('Test 030 : spec.23.1 should restore scoped plugins', function (done) {
             redirectRegistryCalls(pluginName2 + '@~' + pluginVersion2);
             var scopedPackage = '@test-scope/' + pluginName2;
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
@@ -643,7 +643,7 @@ describe('(save flag)', function () {
             });
         }, TIMEOUT);
 
-        it('spec.23.2 should restore plugins without spec attribute', function (done) {
+        it('Test 031 : spec.23.2 should restore plugins without spec attribute', function (done) {
             redirectRegistryCalls(pluginName2);
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
             helpers.setPluginSpec(appPath, pluginName2/**, do not specify spec here */);
@@ -658,7 +658,7 @@ describe('(save flag)', function () {
             .fin(done);
         }, TIMEOUT);
 
-        it('spec.24 should restore only specified platform', function (done) {
+        it('Test 032 : spec.24 should restore only specified platform', function (done) {
             
             helpers.setEngineSpec(appPath, platformName, platformLocalPathNewer);
             helpers.setEngineSpec(appPath, otherPlatformName, otherPlatformSpec);
@@ -679,7 +679,7 @@ describe('(save flag)', function () {
             });
         });
 
-        it('spec.25 should install plugins already added to the project into platform when restoring it', function (done) {
+        it('Test 033 : spec.25 should install plugins already added to the project into platform when restoring it', function (done) {
             var fail = jasmine.createSpy('fail').and.callFake(function (err) {
                 console.log(err.message);
             });
@@ -704,7 +704,7 @@ describe('(save flag)', function () {
     });
 
     describe('(cleanup)', function () {
-        it('removing temp dir', function () {
+        it('Test 034 : removing temp dir', function () {
             shell.rm('-rf', tempPath);
             shell.rm('-rf', platformLocalPathNewer);
             shell.rm('-rf', platformLocalPathNew);

--- a/cordova-lib/spec-cordova/serve.spec.js
+++ b/cordova-lib/spec-cordova/serve.spec.js
@@ -32,6 +32,7 @@ var cordova = require('../src/cordova/cordova'),
 
 var cwd = process.cwd();
 
+//skipped because of CB-7078
 xdescribe('serve command', function() {
     var payloads = {},
         consoleSpy;
@@ -47,7 +48,7 @@ xdescribe('serve command', function() {
         process.env.PWD = cwd;
         shell.rm('-rf', tempDir);
     });
-    it('should not run outside of a Cordova-based project', function() {
+    it('Test 001 : should not run outside of a Cordova-based project', function() {
         process.chdir(tempDir);
 
         expect(function() {
@@ -163,7 +164,7 @@ xdescribe('serve command', function() {
             };
         }
 
-        it('should serve from top-level www if the file exists there', function() {
+        it('Test 002 : should serve from top-level www if the file exists there', function() {
             var payload = 'This is test file.';
             payloads.firefoxos = 'This is the firefoxos test file.';
             test_serve('firefoxos', '/basictest.html', payload, {
@@ -173,7 +174,7 @@ xdescribe('serve command', function() {
             })();
         });
 
-        it('should honour a custom port setting', function() {
+        it('Test 003 : should honour a custom port setting', function() {
             var payload = 'This is test file.';
             payloads.firefoxos = 'This is the firefoxos test file.';
             test_serve('firefoxos', '/basictest.html', payload, {
@@ -209,7 +210,7 @@ xdescribe('serve command', function() {
             test_serve('ios', '/test.html', payloads.ios, {timeout: 10000})();
         });
 
-        it('should fall back to www on firefoxos', function() {
+        it('Test 004 : should fall back to www on firefoxos', function() {
             payloads.firefoxos = 'This is the firefoxos test file.';
             test_serve('firefoxos', '/test.html', payloads.firefoxos)();
         });

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -37,11 +37,12 @@ describe('util module', function() {
             process.env['PWD'] = origPWD;
             process.chdir(cwd);
         });
+        function removeDir(directory) {
+            shell.rm('-rf', directory);            
+        }
         it('should return false if it hits the home directory', function() {
             var somedir = path.join(home, 'somedir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir(somedir);
             expect(util.isCordova(somedir)).toEqual(false);
         });
@@ -52,9 +53,7 @@ describe('util module', function() {
         it('should return the first directory it finds with a .cordova folder in it', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir('-p', anotherdir);
             shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
             expect(util.isCordova(somedir)).toEqual(somedir);
@@ -63,9 +62,7 @@ describe('util module', function() {
             delete process.env['PWD'];
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir('-p', anotherdir);
             shell.mkdir('-p', path.join(somedir, 'www'));
             shell.mkdir('-p', path.join(somedir, 'config.xml'));
@@ -75,9 +72,7 @@ describe('util module', function() {
         it('should use PWD when available', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir('-p', anotherdir);
             shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
             process.env['PWD'] = anotherdir;
@@ -87,9 +82,7 @@ describe('util module', function() {
         it('should use cwd as a fallback when PWD is not a cordova dir', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir('-p', anotherdir);
             shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
             process.env['PWD'] = path.sep;
@@ -99,9 +92,7 @@ describe('util module', function() {
         it('should ignore platform www/config.xml', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
-            this.after(function() {
-                shell.rm('-rf', somedir);
-            });
+            removeDir(somedir);
             shell.mkdir('-p', anotherdir);
             shell.mkdir('-p', path.join(anotherdir, 'www', 'config.xml'));
             shell.mkdir('-p', path.join(somedir, 'www'));
@@ -216,17 +207,17 @@ describe('util module', function() {
         };
 
         beforeEach(function() {
-            isCordova = spyOn(util, 'isCordova').andReturn('/fake/path');
-            listPlatforms = spyOn(util, 'listPlatforms').andReturn(['android']);
+            isCordova = spyOn(util, 'isCordova').and.returnValue('/fake/path');
+            listPlatforms = spyOn(util, 'listPlatforms').and.returnValue(['android']);
         });
 
         it('should throw if called outside of cordova project', function() {
-            isCordova.andReturn(false);
+            isCordova.and.returnValue(false);
             expect(function() { util.preProcessOptions(); }).toThrow();
         });
 
         it('should throw when no platforms added to project', function() {
-            listPlatforms.andReturn([]);
+            listPlatforms.and.returnValue([]);
             expect(function () { util.preProcessOptions(); }).toThrow();
         });
 
@@ -248,7 +239,7 @@ describe('util module', function() {
         });
 
         it('should pick buildConfig if no option is provided, but buildConfig.json exists', function() {
-            spyOn(util, 'existsSync').andReturn(true);
+            spyOn(util, 'existsSync').and.returnValue(true);
             // Using path.join below to normalize path separators
             expect(util.preProcessOptions())
                 .toEqual(jasmine.objectContaining({options: {buildConfig: path.join('/fake/path/build.json')}}));

--- a/cordova-lib/spec-cordova/util.spec.js
+++ b/cordova-lib/spec-cordova/util.spec.js
@@ -40,17 +40,17 @@ describe('util module', function() {
         function removeDir(directory) {
             shell.rm('-rf', directory);            
         }
-        it('should return false if it hits the home directory', function() {
+        it('Test 001 : should return false if it hits the home directory', function() {
             var somedir = path.join(home, 'somedir');
             removeDir(somedir);
             shell.mkdir(somedir);
             expect(util.isCordova(somedir)).toEqual(false);
         });
-        it('should return false if it cannot find a .cordova directory up the directory tree', function() {
+        it('Test 002 : should return false if it cannot find a .cordova directory up the directory tree', function() {
             var somedir = path.join(home, '..');
             expect(util.isCordova(somedir)).toEqual(false);
         });
-        it('should return the first directory it finds with a .cordova folder in it', function() {
+        it('Test 003 : should return the first directory it finds with a .cordova folder in it', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
             removeDir(somedir);
@@ -58,7 +58,7 @@ describe('util module', function() {
             shell.mkdir('-p', path.join(somedir, 'www', 'config.xml'));
             expect(util.isCordova(somedir)).toEqual(somedir);
         });
-        it('should ignore PWD when its undefined', function() {
+        it('Test 004 : should ignore PWD when its undefined', function() {
             delete process.env['PWD'];
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
@@ -69,7 +69,7 @@ describe('util module', function() {
             process.chdir(anotherdir);
             expect(util.isCordova()).toEqual(somedir);
         });
-        it('should use PWD when available', function() {
+        it('Test 005 : should use PWD when available', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
             removeDir(somedir);
@@ -79,7 +79,7 @@ describe('util module', function() {
             process.chdir(path.sep);
             expect(util.isCordova()).toEqual(somedir);
         });
-        it('should use cwd as a fallback when PWD is not a cordova dir', function() {
+        it('Test 006 : should use cwd as a fallback when PWD is not a cordova dir', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
             removeDir(somedir);
@@ -89,7 +89,7 @@ describe('util module', function() {
             process.chdir(anotherdir);
             expect(util.isCordova()).toEqual(somedir);
         });
-        it('should ignore platform www/config.xml', function() {
+        it('Test 007 : should ignore platform www/config.xml', function() {
             var somedir = path.join(home,'somedir');
             var anotherdir = path.join(somedir, 'anotherdir');
             removeDir(somedir);
@@ -104,7 +104,7 @@ describe('util module', function() {
         afterEach(function() {
             shell.rm('-rf', temp);
         });
-        it('should delete .svn folders in any subdirectory of specified dir', function() {
+        it('Test 008 : should delete .svn folders in any subdirectory of specified dir', function() {
             var one = path.join(temp, 'one');
             var two = path.join(temp, 'two');
             var one_svn = path.join(one, '.svn');
@@ -120,7 +120,7 @@ describe('util module', function() {
         afterEach(function() {
             shell.rm('-rf', temp);
         });
-        it('should only return supported platform directories present in a cordova project dir', function() {
+        it('Test 009 : should only return supported platform directories present in a cordova project dir', function() {
             var platforms = path.join(temp, 'platforms');
             var android = path.join(platforms, 'android');
             var ios = path.join(platforms, 'ios');
@@ -139,7 +139,7 @@ describe('util module', function() {
         afterEach(function() {
             shell.rm('-rf', temp);
         });
-        it('should get the supported platforms in the cordova project dir along with their reported versions', function(done) {
+        it('Test 010 : should get the supported platforms in the cordova project dir along with their reported versions', function(done) {
             var platforms = path.join(temp, 'platforms');
             var android = path.join(platforms, 'android');
 
@@ -157,7 +157,7 @@ describe('util module', function() {
         afterEach(function() {
             shell.rm('-rf', temp);
         });
-        it('should only return plugin directories present in a cordova project dir', function() {
+        it('Test 011 : should only return plugin directories present in a cordova project dir', function() {
             var plugins = path.join(temp, 'plugins');
             var android = path.join(plugins, 'android');
             var ios = path.join(plugins, 'ios');
@@ -170,7 +170,7 @@ describe('util module', function() {
             var res = util.findPlugins(plugins);
             expect(res.length).toEqual(4);
         });
-        it('should not return ".svn" directories', function() {
+        it('Test 012 : should not return ".svn" directories', function() {
             var plugins = path.join(temp, 'plugins');
             var android = path.join(plugins, 'android');
             var ios = path.join(plugins, 'ios');
@@ -182,7 +182,7 @@ describe('util module', function() {
             expect(res.length).toEqual(2);
             expect(res.indexOf('.svn')).toEqual(-1);
         });
-        it('should not return "CVS" directories', function() {
+        it('Test 013 : should not return "CVS" directories', function() {
             var plugins = path.join(temp, 'plugins');
             var android = path.join(plugins, 'android');
             var ios = path.join(plugins, 'ios');
@@ -211,34 +211,34 @@ describe('util module', function() {
             listPlatforms = spyOn(util, 'listPlatforms').and.returnValue(['android']);
         });
 
-        it('should throw if called outside of cordova project', function() {
+        it('Test 014 : should throw if called outside of cordova project', function() {
             isCordova.and.returnValue(false);
             expect(function() { util.preProcessOptions(); }).toThrow();
         });
 
-        it('should throw when no platforms added to project', function() {
+        it('Test 015 : should throw when no platforms added to project', function() {
             listPlatforms.and.returnValue([]);
             expect(function () { util.preProcessOptions(); }).toThrow();
         });
 
-        it('should return default options when no arguments passed', function() {
+        it('Test 016 : should return default options when no arguments passed', function() {
             expect(util.preProcessOptions()).toEqual(jasmine.objectContaining(DEFAULT_OPTIONS));
         });
 
-        it('should accept single string argument as platform name', function() {
+        it('Test 017 : should accept single string argument as platform name', function() {
             expect(util.preProcessOptions('ios')).toEqual(jasmine.objectContaining({platforms: ['ios']}));
         });
 
-        it('should accept array of strings as platform names', function() {
+        it('Test 018 : should accept array of strings as platform names', function() {
             expect(util.preProcessOptions(['ios', 'windows'])).toEqual(jasmine.objectContaining({platforms: ['ios', 'windows']}));
         });
 
-        it('should fall back to installed platform if input doesn\'t contain platforms list', function() {
+        it('Test 019 : should fall back to installed platform if input doesn\'t contain platforms list', function() {
             expect(util.preProcessOptions({verbose: true}))
                 .toEqual(jasmine.objectContaining({platforms: ['android'], verbose: true}));
         });
 
-        it('should pick buildConfig if no option is provided, but buildConfig.json exists', function() {
+        it('Test 020 : should pick buildConfig if no option is provided, but buildConfig.json exists', function() {
             spyOn(util, 'existsSync').and.returnValue(true);
             // Using path.join below to normalize path separators
             expect(util.preProcessOptions())
@@ -251,28 +251,28 @@ describe('util module', function() {
             var validOptions = ['--debug', '--release', '--device', '--emulator', '--nobuild', '--list',
                     '--buildConfig=/fake/path/build.json', '--target=foo', '--archs="x86 x64"'];
 
-            it('should return \'options\' unchanged if they are not an array', function() {
+            it('Test 021 : should return \'options\' unchanged if they are not an array', function() {
                 ['foo', true, {bar: true}].forEach(function (optionValue) {
                     expect(util.preProcessOptions({options: optionValue}))
                         .toEqual(jasmine.objectContaining({options: optionValue}));
                 });
             });
 
-            it('should emit \'warn\' event if \'options\' is an Array', function() {
+            it('Test 022 : should emit \'warn\' event if \'options\' is an Array', function() {
                 var warnSpy = jasmine.createSpy('warnSpy');
                 events.on('warn', warnSpy);
                 util.preProcessOptions({options: ['foo']});
                 expect(warnSpy).toHaveBeenCalled();
-                expect(warnSpy.calls[0].args[0]).toMatch('consider updating your cordova.raw.* method calls');
+                expect(warnSpy.calls.argsFor(0)).toMatch('consider updating your cordova.raw.* method calls');
                 events.removeListener('warn', warnSpy);
             });
 
-            it('should convert options Array into object with \'argv\' field', function() {
+            it('Test 023 : should convert options Array into object with \'argv\' field', function() {
                 expect(util.preProcessOptions({options: []}))
                     .toEqual(jasmine.objectContaining({options: {argv: []}}));
             });
 
-            it('should convert known options (platform-agnostic) into resultant object\'s fields', function () {
+            it('Test 024 : should convert known options (platform-agnostic) into resultant object\'s fields', function () {
                 var expectedResult = {
                     'debug': true, 'release': true,
                     'device': true, 'emulator': true,
@@ -291,7 +291,7 @@ describe('util module', function() {
                 });
             });
 
-            it('should try to convert unknown options (platform-specific) into resultant object\'s fields', function () {
+            it('Test 025 : should try to convert unknown options (platform-specific) into resultant object\'s fields', function () {
                 var expectedResult = {
                     'foo': true, 'appx': 'uap', 'gradleArg': '--no-daemon'
                 };
@@ -300,7 +300,7 @@ describe('util module', function() {
                     .toEqual(jasmine.objectContaining(expectedResult));
             });
 
-            it('should copy unknown options (platform-specific) into resultant object\'s argv field', function () {
+            it('Test 026 : should copy unknown options (platform-specific) into resultant object\'s argv field', function () {
                 unknownOptions.forEach(function (validOption) {
                     expect(util.preProcessOptions({options: unknownOptions}).options.argv).toContain(validOption);
                 });

--- a/cordova-lib/spec-cordova/wrappers.spec.js
+++ b/cordova-lib/spec-cordova/wrappers.spec.js
@@ -34,13 +34,13 @@ describe('callback wrapper', function() {
             });
 
             it('should work with no callback and success', function() {
-                raw.andReturn(Q());
+                raw.and.returnValue(Q());
                 cordova[call]();
                 expect(raw).toHaveBeenCalled();
             });
 
             it('should call the callback on success', function(done) {
-                raw.andReturn(Q());
+                raw.and.returnValue(Q());
                 cordova[call](function(err) {
                     expect(err).toBeUndefined();
                     done();
@@ -49,7 +49,7 @@ describe('callback wrapper', function() {
 
             it('should call the callback with the error on failure', function(done) {
                 var err = new Error('junk');
-                raw.andReturn(Q.reject(err));
+                raw.and.returnValue(Q.reject(err));
                 cordova[call](function(e) {
                     expect(e).toEqual(err);
                     done();
@@ -58,4 +58,3 @@ describe('callback wrapper', function() {
         });
     }
 });
-

--- a/cordova-lib/spec-cordova/wrappers.spec.js
+++ b/cordova-lib/spec-cordova/wrappers.spec.js
@@ -33,13 +33,13 @@ describe('callback wrapper', function() {
                 raw = spyOn(cordova.raw, call);
             });
 
-            it('should work with no callback and success', function() {
+            it('Test 001 : should work with no callback and success', function() {
                 raw.and.returnValue(Q());
                 cordova[call]();
                 expect(raw).toHaveBeenCalled();
             });
 
-            it('should call the callback on success', function(done) {
+            it('Test 002 : should call the callback on success', function(done) {
                 raw.and.returnValue(Q());
                 cordova[call](function(err) {
                     expect(err).toBeUndefined();
@@ -47,7 +47,7 @@ describe('callback wrapper', function() {
                 });
             });
 
-            it('should call the callback with the error on failure', function(done) {
+            it('Test 003 : should call the callback with the error on failure', function(done) {
                 var err = new Error('junk');
                 raw.and.returnValue(Q.reject(err));
                 cordova[call](function(e) {

--- a/cordova-lib/spec-plugman/add_platform.spec.js
+++ b/cordova-lib/spec-plugman/add_platform.spec.js
@@ -21,7 +21,7 @@ var platform = require('../src/plugman/platform'),
     fs = require('fs');
 
 describe( 'platform add/remove', function() {
-    it( 'should call platform add', function() {
+    it( 'Test 001 : should call platform add', function() {
         var sPlatformA = spyOn( platform, 'add' ).and.returnValue(Q()),
             sPlatformR = spyOn( platform, 'remove' ).and.returnValue(Q());
         platform.add();
@@ -35,14 +35,12 @@ describe( 'platform add/remove', function() {
 describe( 'platform add', function() {
     var done = false,
         existsSync;
-    function platformPromise( f ) {
-        f.then( function() { done = true; }, function(err) { done = err; } );
-    }
+
     beforeEach( function() {
         existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
         done = false;
     });
-    it( 'should error on non existing plugin.xml', function(done) {
+    it( 'Test 002 : should error on non existing plugin.xml', function(done) {
         platform.add().then(function(result){
             expect(false).toBe(true);
             done();
@@ -58,14 +56,12 @@ describe( 'platform add', function() {
 describe( 'platform remove', function() {
     var done = false,
         existsSync;
-    function platformPromise( f ) {
-        f.then( function() { done = true; }, function(err) { done = err; } );
-    }
+        
     beforeEach( function() {
         existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
         done = false;
     });
-    it( 'should error on non existing plugin.xml', function(done) {
+    it( 'Test 003 : should error on non existing plugin.xml', function(done) {
         platform.remove().then(function(result) {
             expect(false).toBe(true);
             done();

--- a/cordova-lib/spec-plugman/add_platform.spec.js
+++ b/cordova-lib/spec-plugman/add_platform.spec.js
@@ -22,8 +22,8 @@ var platform = require('../src/plugman/platform'),
 
 describe( 'platform add/remove', function() {
     it( 'should call platform add', function() {
-        var sPlatformA = spyOn( platform, 'add' ).andReturn(Q()),
-            sPlatformR = spyOn( platform, 'remove' ).andReturn(Q());
+        var sPlatformA = spyOn( platform, 'add' ).and.returnValue(Q()),
+            sPlatformR = spyOn( platform, 'remove' ).and.returnValue(Q());
         platform.add();
         expect(sPlatformA).toHaveBeenCalled();
         platform.remove();
@@ -39,18 +39,19 @@ describe( 'platform add', function() {
         f.then( function() { done = true; }, function(err) { done = err; } );
     }
     beforeEach( function() {
-        existsSync = spyOn( fs, 'existsSync' ).andReturn( false );
+        existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
         done = false;
     });
-    it( 'should error on non existing plugin.xml', function() {
-        runs(function() {
-            platformPromise( platform.add() );
+    it( 'should error on non existing plugin.xml', function(done) {
+        platform.add().then(function(result){
+            expect(false).toBe(true);
+            done();
+        },
+        function err(errMsg) {
+            expect(errMsg.toString()).toContain('can\'t find a plugin.xml.  Are you in the plugin?');
+            done();
         });
-        waitsFor(function() { return done; }, 'platform promise never resolved', 500);
-        runs(function() {
-            expect(''+ done ).toContain( 'can\'t find a plugin.xml.  Are you in the plugin?'  );
-        });
-    });
+    }, 6000);
 });
 
 
@@ -61,16 +62,17 @@ describe( 'platform remove', function() {
         f.then( function() { done = true; }, function(err) { done = err; } );
     }
     beforeEach( function() {
-        existsSync = spyOn( fs, 'existsSync' ).andReturn( false );
+        existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
         done = false;
     });
-    it( 'should error on non existing plugin.xml', function() {
-        runs(function() {
-            platformPromise( platform.remove() );
+    it( 'should error on non existing plugin.xml', function(done) {
+        platform.remove().then(function(result) {
+            expect(false).toBe(true);
+            done();
+        },
+        function err(errMsg) {
+            expect(errMsg.toString()).toContain( 'can\'t find a plugin.xml.  Are you in the plugin?'  );
+            done();
         });
-        waitsFor(function() { return done; }, 'platform promise never resolved', 500);
-        runs(function() {
-            expect(''+ done ).toContain( 'can\'t find a plugin.xml.  Are you in the plugin?'  );
-        });
-    });
+    }, 6000);
 });

--- a/cordova-lib/spec-plugman/common.js
+++ b/cordova-lib/spec-plugman/common.js
@@ -59,21 +59,21 @@ module.exports = common = {
 
         startsWith: function(emitSpy, string)
         {
-            var match = [], i;
-            for(i in emitSpy.argsForCall) {
-                if(emitSpy.argsForCall[i][1].substr(0, string.length) === string)
-                    match.push(emitSpy.argsForCall[i][1]);
-            }
+            var match = [];
+            emitSpy.calls.all().forEach(function(val, i) {
+                if(emitSpy.calls.argsFor(i)[1].substr(0, string.length) === string)
+                    match.push(emitSpy.calls.argsFor(i)[1]);
+            });
             return match;
         },
 
         contains: function(emitSpy, string)
         {
-            var match = [], i;
-            for(i in emitSpy.argsForCall) {
-                if(emitSpy.argsForCall[i][1].indexOf(string) >= 0)
-                    match.push(emitSpy.argsForCall[i][1]);
-            }
+            var match = [];
+            emitSpy.calls.all().forEach(function(val, i) {
+                if(emitSpy.calls.argsFor(i)[1].indexOf(string) >= 0)
+                    match.push(emitSpy.calls.argsFor(i)[1]);
+            });
             return match;
         }
     }

--- a/cordova-lib/spec-plugman/config.spec.js
+++ b/cordova-lib/spec-plugman/config.spec.js
@@ -22,7 +22,7 @@ var config = require('../src/plugman/config'),
 
 describe('config', function() {
     it('should run config', function() {
-        var sConfig = spyOn(registry, 'config').andReturn(Q());
+        var sConfig = spyOn(registry, 'config').and.returnValue(Q());
         var params = ['set', 'registry', 'http://registry.cordova.io'];
         config(params);
         expect(sConfig).toHaveBeenCalledWith(params);

--- a/cordova-lib/spec-plugman/config.spec.js
+++ b/cordova-lib/spec-plugman/config.spec.js
@@ -21,7 +21,7 @@ var config = require('../src/plugman/config'),
     registry = require('../src/plugman/registry/registry');
 
 describe('config', function() {
-    it('should run config', function() {
+    it('Test 001 : should run config', function() {
         var sConfig = spyOn(registry, 'config').and.returnValue(Q());
         var params = ['set', 'registry', 'http://registry.cordova.io'];
         config(params);

--- a/cordova-lib/spec-plugman/create.spec.js
+++ b/cordova-lib/spec-plugman/create.spec.js
@@ -49,6 +49,7 @@ describe( 'create plugin', function() {
             expect( writeFileSync.calls.count() ).toEqual( 2 );
             done();
         }).fail(function err(errMsg) {
+            expect(errMsg).toBeUndefined();
             done();
         });
     }, 6000);

--- a/cordova-lib/spec-plugman/create.spec.js
+++ b/cordova-lib/spec-plugman/create.spec.js
@@ -24,7 +24,7 @@ var create = require('../src/plugman/create'),
 
 describe( 'create', function() {
     it( 'should call create', function() {
-        var sCreate = spyOn( plugman, 'create' ).andReturn(Q());
+        var sCreate = spyOn( plugman, 'create' ).and.returnValue(Q());
         plugman.create();
         expect(sCreate).toHaveBeenCalled();
     });
@@ -39,13 +39,13 @@ describe( 'create plugin', function() {
         f.then( function() { done = true; }, function(err) { done = err; } );
     }
     beforeEach( function() {
-        existsSync = spyOn( fs, 'existsSync' ).andReturn( false );
-        mkdir = spyOn( shell, 'mkdir' ).andReturn( true );
+        existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
+        mkdir = spyOn( shell, 'mkdir' ).and.returnValue( true );
         writeFileSync = spyOn( fs, 'writeFileSync' );
         done = false;
     });
 
-    it( 'should be successful', function() {
+    it( 'should be successful', function(done) {
         runs(function() {
             createPromise( create( 'name', 'org.plugin.id', '0.0.0', '.', [] ) );
         });
@@ -64,17 +64,18 @@ describe( 'create plugin in existing plugin', function() {
         f.then( function() { done = true; }, function(err) { done = err; } );
     }
     beforeEach( function() {
-        existsSync = spyOn( fs, 'existsSync' ).andReturn( true );
+        existsSync = spyOn( fs, 'existsSync' ).and.returnValue( true );
         done = false;
     });
 
-    it( 'should fail due to an existing plugin.xml', function() {
-        runs(function() {
-            createPromise( create() );
+    it( 'should fail due to an existing plugin.xml', function(done) {
+        create().then(function(result) {
+            expect(false).toBe(true);
+            done();
+        },
+        function err(errMsg) {
+            expect(errMsg.toString()).toContain( 'plugin.xml already exists. Are you already in a plugin?'  );
+            done();
         });
-        waitsFor(function() { return done; }, 'create promise never resolved', 500);
-        runs(function() {
-            expect(''+ done ).toContain( 'plugin.xml already exists. Are you already in a plugin?'  );
-        });
-    });
+    }, 6000);
 });

--- a/cordova-lib/spec-plugman/create.spec.js
+++ b/cordova-lib/spec-plugman/create.spec.js
@@ -23,7 +23,7 @@ var create = require('../src/plugman/create'),
     plugman = require('../src/plugman/plugman');
 
 describe( 'create', function() {
-    it( 'should call create', function() {
+    it( 'Test 001 : should call create', function() {
         var sCreate = spyOn( plugman, 'create' ).and.returnValue(Q());
         plugman.create();
         expect(sCreate).toHaveBeenCalled();
@@ -35,9 +35,7 @@ describe( 'create plugin', function() {
         existsSync,
         mkdir,
         writeFileSync;
-    function createPromise( f ) {
-        f.then( function() { done = true; }, function(err) { done = err; } );
-    }
+
     beforeEach( function() {
         existsSync = spyOn( fs, 'existsSync' ).and.returnValue( false );
         mkdir = spyOn( shell, 'mkdir' ).and.returnValue( true );
@@ -45,35 +43,32 @@ describe( 'create plugin', function() {
         done = false;
     });
 
-    it( 'should be successful', function(done) {
-        runs(function() {
-            createPromise( create( 'name', 'org.plugin.id', '0.0.0', '.', [] ) );
+    it( 'Test 002 : should be successful', function(done) {
+        create('name', 'org.plugin.id', '0.0.0', '.', [])
+        .then(function(result) {
+            expect( writeFileSync.calls.count() ).toEqual( 2 );
+            done();
+        }).fail(function err(errMsg) {
+            done();
         });
-        waitsFor(function() { return done; }, 'create promise never resolved', 500);
-        runs(function() {
-            expect( done ).toBe( true );
-            expect( writeFileSync.calls.length ).toEqual( 2 );
-        });
-    });
+    }, 6000);
 });
 
 describe( 'create plugin in existing plugin', function() {
     var done = false,
         existsSync;
-    function createPromise( f ) {
-        f.then( function() { done = true; }, function(err) { done = err; } );
-    }
+
     beforeEach( function() {
         existsSync = spyOn( fs, 'existsSync' ).and.returnValue( true );
         done = false;
     });
 
-    it( 'should fail due to an existing plugin.xml', function(done) {
-        create().then(function(result) {
+    it( 'Test 003 : should fail due to an existing plugin.xml', function(done) {
+        create()
+        .then(function(result) {
             expect(false).toBe(true);
             done();
-        },
-        function err(errMsg) {
+        }).fail(function err(errMsg) {
             expect(errMsg.toString()).toContain( 'plugin.xml already exists. Are you already in a plugin?'  );
             done();
         });

--- a/cordova-lib/spec-plugman/fetch.spec.js
+++ b/cordova-lib/spec-plugman/fetch.spec.js
@@ -70,22 +70,22 @@ describe('fetch', function() {
             fetch.__set__('localPlugins', null);
         });
 
-        it('should copy locally-available plugin to plugins directory', function(done) {
+        it('Test 001 : should copy locally-available plugin to plugins directory', function(done) {
             wrapper(fetch(test_plugin, temp), done, function() {
                 expect(cp).toHaveBeenCalledWith('-R', path.join(test_plugin, '*'), path.join(temp, test_plugin_id));
             });
         });
-        it('should copy locally-available plugin to plugins directory when adding a plugin with searchpath argument', function(done) {
+        it('Test 002 : should copy locally-available plugin to plugins directory when adding a plugin with searchpath argument', function(done) {
             wrapper(fetch(test_plugin_id, temp, { searchpath: test_plugin_searchpath }), done, function() {
                 expect(cp).toHaveBeenCalledWith('-R', path.join(test_plugin, '*'), path.join(temp, test_plugin_id));
             });
         });
-        it('should create a symlink if used with `link` param', function(done) {
+        it('Tet 003 : should create a symlink if used with `link` param', function(done) {
             wrapper(fetch(test_plugin, temp, { link: true }), done, function() {
                 expect(sym).toHaveBeenCalledWith(test_plugin, path.join(temp, test_plugin_id), 'dir');
             });
         });
-        it('should fail when the expected ID doesn\'t match', function(done) {
+        it('Test 004 : should fail when the expected ID doesn\'t match', function(done) {
             fetch(test_plugin, temp, { expected_id: 'wrongID' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -93,12 +93,12 @@ describe('fetch', function() {
                 expect(''+err).toContain('Expected plugin to have ID "wrongID" but got');
             }).fin(done);
         });
-        it('should succeed when the expected ID is correct', function(done) {
+        it('Test 005 : should succeed when the expected ID is correct', function(done) {
             wrapper(fetch(test_plugin, temp, { expected_id: test_plugin_id }), done, function() {
                 expect(1).toBe(1);
             });
         });
-        it('should fail when the expected ID with version specified doesn\'t match', function(done) {
+        it('Test 006 : should fail when the expected ID with version specified doesn\'t match', function(done) {
             fetch(test_plugin, temp, { expected_id: test_plugin_id + '@wrongVersion' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -106,7 +106,7 @@ describe('fetch', function() {
                 expect(''+err).toContain('to satisfy version "wrongVersion" but got');
             }).fin(done);
         });
-        it('should succeed when the plugin version specified is correct', function(done) {
+        it('Test 007 : should succeed when the plugin version specified is correct', function(done) {
             var exp_id = test_plugin_id + '@' + test_plugin_version;
             wrapper(fetch(test_plugin, temp, { expected_id: exp_id}), done, function() {
                 expect(1).toBe(1);
@@ -116,29 +116,21 @@ describe('fetch', function() {
     describe('git plugins', function() {
         var clone, save_metadata, done;
 
-        function fetchPromise(f) {
-            f.then(function() { done = true; }, function(err) { done = err; });
-        }
-
         beforeEach(function() {
             clone = spyOn(plugins, 'clonePluginGitRepo').and.returnValue(Q(test_plugin));
             save_metadata = spyOn(metadata, 'save_fetch_metadata');
             done = false;
         });
-        it('should call clonePluginGitRepo for https:// and git:// based urls', function(done) {
+        it('Test 008 : should call clonePluginGitRepo for https:// and git:// based urls', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
-            runs(function() {
-                fetchPromise(fetch(url, temp));
+                fetch(url, temp).then(function(){
+                    expect(save_metadata).toHaveBeenCalled();
+                    expect(clone).toHaveBeenCalledWith(url, temp, '.', undefined, undefined);
+                    done();
             });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
-                expect(done).toBe(true);
-                expect(clone).toHaveBeenCalledWith(url, temp, '.', undefined, undefined);
-                expect(save_metadata).toHaveBeenCalled();
-            });
-        });
+        }, 6000);
         
-        it('should call clonePluginGitRepo with subdir if applicable', function(done) {
+        it('Test 009 : should call clonePluginGitRepo with subdir if applicable', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
             var dir = 'fakeSubDir';
             fetch(url, temp, { subdir: dir }).then(function(){
@@ -148,7 +140,7 @@ describe('fetch', function() {
             });
         }, 6000);
 
-        it('should call clonePluginGitRepo with subdir and git ref if applicable', function(done) {
+        it('Test 010 : should call clonePluginGitRepo with subdir and git ref if applicable', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
             var dir = 'fakeSubDir';
             var ref = 'fakeGitRef';
@@ -159,7 +151,7 @@ describe('fetch', function() {
             });
         }, 6000);
 
-        it('should extract the git ref from the URL hash, if provided', function(done) {
+        it('Test 011 : should extract the git ref from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#fakeGitRef';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
             fetch(url, temp, {}).then(function(){
@@ -169,7 +161,7 @@ describe('fetch', function() {
             });
         }, 6000);
 
-        it('should extract the subdir from the URL hash, if provided', function(done) {
+        it('Test 012 : should extract the subdir from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#:fakeSubDir';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
             fetch(url, temp, {}).then(function(result){
@@ -179,7 +171,7 @@ describe('fetch', function() {
             });
         }, 6000);
 
-        it('should extract the git ref and subdir from the URL hash, if provided', function(done) {
+        it('Test 013 : should extract the git ref and subdir from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#fakeGitRef:/fake/Sub/Dir/';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
             fetch(url, temp, {}).then(function(result){
@@ -189,7 +181,7 @@ describe('fetch', function() {
             });
         }, 6000);
 
-        it('should fail when the expected ID doesn\'t match', function(done) {
+        it('Test 014 : should fail when the expected ID doesn\'t match', function(done) {
             fetch('https://github.com/bobeast/GAPlugin.git', temp, { expected_id: 'wrongID' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -197,7 +189,7 @@ describe('fetch', function() {
                 expect(''+err).toContain('Expected plugin to have ID "wrongID" but got');
             }).fin(done);
         });
-        it('should fail when the expected ID with version specified doesn\'t match', function(done) {
+        it('Test 015 : should fail when the expected ID with version specified doesn\'t match', function(done) {
             fetch('https://github.com/bobeast/GAPlugin.git', temp, { expected_id: 'id@wrongVersion' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -205,7 +197,7 @@ describe('fetch', function() {
                 expect(''+err).toContain('Expected plugin to have ID "id" but got');
             }).fin(done);
         });
-        it('should succeed when the expected ID is correct', function(done) {
+        it('Test 016 : should succeed when the expected ID is correct', function(done) {
             wrapper(fetch('https://github.com/bobeast/GAPlugin.git', temp, { expected_id: test_plugin_id }), done, function() {
                 expect(1).toBe(1);
             });
@@ -219,19 +211,19 @@ describe('fetch', function() {
         });
 
         // this commit uses the new id
-        it('should fetch from a commit-sha', function(done) {
+        it('Test 017 : should fetch from a commit-sha', function(done) {
             wrapper(fetch('http://github.com/apache/cordova-plugin-device.git#ad5f1e7bfd05ef98c01df549a0fa98036a5625db', temp, { expected_id: 'cordova-plugin-device' }), done, function() {
                 expect(1).toBe(1);
             });
         });
         // this branch uses the old id
-        it('should fetch from a branch', function(done) {
+        it('Test 018 : should fetch from a branch', function(done) {
             wrapper(fetch('http://github.com/apache/cordova-plugin-device.git#cdvtest', temp, { expected_id: 'org.apache.cordova.device' }), done, function() {
                 expect(1).toBe(1);
             });
         });
         // this tag uses the new id
-        it('should fetch from a tag', function(done) {
+        it('Test 019 : should fetch from a tag', function(done) {
             wrapper(fetch('http://github.com/apache/cordova-plugin-device.git#r1.0.0', temp, { expected_id: 'cordova-plugin-device' }), done, function() {
                 expect(1).toBe(1);
             });
@@ -244,7 +236,7 @@ describe('fetch', function() {
         var appDir = path.join(__dirname, 'plugins/recursivePlug/demo');
 
         if(/^win/.test(process.platform)) {
-            it('should copy all but the /demo/ folder',function(done) {
+            it('Test 020 : should copy all but the /demo/ folder',function(done) {
                 var cp = spyOn(shell, 'cp');
                 wrapper(fetch(srcDir, appDir),done, function() {
                     expect(cp).toHaveBeenCalledWith('-R',path.join(srcDir,'asset.txt'),path.join(appDir,'test-recursive'));
@@ -253,7 +245,7 @@ describe('fetch', function() {
             });
         }
         else {
-            it('should skip copy to avoid recursive error', function(done) {
+            it('Test 021 : should skip copy to avoid recursive error', function(done) {
 
                 var cp = spyOn(shell, 'cp').and.callFake(function(){});
 
@@ -277,7 +269,7 @@ describe('fetch', function() {
         });
 
 
-        it('should fail when the expected ID doesn\'t match', function(done) {
+        it('Test 022 : should fail when the expected ID doesn\'t match', function(done) {
             fetch(pluginId, temp, { expected_id: 'wrongID' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -285,7 +277,7 @@ describe('fetch', function() {
                 expect(''+err).toContain('Expected plugin to have ID "wrongID" but got');
             }).fin(done);
         });
-        it('should fail when the expected ID with version specified doesn\'t match', function(done) {
+        it('Test 022 : should fail when the expected ID with version specified doesn\'t match', function(done) {
             fetch(pluginId, temp, { expected_id: test_plugin_id + '@wrongVersion' })
             .then(function() {
                 expect('this call').toBe('fail');
@@ -293,23 +285,23 @@ describe('fetch', function() {
                 expect(''+err).toContain('to satisfy version "wrongVersion" but got');
             }).fin(done);
         });
-        it('should succeed when the expected ID is correct', function(done) {
+        it('Test 023 : should succeed when the expected ID is correct', function(done) {
             wrapper(fetch(pluginId, temp, { expected_id: test_plugin_id }), done, function() {
                 expect(1).toBe(1);
             });
         });
-        it('should succeed when the plugin version specified is correct', function(done) {
+        it('Test 024 : should succeed when the plugin version specified is correct', function(done) {
             wrapper(fetch(pluginId, temp, { expected_id: test_plugin_id + '@' + test_plugin_version }), done, function() {
                 expect(1).toBe(1);
             });
         });
-        it('should fetch plugins that are scoped packages', function(done) {
+        it('Test 025 : should fetch plugins that are scoped packages', function(done) {
             var scopedPackage = '@testcope/dummy-plugin';
             wrapper(fetch(scopedPackage, temp, { expected_id: test_plugin_id }), done, function() {
                 expect(sFetch).toHaveBeenCalledWith([scopedPackage]);
             });
         });
-        it('should fetch plugins that are scoped packages and have versions specified', function(done) {
+        it('Test 026 : should fetch plugins that are scoped packages and have versions specified', function(done) {
             var scopedPackage = '@testcope/dummy-plugin@latest';
             wrapper(fetch(scopedPackage, temp, { expected_id: test_plugin_id }), done, function() {
                 expect(sFetch).toHaveBeenCalledWith([scopedPackage]);

--- a/cordova-lib/spec-plugman/fetch.spec.js
+++ b/cordova-lib/spec-plugman/fetch.spec.js
@@ -64,7 +64,7 @@ describe('fetch', function() {
         beforeEach(function() {
             rm = spyOn(shell, 'rm');
             sym = spyOn(fs, 'symlinkSync');
-            cp = spyOn(shell, 'cp').andCallThrough();
+            cp = spyOn(shell, 'cp').and.callThrough();
             save_metadata = spyOn(metadata, 'save_fetch_metadata');
             realrm('-rf', temp);
             fetch.__set__('localPlugins', null);
@@ -121,11 +121,11 @@ describe('fetch', function() {
         }
 
         beforeEach(function() {
-            clone = spyOn(plugins, 'clonePluginGitRepo').andReturn(Q(test_plugin));
+            clone = spyOn(plugins, 'clonePluginGitRepo').and.returnValue(Q(test_plugin));
             save_metadata = spyOn(metadata, 'save_fetch_metadata');
             done = false;
         });
-        it('should call clonePluginGitRepo for https:// and git:// based urls', function() {
+        it('should call clonePluginGitRepo for https:// and git:// based urls', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
             runs(function() {
                 fetchPromise(fetch(url, temp));
@@ -137,67 +137,58 @@ describe('fetch', function() {
                 expect(save_metadata).toHaveBeenCalled();
             });
         });
-        it('should call clonePluginGitRepo with subdir if applicable', function() {
+        
+        it('should call clonePluginGitRepo with subdir if applicable', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
             var dir = 'fakeSubDir';
-            runs(function() {
-                fetchPromise(fetch(url, temp, { subdir: dir }));
-            });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
+            fetch(url, temp, { subdir: dir }).then(function(){
                 expect(clone).toHaveBeenCalledWith(url, temp, dir, undefined, undefined);
                 expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-        });
-        it('should call clonePluginGitRepo with subdir and git ref if applicable', function() {
+        }, 6000);
+
+        it('should call clonePluginGitRepo with subdir and git ref if applicable', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git';
             var dir = 'fakeSubDir';
             var ref = 'fakeGitRef';
-            runs(function() {
-                fetchPromise(fetch(url, temp, { subdir: dir, git_ref: ref }));
-            });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
+            fetch(url, temp, { subdir: dir, git_ref: ref }).then(function(){
                 expect(clone).toHaveBeenCalledWith(url, temp, dir, ref, undefined);
                 expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-        });
-        it('should extract the git ref from the URL hash, if provided', function() {
+        }, 6000);
+
+        it('should extract the git ref from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#fakeGitRef';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
-            runs(function() {
-                fetchPromise(fetch(url, temp, {}));
-            });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
+            fetch(url, temp, {}).then(function(){
                 expect(clone).toHaveBeenCalledWith(baseURL, temp, '.', 'fakeGitRef', undefined);
                 expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-        });
-        it('should extract the subdir from the URL hash, if provided', function() {
+        }, 6000);
+
+        it('should extract the subdir from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#:fakeSubDir';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
-            runs(function() {
-                fetchPromise(fetch(url, temp, {}));
-            });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
+            fetch(url, temp, {}).then(function(result){
                 expect(clone).toHaveBeenCalledWith(baseURL, temp, 'fakeSubDir', undefined, undefined);
                 expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-        });
-        it('should extract the git ref and subdir from the URL hash, if provided', function() {
+        }, 6000);
+
+        it('should extract the git ref and subdir from the URL hash, if provided', function(done) {
             var url = 'https://github.com/bobeast/GAPlugin.git#fakeGitRef:/fake/Sub/Dir/';
             var baseURL = 'https://github.com/bobeast/GAPlugin.git';
-            runs(function() {
-                fetchPromise(fetch(url, temp, {}));
-            });
-            waitsFor(function() { return done; }, 'fetch promise never resolved', 250);
-            runs(function() {
+            fetch(url, temp, {}).then(function(result){
                 expect(clone).toHaveBeenCalledWith(baseURL, temp, 'fake/Sub/Dir', 'fakeGitRef', undefined);
                 expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-        });
+        }, 6000);
+
         it('should fail when the expected ID doesn\'t match', function(done) {
             fetch('https://github.com/bobeast/GAPlugin.git', temp, { expected_id: 'wrongID' })
             .then(function() {
@@ -264,7 +255,7 @@ describe('fetch', function() {
         else {
             it('should skip copy to avoid recursive error', function(done) {
 
-                var cp = spyOn(shell, 'cp').andCallFake(function(){});
+                var cp = spyOn(shell, 'cp').and.callFake(function(){});
 
                 wrapper(fetch(srcDir, appDir),done, function() {
                     expect(cp).not.toHaveBeenCalled();
@@ -281,7 +272,7 @@ describe('fetch', function() {
             rm = spyOn(shell, 'rm');
             sym = spyOn(fs, 'symlinkSync');
             save_metadata = spyOn(metadata, 'save_fetch_metadata');
-            sFetch = spyOn(registry, 'fetch').andReturn(Q(test_plugin));
+            sFetch = spyOn(registry, 'fetch').and.returnValue(Q(test_plugin));
             realrm('-rf', temp);
         });
 

--- a/cordova-lib/spec-plugman/info.spec.js
+++ b/cordova-lib/spec-plugman/info.spec.js
@@ -22,7 +22,7 @@ var search = require('../src/plugman/info'),
 
 describe('info', function() {
     it('should show plugin info', function() {
-        var sSearch = spyOn(registry, 'info').andReturn(Q({
+        var sSearch = spyOn(registry, 'info').and.returnValue(Q({
             name: 'fakePlugin',
             version: '1.0.0',
             engines: [{ name: 'plugman', version: '>=0.11' }]

--- a/cordova-lib/spec-plugman/info.spec.js
+++ b/cordova-lib/spec-plugman/info.spec.js
@@ -21,7 +21,7 @@ var search = require('../src/plugman/info'),
     registry = require('../src/plugman/registry/registry');
 
 describe('info', function() {
-    it('should show plugin info', function() {
+    it('Test 001 : should show plugin info', function() {
         var sSearch = spyOn(registry, 'info').and.returnValue(Q({
             name: 'fakePlugin',
             version: '1.0.0',

--- a/cordova-lib/spec-plugman/install.spec.js
+++ b/cordova-lib/spec-plugman/install.spec.js
@@ -118,12 +118,12 @@ describe('plugman install start', function() {
 
     beforeEach(function() {
         config_queue_add = spyOn(PlatformJson.prototype, 'addInstalledPluginToPrepareQueue');
-        proc = spyOn(actions.prototype, 'process').andReturn( Q(true) );
+        proc = spyOn(actions.prototype, 'process').and.returnValue( Q(true) );
         actions_push = spyOn(actions.prototype, 'push');
         ca = spyOn(actions.prototype, 'createAction');
 
         var origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function(path) {
             if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
             return origParseElementtreeSync(path);
         });
@@ -138,7 +138,7 @@ describe('plugman install start', function() {
         var returnValues = [true, {}, [], 'foo', function(){}];
         var api = knownPlatforms.getPlatformApi('android', project);
         var addPluginOrig = api.addPlugin;
-        spyOn(api, 'addPlugin').andCallFake(function () {
+        spyOn(api, 'addPlugin').and.callFake(function () {
             return addPluginOrig.apply(api, arguments)
             .thenResolve(returnValues[returnValueIndex++]);
         });
@@ -206,19 +206,19 @@ describe('install', function() {
 
     beforeEach(function() {
 
-        exec = spyOn(child_process, 'exec').andCallFake(function(cmd, cb) {
+        exec = spyOn(child_process, 'exec').and.callFake(function(cmd, cb) {
             cb(false, '', '');
         });
-        spawnSpy = spyOn(superspawn, 'spawn').andReturn(Q('3.1.0'));
-        spyOn(fs, 'mkdirSync').andReturn(true);
-        spyOn(shell, 'mkdir').andReturn(true);
-        spyOn(platforms, 'copyFile').andReturn(true);
+        spawnSpy = spyOn(superspawn, 'spawn').and.returnValue(Q('3.1.0'));
+        spyOn(fs, 'mkdirSync').and.returnValue(true);
+        spyOn(shell, 'mkdir').and.returnValue(true);
+        spyOn(platforms, 'copyFile').and.returnValue(true);
 
-        fetchSpy = spyOn(plugman.raw, 'fetch').andReturn( Q( plugins['com.cordova.engine'] ) );
-        chmod = spyOn(fs, 'chmodSync').andReturn(true);
-        spyOn(fs, 'writeFileSync').andReturn(true);
-        cp = spyOn(shell, 'cp').andReturn(true);
-        rm = spyOn(shell, 'rm').andReturn(true);
+        fetchSpy = spyOn(plugman.raw, 'fetch').and.returnValue( Q( plugins['com.cordova.engine'] ) );
+        chmod = spyOn(fs, 'chmodSync').and.returnValue(true);
+        spyOn(fs, 'writeFileSync').and.returnValue(true);
+        cp = spyOn(shell, 'cp').and.returnValue(true);
+        rm = spyOn(shell, 'rm').and.returnValue(true);
         add_to_queue = spyOn(PlatformJson.prototype, 'addInstalledPluginToPrepareQueue');
         done = false;
     });
@@ -237,8 +237,8 @@ describe('install', function() {
             expect(results['emit_results'][2]).toBe('Remember that your api key is batman!');
         });
         it('should call fetch if provided plugin cannot be resolved locally', function() {
-            fetchSpy.andReturn( Q( plugins['org.test.plugins.dummyplugin'] ) );
-            spyOn(fs, 'existsSync').andCallFake( fake['existsSync']['noPlugins'] );
+            fetchSpy.and.returnValue( Q( plugins['org.test.plugins.dummyplugin'] ) );
+            spyOn(fs, 'existsSync').and.callFake( fake['existsSync']['noPlugins'] );
 
             runs(function() {
                 installPromise(install('android', project, 'CLEANYOURSHORTS' ));
@@ -250,8 +250,8 @@ describe('install', function() {
             });
         });
         it('should call fetch and convert oldID to newID', function() {
-            fetchSpy.andReturn( Q( plugins['org.test.plugins.dummyplugin'] ) );
-            spyOn(fs, 'existsSync').andCallFake( fake['existsSync']['noPlugins'] );
+            fetchSpy.and.returnValue( Q( plugins['org.test.plugins.dummyplugin'] ) );
+            spyOn(fs, 'existsSync').and.callFake( fake['existsSync']['noPlugins'] );
             var emit = spyOn(events, 'emit');
             runs(function() {
                 installPromise(install('android', project, 'org.apache.cordova.device' ));
@@ -268,12 +268,12 @@ describe('install', function() {
             var fail, satisfies;
             beforeEach(function () {
                 fail = jasmine.createSpy('fail');
-                satisfies = spyOn(semver, 'satisfies').andReturn(true);
-                spyOn(PlatformJson.prototype, 'isPluginInstalled').andReturn(false);
+                satisfies = spyOn(semver, 'satisfies').and.returnValue(true);
+                spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
             });
 
             it('should check version if plugin has engine tag', function(done){
-                exec.andCallFake(function(cmd, cb) { cb(null, '2.5.0\n'); });
+                exec.and.callFake(function(cmd, cb) { cb(null, '2.5.0\n'); });
                 install('android', project, plugins['com.cordova.engine'])
                 .fail(fail)
                 .fin(function () {
@@ -282,7 +282,7 @@ describe('install', function() {
                 });
             });
             it('should check version and munge it a little if it has "rc" in it so it plays nice with semver (introduce a dash in it)', function(done) {
-                exec.andCallFake(function(cmd, cb) { cb(null, '3.0.0rc1\n'); });
+                exec.and.callFake(function(cmd, cb) { cb(null, '3.0.0rc1\n'); });
                 install('android', project, plugins['com.cordova.engine'])
                 .fail(fail)
                 .fin(function () {
@@ -291,7 +291,7 @@ describe('install', function() {
                 });
             });
             it('should check specific platform version over cordova version if specified', function(done) {
-                exec.andCallFake(function(cmd, cb) { cb(null, '3.1.0\n'); });
+                exec.and.callFake(function(cmd, cb) { cb(null, '3.1.0\n'); });
                 install('android', project, plugins['com.cordova.engine-android'])
                 .fail(fail)
                 .fin(function() {
@@ -301,7 +301,7 @@ describe('install', function() {
             });
             it('should check platform sdk version if specified', function(done) {
                 var cordovaVersion = require('../package.json').version.replace(/-dev|-nightly.*$/, '');
-                exec.andCallFake(function(cmd, cb) { cb(null, '18\n'); });
+                exec.and.callFake(function(cmd, cb) { cb(null, '18\n'); });
                 install('android', project, plugins['com.cordova.engine-android'])
                 .fail(fail)
                 .fin(function() {
@@ -344,7 +344,7 @@ describe('install', function() {
         });
 
         it('should not check custom engine version that is not supported for platform', function() {
-            var spy = spyOn(semver, 'satisfies').andReturn(true);
+            var spy = spyOn(semver, 'satisfies').and.returnValue(true);
             runs(function() {
                 installPromise( install('blackberry10', project, plugins['com.cordova.engine']) );
             });
@@ -357,10 +357,10 @@ describe('install', function() {
         describe('with dependencies', function() {
             var emit;
             beforeEach(function() {
-                spyOn(fs, 'existsSync').andCallFake( fake['existsSync']['noPlugins'] );
-                fetchSpy.andCallFake( fake['fetch']['dependencies'] );
+                spyOn(fs, 'existsSync').and.callFake( fake['existsSync']['noPlugins'] );
+                fetchSpy.and.callFake( fake['fetch']['dependencies'] );
                 emit = spyOn(events, 'emit');
-                exec.andCallFake(function(cmd, cb) {
+                exec.and.callFake(function(cmd, cb) {
                     cb(null, '9.0.0\n');
                 });
             });
@@ -450,7 +450,7 @@ describe('install', function() {
             it('install uses meta data (if available) of top level plugin source', function() {
                 // Fake metadata so plugin 'B' appears from 'meta/B'
                 var meta = require('../src/plugman/util/metadata');
-                spyOn(meta, 'get_fetch_metadata').andCallFake(function(){
+                spyOn(meta, 'get_fetch_metadata').and.callFake(function(){
                     return {
                         source: {type: 'dir', url: path.join(plugins['B'], '..', 'meta')}
                     };
@@ -490,7 +490,7 @@ describe('install', function() {
         });
         it('should throw if variables are missing', function(done) {
             var success = jasmine.createSpy('success');
-            spyOn(PlatformJson.prototype, 'isPluginInstalled').andReturn(false);
+            spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
             install('android', project, plugins['com.adobe.vars'])
             .then(success)
             .fail(function (err) {
@@ -502,9 +502,9 @@ describe('install', function() {
             });
         });
         it('should throw if git is not found on the path and a remote url is requested', function() {
-            spyOn(fs, 'existsSync').andCallFake( fake['existsSync']['noPlugins'] );
-            fetchSpy.andCallThrough();
-            spyOn(shell, 'which').andReturn(null);
+            spyOn(fs, 'existsSync').and.callFake( fake['existsSync']['noPlugins'] );
+            fetchSpy.and.callThrough();
+            spyOn(shell, 'which').and.returnValue(null);
             runs(function() {
                 installPromise( install('android', project, 'https://git-wip-us.apache.org/repos/asf/cordova-plugin-camera.git') );
             });
@@ -514,8 +514,8 @@ describe('install', function() {
             });
         });
         it('should not fail when trying to install plugin less than minimum version. Skip instead  ', function(){
-            spyOn(semver, 'satisfies').andReturn(false);
-            exec.andCallFake(function(cmd, cb) {
+            spyOn(semver, 'satisfies').and.returnValue(false);
+            exec.and.callFake(function(cmd, cb) {
                 cb(null, '0.0.1\n');
             });
             runs(function() {
@@ -528,13 +528,13 @@ describe('install', function() {
         });
         it('should throw if the engine scriptSrc escapes out of the plugin dir.', function(done) {
             var success = jasmine.createSpy('success'),
-                fail = jasmine.createSpy('fail').andCallFake(function(err) {
+                fail = jasmine.createSpy('fail').and.callFake(function(err) {
                     // <engine name="path-escaping-plugin" version=">=1.0.0" scriptSrc="../../../malicious/script" platform="*" />
                     expect(err).toBeDefined();
                     expect(err.message.indexOf('Security violation:')).toBe(0);
                 });
 
-            spyOn(PlatformJson.prototype, 'isPluginInstalled').andReturn(false);
+            spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
             install('android', project, plugins['org.test.invalid.engine.script'])
                 .then(success)
                 .fail(fail)
@@ -547,7 +547,7 @@ describe('install', function() {
         it('should throw if a non-default cordova engine platform attribute is not defined.', function(done) {
             var success = jasmine.createSpy('success'),
                 fail = jasmine.createSpy('fail');
-            spyOn(PlatformJson.prototype, 'isPluginInstalled').andReturn(false);
+            spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
             install('android', project, plugins['org.test.invalid.engine.no.platform'])
                 .then(success)
                 .fail(fail)
@@ -560,7 +560,7 @@ describe('install', function() {
         it('should throw if a non-default cordova engine scriptSrc attribute is not defined.', function(done) {
             var success = jasmine.createSpy('success'),
                 fail = jasmine.createSpy('fail');
-            spyOn(PlatformJson.prototype, 'isPluginInstalled').andReturn(false);
+            spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
             install('android', project, plugins['org.test.invalid.engine.no.scriptSrc'])
                 .then(success)
                 .fail(fail)

--- a/cordova-lib/spec-plugman/install.spec.js
+++ b/cordova-lib/spec-plugman/install.spec.js
@@ -213,7 +213,7 @@ describe('install', function() {
             spyOn(fs, 'existsSync').and.callFake( fake['existsSync']['noPlugins'] );
             install('android', project, 'CLEANYOURSHORTS')
             .fail(function(err){
-                console.log(err);
+                expect(err).toBeUndefined();
             })
             .fin(function () {
                 expect(fetchSpy).toHaveBeenCalled();
@@ -230,7 +230,7 @@ describe('install', function() {
                 return true;
             })
             .fail(function(err){
-                console.log(err);
+                expect(err).toBeUndefined();
             })
             .fin(function () {
                 expect(emit.calls.argsFor(0)[1]).toBe('Notice: org.apache.cordova.device has been automatically converted to cordova-plugin-device and fetched from npm. This is due to our old plugins registry shutting down.');

--- a/cordova-lib/spec-plugman/owner.spec.js
+++ b/cordova-lib/spec-plugman/owner.spec.js
@@ -22,7 +22,7 @@ var owner = require('../src/plugman/owner'),
 
 describe('owner', function() {
     it('should run owner', function() {
-        var sOwner = spyOn(registry, 'owner').andReturn(Q());
+        var sOwner = spyOn(registry, 'owner').and.returnValue(Q());
         var params = ['add', 'anis', 'org.test.plugins.dummyplugin'];
         owner(params);
         expect(sOwner).toHaveBeenCalledWith(params);

--- a/cordova-lib/spec-plugman/owner.spec.js
+++ b/cordova-lib/spec-plugman/owner.spec.js
@@ -21,7 +21,7 @@ var owner = require('../src/plugman/owner'),
     registry = require('../src/plugman/registry/registry');
 
 describe('owner', function() {
-    it('should run owner', function() {
+    it('Test 001 : should run owner', function() {
         var sOwner = spyOn(registry, 'owner').and.returnValue(Q());
         var params = ['add', 'anis', 'org.test.plugins.dummyplugin'];
         owner(params);

--- a/cordova-lib/spec-plugman/platforms/android.spec.js
+++ b/cordova-lib/spec-plugman/platforms/android.spec.js
@@ -49,12 +49,12 @@ function copyArray(arr) {
 
 describe('android project handler', function() {
     describe('www_dir method', function() {
-        it('should return cordova-android project www location using www_dir', function() {
+        it('Test 001 : should return cordova-android project www location using www_dir', function() {
             expect(android.www_dir(path.sep)).toEqual(path.sep + path.join('assets', 'www'));
         });
     });
     describe('package_name method', function() {
-        it('should return an android project\'s proper package name', function() {
+        it('Test 002 : should return an android project\'s proper package name', function() {
             expect(android.package_name(path.join(android_one_project, '..'))).toEqual('com.alunny.childapp');
         });
     });
@@ -67,7 +67,7 @@ describe('android project handler', function() {
             shell.rm('-rf', temp);
         });
         describe('of <lib-file> elements', function() {
-            it('should copy jar files to project/libs', function () {
+            it('Test 003 : should copy jar files to project/libs', function () {
                 var s = spyOn(common, 'copyFile');
 
                 android['lib-file'].install(valid_libs[0], dummyplugin, temp);
@@ -75,7 +75,7 @@ describe('android project handler', function() {
             });
         });
         describe('of <resource-file> elements', function() {
-            it('should copy files', function () {
+            it('Test 004 : should copy files', function () {
                 var s = spyOn(common, 'copyFile');
 
                 android['resource-file'].install(valid_resources[0], dummyplugin, temp);
@@ -87,19 +87,20 @@ describe('android project handler', function() {
                 shell.cp('-rf', android_one_project, temp);
             });
 
-            it('should copy stuff from one location to another by calling common.copyFile', function() {
+            it('Test 005 : should copy stuff from one location to another by calling common.copyFile', function() {
                 var source = copyArray(valid_source);
                 var s = spyOn(common, 'copyFile');
                 android['source-file'].install(source[0], dummyplugin, temp);
                 expect(s).toHaveBeenCalledWith(dummyplugin, 'src/android/DummyPlugin.java', temp, path.join('src', 'com', 'phonegap', 'plugins', 'dummyplugin', 'DummyPlugin.java'), false);
             });
-            it('should throw if source file cannot be found', function() {
+            it('Test 006 : should throw if source file cannot be found', function() {
                 var source = copyArray(invalid_source);
                 expect(function() {
                     android['source-file'].install(source[0], faultyplugin, temp);
-                }).toThrow('"' + path.resolve(faultyplugin, 'src/android/NotHere.java') + '" not found!');
+                    //expect(parser.parse(raw)).toThrow(new Error("Parsing is not possible"));
+                }).toThrow(new Error('"' + path.resolve(faultyplugin, 'src/android/NotHere.java') + '" not found!'));
             });
-            it('should throw if target file already exists', function() {
+            it('Test 007 : should throw if target file already exists', function() {
                 // write out a file
                 var target = path.resolve(temp, 'src/com/phonegap/plugins/dummyplugin');
                 shell.mkdir('-p', target);
@@ -109,7 +110,7 @@ describe('android project handler', function() {
                 var source = copyArray(valid_source);
                 expect(function() {
                     android['source-file'].install(source[0], dummyplugin, temp);
-                }).toThrow('"' + target + '" already exists!');
+                }).toThrow(new Error('"' + target + '" already exists!'));
             });
         });
     });
@@ -122,7 +123,7 @@ describe('android project handler', function() {
             shell.rm('-rf', temp);
             android.purgeProjectFileCache(temp);
         });
-        it('with custom=true', function() {
+        it('Test 008 : with custom=true', function() {
             var packageIdSuffix = 'childapp';
             var frameworkElement = { src: 'plugin-lib', custom: true };
             var mainProjectPropsFile = path.resolve(temp, 'project.properties');
@@ -149,7 +150,7 @@ describe('android project handler', function() {
             expect(finalProjectProperties).not.toMatch('\nandroid.library.reference.3='+dummy_id+'/'+packageIdSuffix+'-plugin-lib', 'Reference to library not added');
             expect(fs.existsSync(subDir)).toBe(false, 'Should delete subdir');
         });
-        it('with custom=true type=gradleReference', function() {
+        it('Test 009 : with custom=true type=gradleReference', function() {
             var packageIdSuffix = 'childapp';
             var frameworkElement = { src: 'extra.gradle', custom: true, type: 'gradleReference'};
             var mainProjectPropsFile = path.resolve(temp, 'project.properties');
@@ -170,7 +171,7 @@ describe('android project handler', function() {
             expect(finalProjectProperties).not.toMatch('\ncordova.gradle.include.1='+dummy_id+'/'+packageIdSuffix+'-extra.gradle', 'Reference to gradle not added');
             expect(fs.existsSync(subDir)).toBe(false, 'Should delete subdir');
         });
-        it('with custom=false pre 4.0', function() {
+        it('Test 010 : with custom=false pre 4.0', function() {
             var packageIdSuffix = 'childapp';
             var frameworkElement = { src: 'extras/android/support/v4', custom: false};
             var mainProjectPropsFile = path.resolve(temp, 'project.properties');
@@ -193,7 +194,7 @@ describe('android project handler', function() {
             finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).not.toMatch('\ncordova.gradle.include.1='+dummy_id+'/'+packageIdSuffix+'-extra.gradle', 'Reference to gradle not added');
         });
-        it('with custom=false post 4.0', function() {
+        it('Test 011 : with custom=false post 4.0', function() {
             var frameworkElement = { src: 'extras/android/support/v4', custom: false};
             var mainProjectPropsFile = path.resolve(temp, 'project.properties');
             fs.writeFileSync(path.join(temp, 'local.properties'), 'sdk.dir=' + path.join(temp, '..', 'SDK'));
@@ -213,7 +214,7 @@ describe('android project handler', function() {
             finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).not.toMatch('\ncordova.system.library.1=' + 'extras/android/support/v4', 'Sublibrary not added');
         });
-        it('with custom=true and parent', function () {
+        it('Test 012 : with custom=true and parent', function () {
             var packageIdSuffix = 'childapp';
             var frameworkElement = { src: 'plugin-lib', custom: true };
             var frameworkElementChild = { src: 'plugin-lib2', custom: true, parent: 'plugin-lib' };
@@ -247,7 +248,7 @@ describe('android project handler', function() {
 
             expect(fs.existsSync(subDir)).toBe(false, 'Should delete subdir');
         });
-        it('with custom=false and parent', function () {
+        it('Test 013 : with custom=false and parent', function () {
             var packageIdSuffix = 'childapp';
             var frameworkElement = { src: 'plugin-lib', custom: true };
             var frameworkElementChild = { src: 'extras/android/support/v4', custom: false, parent: 'plugin-lib' };
@@ -263,7 +264,7 @@ describe('android project handler', function() {
             android.parseProjectFile(temp).write();
             android.parseProjectFile(parentDir).write();
 
-            exec.reset();
+            exec.calls.reset();
 
             var finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
             var libReference = '\nandroid.library.reference.1=' + path.join('..', '..', sdkLibRelativeDir).replace(/\\/g, '/');
@@ -294,16 +295,16 @@ describe('android project handler', function() {
         afterEach(function() {
             shell.rm('-rf', temp);
         });
-        describe('of <lib-file> elements', function(done) {
-            it('should remove jar files', function () {
+        describe('of <lib-file> elements', function() {
+            it('Test 014 : should remove jar files', function () {
                 var s = spyOn(common, 'removeFile');
                 android['lib-file'].install(valid_libs[0], dummyplugin, temp);
                 android['lib-file'].uninstall(valid_libs[0], temp, dummy_id);
                 expect(s).toHaveBeenCalledWith(temp, path.join('libs', 'TestLib.jar'));
             });
         });
-        describe('of <resource-file> elements', function(done) {
-            it('should remove files', function () {
+        describe('of <resource-file> elements', function() {
+            it('Test 015 : should remove files', function () {
                 var s = spyOn(common, 'removeFile');
                 android['resource-file'].install(valid_resources[0], dummyplugin, temp);
                 android['resource-file'].uninstall(valid_resources[0], temp, dummy_id);
@@ -311,7 +312,7 @@ describe('android project handler', function() {
             });
         });
         describe('of <source-file> elements', function() {
-            it('should remove stuff by calling common.deleteJava', function() {
+            it('Test 016 : should remove stuff by calling common.deleteJava', function() {
                 var s = spyOn(common, 'deleteJava');
                 android['source-file'].install(valid_source[0], dummyplugin, temp, dummy_id);
                 var source = copyArray(valid_source);

--- a/cordova-lib/spec-plugman/platforms/blackberry10.spec.js
+++ b/cordova-lib/spec-plugman/platforms/blackberry10.spec.js
@@ -40,13 +40,13 @@ function copyArray(arr) {
 
 describe('blackberry10 project handler', function() {
     describe('www_dir method', function() {
-        it('should return cordova-blackberry10 project www location using www_dir', function() {
+        it('Test 001 : should return cordova-blackberry10 project www location using www_dir', function() {
             expect(blackberry10.www_dir(path.sep)).toEqual(path.sep + 'www');
         });
     });
 
     describe('package_name method', function() {
-        it('should return a blackberry10 project\'s proper package name', function() {
+        it('Test 002 : should return a blackberry10 project\'s proper package name', function() {
             expect(blackberry10.package_name(path.join(blackberry10_project, '..'))).toEqual('cordovaExample');
         });
     });
@@ -60,7 +60,7 @@ describe('blackberry10 project handler', function() {
             shell.rm('-rf', temp);
         });
         describe('of <lib-file> elements', function() {
-            it('should copy so files to native/target/plugins', function () {
+            it('Test 003 : should copy so files to native/target/plugins', function () {
                 var plugin = plugins.echo,
                     libs = copyArray(plugin.getLibFiles('blackberry10')),
                     s = spyOn(common, 'copyFile');
@@ -70,7 +70,7 @@ describe('blackberry10 project handler', function() {
             });
         });
         describe('of <source-file> elements', function() {
-            it('should copy stuff from one location to another by calling common.copyFile', function() {
+            it('Test 004 : should copy stuff from one location to another by calling common.copyFile', function() {
                 var plugin = plugins.echo,
                     source = copyArray(plugin.getSourceFiles('blackberry10')),
                     s = spyOn(common, 'copyFile');
@@ -79,20 +79,20 @@ describe('blackberry10 project handler', function() {
                 expect(s).toHaveBeenCalledWith(plugin.dir, 'src/blackberry10/index.js', temp, path.join('native', 'device', 'chrome', 'plugin', 'com.cordova.echo', 'index.js'), false);
                 expect(s).toHaveBeenCalledWith(plugin.dir, 'src/blackberry10/index.js', temp, path.join('native', 'simulator', 'chrome', 'plugin', 'com.cordova.echo', 'index.js'), false);
             });
-            it('defaults to plugin id when dest is not present', function() {
+            it('Test 005 : defaults to plugin id when dest is not present', function() {
                 var source = copyArray(plugins.dummy.getSourceFiles('blackberry10'));
                 var s = spyOn(common, 'copyFile');
                 blackberry10['source-file'].install(source[0], plugins.dummy.dir, temp, plugins.dummy.id);
                 expect(s).toHaveBeenCalledWith(plugins.dummy.dir, 'src/blackberry10/index.js', temp, path.join('native', 'device', 'chrome', 'plugin', plugins.dummy.id, 'index.js'), false);
                 expect(s).toHaveBeenCalledWith(plugins.dummy.dir, 'src/blackberry10/index.js', temp, path.join('native', 'simulator', 'chrome', 'plugin', plugins.dummy.id, 'index.js'), false);
             });
-            it('should throw if source file cannot be found', function() {
+            it('Test 006 : should throw if source file cannot be found', function() {
                 var source = copyArray(plugins.faulty.getSourceFiles('blackberry10'));
                 expect(function() {
                     blackberry10['source-file'].install(source[0], plugins.faulty.dir, temp, plugins.faulty.id);
-                }).toThrow('"' + path.resolve(plugins.faulty.dir, 'src/blackberry10/index.js') + '" not found!');
+                }).toThrow(new Error ('"' + path.resolve(plugins.faulty.dir, 'src/blackberry10/index.js') + '" not found!'));
             });
-            it('should throw if target file already exists', function() {
+            it('Test 007 : should throw if target file already exists', function() {
                 // write out a file
                 var target = path.resolve(temp, 'native/device/chrome/plugin/org.test.plugins.dummyplugin');
                 shell.mkdir('-p', target);
@@ -102,7 +102,7 @@ describe('blackberry10 project handler', function() {
                 var source = copyArray(plugins.dummy.getSourceFiles('blackberry10'));
                 expect(function() {
                     blackberry10['source-file'].install(source[0], plugins.dummy.dir, temp, plugins.dummy.id);
-                }).toThrow('"' + target + '" already exists!');
+                }).toThrow(new Error ('"' + target + '" already exists!'));
             });
         });
     });
@@ -116,7 +116,7 @@ describe('blackberry10 project handler', function() {
             shell.rm('-rf', temp);
         });
         describe('of <source-file> elements', function() {
-            it('should remove stuff by calling common.removeFile', function() {
+            it('Test 008 : should remove stuff by calling common.removeFile', function() {
                 var s = spyOn(common, 'removeFile'),
                     plugin = plugins.echo;
                 var source = copyArray(plugin.getSourceFiles('blackberry10'));
@@ -125,7 +125,7 @@ describe('blackberry10 project handler', function() {
                 expect(s).toHaveBeenCalledWith(temp, path.join('native', 'device', 'chrome', 'plugin', 'com.cordova.echo', 'index.js'));
                 expect(s).toHaveBeenCalledWith(temp, path.join('native', 'simulator', 'chrome', 'plugin', 'com.cordova.echo', 'index.js'));
             });
-            it('should remove stuff by calling common.removeFile', function() {
+            it('Test 009 : should remove stuff by calling common.removeFile', function() {
                 var s = spyOn(common, 'removeFile'),
                     plugin = plugins.dummy;
                 var source = copyArray(plugin.getSourceFiles('blackberry10'));
@@ -135,8 +135,8 @@ describe('blackberry10 project handler', function() {
                 expect(s).toHaveBeenCalledWith(temp, path.join('native', 'simulator', 'chrome', 'plugin', plugin.id, 'index.js'));
             });
         });
-        describe('of <lib-file> elements', function(done) {
-            it('should remove so files from www/plugins', function () {
+        describe('of <lib-file> elements', function() {
+            it('Test 010 : should remove so files from www/plugins', function () {
                 var s = spyOn(common, 'removeFile'),
                     plugin = plugins.echo;
                 var source = copyArray(plugin.getLibFiles('blackberry10'));

--- a/cordova-lib/spec-plugman/platforms/common.spec.js
+++ b/cordova-lib/spec-plugman/platforms/common.spec.js
@@ -36,7 +36,7 @@ var common = require('../../src/plugman/platforms/common')
 
 describe('common platform handler', function() {
     describe('resolveSrcPath', function() {
-        it('should not throw if path exists', function(){
+        it('Test 001 : should not throw if path exists', function(){
             shell.mkdir('-p', test_dir);
             var target = path.join(test_dir, 'somefile');
             fs.writeFileSync(target, '80085', 'utf-8');
@@ -46,24 +46,24 @@ describe('common platform handler', function() {
     });
 
     describe('resolveTargetPath', function() {
-        it('should throw if path exists', function(){
+        it('Test 002 : should throw if path exists', function(){
             shell.mkdir('-p', test_dir);
             expect(function(){common.resolveTargetPath(test_dir);}).toThrow();
             shell.rm('-rf', test_dir);
         });
 
-        it('should not throw if path cannot be resolved', function(){
+        it('Test 003 : should not throw if path cannot be resolved', function(){
             expect(function(){common.resolveTargetPath(test_dir, 'somefile');}).not.toThrow();
         });
     });
 
     describe('copyFile', function() {
-        it('should throw if source path not found', function(){
+        it('Test 004 : should throw if source path not found', function(){
             expect(function(){common.copyFile(test_dir, src, project_dir, dest);}).
                 toThrow(new Error('"' + src + '" not found!'));
         });
 
-        it('should throw if src not in plugin directory', function(){
+        it('Test 005 : should throw if src not in plugin directory', function(){
             shell.mkdir('-p', project_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
             expect(function(){common.copyFile(test_dir, '../non_plugin_file', project_dir, dest);}).
@@ -71,7 +71,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', test_dir);
         });
 
-        it('should allow symlink src, if inside plugin', function(){
+        it('Test 006 : should allow symlink src, if inside plugin', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
@@ -84,7 +84,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should deeply symlink directory tree when src is a directory', function(){
+        it('Test 007 : should deeply symlink directory tree when src is a directory', function(){
             var symlink_dir_relative_subdir = path.dirname(symlink_dir_relative_file);
 
             shell.mkdir('-p', path.join(symlink_dir, symlink_dir_relative_subdir));
@@ -102,7 +102,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should throw if symlink is linked to a file outside the plugin', function(){
+        it('Test 008 : should throw if symlink is linked to a file outside the plugin', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');
 
@@ -116,7 +116,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should throw if dest is outside the project directory', function(){
+        it('Test 009 : should throw if dest is outside the project directory', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
             expect(function(){common.copyFile(test_dir, java_file, project_dir, non_plugin_file);}).
@@ -124,11 +124,11 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should call mkdir -p on target path', function(){
+        it('Test 010 : should call mkdir -p on target path', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(shell, 'mkdir').andCallThrough();
+            var s = spyOn(shell, 'mkdir').and.callThrough();
             var resolvedDest = common.resolveTargetPath(project_dir, dest);
 
             common.copyFile(test_dir, java_file, project_dir, dest);
@@ -138,11 +138,11 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
-        it('should call cp source/dest paths', function(){
+        it('Test 011 : should call cp source/dest paths', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(shell, 'cp').andCallThrough();
+            var s = spyOn(shell, 'cp').and.callThrough();
             var resolvedDest = common.resolveTargetPath(project_dir, dest);
 
             common.copyFile(test_dir, java_file, project_dir, dest);
@@ -156,7 +156,7 @@ describe('common platform handler', function() {
     });
 
     describe('copyNewFile', function () {
-        it('should throw if target path exists', function(){
+        it('Test 012 : should throw if target path exists', function(){
             shell.mkdir('-p', dest);
             expect(function(){common.copyNewFile(test_dir, src, project_dir, dest);}).
                 toThrow(new Error('"' + dest + '" already exists!'));
@@ -166,11 +166,11 @@ describe('common platform handler', function() {
     });
 
     describe('deleteJava', function() {
-        it('should call fs.unlinkSync on the provided paths', function(){
+        it('Test 013 : should call fs.unlinkSync on the provided paths', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
-            var s = spyOn(fs, 'unlinkSync').andCallThrough();
+            var s = spyOn(fs, 'unlinkSync').and.callThrough();
             common.deleteJava(project_dir, java_file);
             expect(s).toHaveBeenCalled();
             expect(s).toHaveBeenCalledWith(path.resolve(project_dir, java_file));
@@ -178,7 +178,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', java_dir);
         });
 
-        it('should delete empty directories after removing source code in a java src path hierarchy', function(){
+        it('Test 014 : should delete empty directories after removing source code in a java src path hierarchy', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 
@@ -190,7 +190,7 @@ describe('common platform handler', function() {
             shell.rm('-rf', java_dir);
         });
 
-        it('should never delete the top-level src directory, even if all plugins added were removed', function(){
+        it('Test 015 : should never delete the top-level src directory, even if all plugins added were removed', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(java_file, 'contents', 'utf-8');
 

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -61,10 +61,6 @@ function copyArray(arr) {
     return Array.prototype.slice.call(arr, 0);
 }
 
-function installPromise(f) {
-    f.then(function(res) { done = true; }, function(err) { done = err; });
-}
-
 function slashJoin() {
     // In some places we need to use forward slash instead of path.join().
     // See CB-7311.
@@ -311,7 +307,7 @@ describe('ios project handler', function() {
                 expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBeTruthy();
                 done();
             }).then(function () {
-                return install('ios', temp, dummyplugin)
+                return install('ios', temp, dummyplugin);
             }).then(function () {
                 var xcode = ios.parseProjectFile(temp).xcode;
                 // from org.test.plugins.dummyplugin

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -82,40 +82,40 @@ describe('ios project handler', function() {
     });
 
     describe('www_dir method', function() {
-        it('should return cordova-ios project www location using www_dir', function() {
+        it('Test 001 : should return cordova-ios project www location using www_dir', function() {
             expect(ios.www_dir(path.sep)).toEqual(path.sep + 'www');
         });
     });
 
     describe('package_name method', function() {
-        it('should return the CFBundleIdentifier from the project\'s Info.plist file', function() {
+        it('Test 002 : should return the CFBundleIdentifier from the project\'s Info.plist file', function() {
             expect(ios.package_name(ios_project)).toEqual('com.example.friendstring');
         });
     });
 
     describe('parseProjectFile method', function () {
-        it('should throw if project is not an xcode project', function() {
+        it('Test 003 : should throw if project is not an xcode project', function() {
             expect(function() {
                 ios.parseProjectFile(temp);
-            }).toThrow('does not appear to be an xcode project (no xcode project file)');
+            }).toThrow(new Error ('does not appear to be an xcode project (no xcode project file)'));
         });
-        it('should throw if project does not contain an appropriate config.xml file', function() {
+        it('Test 004 : should throw if project does not contain an appropriate config.xml file', function() {
             shell.cp('-rf', ios_config_xml_project, temp);
             shell.rm(path.join(temp, 'SampleApp', 'config.xml'));
 
             expect(function() {
                 ios.parseProjectFile(temp);
-            }).toThrow('could not find -Info.plist file, or config.xml file.');
+            }).toThrow(new Error ('could not find -Info.plist file, or config.xml file.'));
         });
-        it('should throw if project does not contain an appropriate -Info.plist file', function() {
+        it('Test 005 : should throw if project does not contain an appropriate -Info.plist file', function() {
             shell.cp('-rf', ios_config_xml_project, temp);
             shell.rm(path.join(temp, 'SampleApp', 'SampleApp-Info.plist'));
 
             expect(function () {
                 ios.parseProjectFile(temp);
-            }).toThrow('could not find -Info.plist file, or config.xml file.');
+            }).toThrow(new Error ('could not find -Info.plist file, or config.xml file.'));
         });
-        it('should return right directory when multiple .plist files are present', function() {
+        it('Test 006 : should return right directory when multiple .plist files are present', function() {
             shell.cp('-rf', ios_config_xml_project, temp);
             //Create a folder named A with config.xml and .plist files in it
             var pathToFolderA = path.join(temp, 'A');
@@ -144,13 +144,13 @@ describe('ios project handler', function() {
         });
 
         describe('of <source-file> elements', function() {
-            it('should throw if source-file src cannot be found', function() {
+            it('Test 006 : should throw if source-file src cannot be found', function() {
                 var source = copyArray(invalid_source);
                 expect(function() {
                     ios['source-file'].install(source[1], faultyplugin, temp, faulty_id, null, proj_files);
                 }).toThrow();
             });
-            it('should throw if source-file target already exists', function() {
+            it('Test 007 : should throw if source-file target already exists', function() {
                 var source = copyArray(valid_source);
                 var target = path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.m');
                 shell.mkdir('-p', path.dirname(target));
@@ -159,13 +159,13 @@ describe('ios project handler', function() {
                     ios['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
                 }).toThrow();
             });
-            it('should call into xcodeproj\'s addSourceFile appropriately when element has no target-dir', function() {
+            it('Test 008 : should call into xcodeproj\'s addSourceFile appropriately when element has no target-dir', function() {
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir === undefined; });
                 var spy = spyOn(proj_files.xcode, 'addSourceFile');
                 ios['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.m'), {});
             });
-            it('should call into xcodeproj\'s addSourceFile appropriately when element has a target-dir', function() {
+            it('Test 009 : should call into xcodeproj\'s addSourceFile appropriately when element has a target-dir', function() {
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir !== undefined; });
                 var spy = spyOn(proj_files.xcode, 'addSourceFile');
                 ios['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
@@ -177,13 +177,13 @@ describe('ios project handler', function() {
                 ios['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPluginCommand.m'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.m'));
             });
-            it('should cp the file to the right target location when element has a target-dir', function() {
+            it('Test 010 : should cp the file to the right target location when element has a target-dir', function() {
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir !== undefined; });
                 var spy = spyOn(shell, 'cp');
                 ios['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'TargetDirTest.m'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir', 'TargetDirTest.m'));
             });
-            it('should call into xcodeproj\'s addFramework appropriately when element has framework=true set', function() {
+            it('Test 011 : should call into xcodeproj\'s addFramework appropriately when element has framework=true set', function() {
                 var source = copyArray(valid_source).filter(function(s) { return s.framework; });
                 spyOn(proj_files.xcode, 'addSourceFile');
                 var spy = spyOn(proj_files.xcode, 'addFramework');
@@ -193,13 +193,13 @@ describe('ios project handler', function() {
         });
 
         describe('of <header-file> elements', function() {
-            it('should throw if header-file src cannot be found', function() {
+            it('Test 012 : should throw if header-file src cannot be found', function() {
                 var headers = copyArray(invalid_headers);
                 expect(function() {
                     ios['header-file'].install(headers[1], faultyplugin, temp, faulty_id, null, proj_files);
                 }).toThrow();
             });
-            it('should throw if header-file target already exists', function() {
+            it('Test 013 : should throw if header-file target already exists', function() {
                 var headers = copyArray(valid_headers);
                 var target = path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.h');
                 shell.mkdir('-p', path.dirname(target));
@@ -208,25 +208,25 @@ describe('ios project handler', function() {
                     ios['header-file'].install(headers[0], dummyplugin, temp, dummy_id, null, proj_files);
                 }).toThrow();
             });
-            it('should call into xcodeproj\'s addHeaderFile appropriately when element has no target-dir', function() {
+            it('Test 014 : should call into xcodeproj\'s addHeaderFile appropriately when element has no target-dir', function() {
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir === undefined; });
                 var spy = spyOn(proj_files.xcode, 'addHeaderFile');
                 ios['header-file'].install(headers[0], dummyplugin, temp, dummy_id,  null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('should call into xcodeproj\'s addHeaderFile appropriately when element a target-dir', function() {
+            it('Test 015 : should call into xcodeproj\'s addHeaderFile appropriately when element a target-dir', function() {
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir !== undefined; });
                 var spy = spyOn(proj_files.xcode, 'addHeaderFile');
                 ios['header-file'].install(headers[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.h'));
             });
-            it('should cp the file to the right target location when element has no target-dir', function() {
+            it('Test 016 : should cp the file to the right target location when element has no target-dir', function() {
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir === undefined; });
                 var spy = spyOn(shell, 'cp');
                 ios['header-file'].install(headers[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith('-f', path.join(dummyplugin, 'src', 'ios', 'DummyPluginCommand.h'), path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('should cp the file to the right target location when element has a target-dir', function() {
+            it('Test 017 : should cp the file to the right target location when element has a target-dir', function() {
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir !== undefined; });
                 var spy = spyOn(shell, 'cp');
                 ios['header-file'].install(headers[0], dummyplugin, temp, dummy_id, null, proj_files);
@@ -235,28 +235,28 @@ describe('ios project handler', function() {
         });
 
         describe('of <resource-file> elements', function() {
-            it('should throw if resource-file src cannot be found', function() {
+            it('Test 018 : should throw if resource-file src cannot be found', function() {
                 var resources = copyArray(invalid_resources);
                 expect(function() {
                     ios['resource-file'].install(resources[0], faultyplugin, temp, 'pluginid', null, proj_files);
-                }).toThrow('cannot find "' + path.resolve(faultyplugin, 'src/ios/IDontExist.bundle') + '" ios <resource-file>');
+                }).toThrow(new Error ('cannot find "' + path.resolve(faultyplugin, 'src/ios/IDontExist.bundle') + '" ios <resource-file>'));
             });
-            it('should throw if resource-file target already exists', function() {
+            it('Test 019 : should throw if resource-file target already exists', function() {
                 var resources = copyArray(valid_resources);
                 var target = path.join(temp, 'SampleApp', 'Resources', 'DummyPlugin.bundle');
                 shell.mkdir('-p', path.dirname(target));
                 fs.writeFileSync(target, 'some bs', 'utf-8');
                 expect(function() {
                     ios['resource-file'].install(resources[0], dummyplugin, temp, 'pluginid',null, proj_files);
-                }).toThrow('target destination "' + target + '" already exists');
+                }).toThrow(new Error ('target destination "' + target + '" already exists'));
             });
-            it('should call into xcodeproj\'s addResourceFile', function() {
+            it('Test 020 : should call into xcodeproj\'s addResourceFile', function() {
                 var resources = copyArray(valid_resources);
                 var spy = spyOn(proj_files.xcode, 'addResourceFile');
                 ios['resource-file'].install(resources[0], dummyplugin, temp, 'pluginid', null, proj_files);
                 expect(spy).toHaveBeenCalledWith(path.join('Resources', 'DummyPlugin.bundle'));
             });
-            it('should cp the file to the right target location', function() {
+            it('Test 021 : should cp the file to the right target location', function() {
                 var resources = copyArray(valid_resources);
                 var spy = spyOn(shell, 'cp');
                 ios['resource-file'].install(resources[0], dummyplugin, temp, 'pluginid', null, proj_files);
@@ -265,7 +265,7 @@ describe('ios project handler', function() {
         });
         describe('of <framework> elements', function() {
 
-            it('should call into xcodeproj\'s addFramework', function() {
+            it('Test 022 : should call into xcodeproj\'s addFramework', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
@@ -277,21 +277,21 @@ describe('ios project handler', function() {
             // * framework that shouldn't be added/removed
 
             describe('with custom="true" attribute', function () {
-                it('should throw if framework src cannot be found', function() {
+                it('Test 023 : should throw if framework src cannot be found', function() {
                     var frameworks = copyArray(invalid_custom_frameworks);
                     expect(function() {
                         ios['framework'].install(frameworks[0], faultyplugin, temp, dummy_id, null, proj_files);
-                    }).toThrow('cannot find "' + path.resolve(faultyplugin, 'src/ios/NonExistantCustomFramework.framework') + '" ios <framework>');
+                    }).toThrow(new Error ('cannot find "' + path.resolve(faultyplugin, 'src/ios/NonExistantCustomFramework.framework') + '" ios <framework>'));
                 });
-                it('should throw if framework target already exists', function() {
+                it('Test 024 : should throw if framework target already exists', function() {
                     var frameworks = copyArray(valid_custom_frameworks);
                     var target = path.join(temp, 'SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework');
                     shell.mkdir('-p', target);
                     expect(function() {
                         ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                    }).toThrow('target destination "' + target + '" already exists');
+                    }).toThrow(new Error ('target destination "' + target + '" already exists'));
                 });
-                it('should cp the file to the right target location', function() {
+                it('Test 025 : should cp the file to the right target location', function() {
                     var frameworks = copyArray(valid_custom_frameworks);
                     var spy = spyOn(shell, 'cp');
                     ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
@@ -300,15 +300,19 @@ describe('ios project handler', function() {
                 });
             });
         });
-        it('of two plugins should apply xcode file changes from both', function(){
-            runs(function() {
-                installPromise(
-                    install('ios', temp, dummyplugin)
-                    .then(function () { install('ios', temp, weblessplugin); })
-                );
-            });
-            waitsFor(function() { return done; }, 'install promise never resolved', 200);
-            runs(function() {
+        it('Test 026 : of two plugins should apply xcode file changes from both', function(done){
+            return install('ios', temp, weblessplugin)
+            .then(function (result) { 
+                var xcode = ios.parseProjectFile(temp).xcode;
+                // from org.test.plugins.weblessplugin
+                expect(xcode.hasFile(slashJoin('Resources', 'WeblessPluginViewController.xib'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.h'))).toBeTruthy();
+                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.m'))).toBeTruthy();
+                expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBeTruthy();
+                done();
+            }).then(function () {
+                return install('ios', temp, dummyplugin)
+            }).then(function () {
                 var xcode = ios.parseProjectFile(temp).xcode;
                 // from org.test.plugins.dummyplugin
                 expect(xcode.hasFile(slashJoin('Resources', 'DummyPlugin.bundle'))).toBeTruthy();
@@ -317,32 +321,28 @@ describe('ios project handler', function() {
                 expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.h'))).toBeTruthy();
                 expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.dummyplugin','targetDir','TargetDirTest.m'))).toBeTruthy();
                 expect(xcode.hasFile(slashJoin('SampleApp','Plugins','org.test.plugins.dummyplugin','Custom.framework'))).toBeTruthy();
-                // from org.test.plugins.weblessplugin
-                expect(xcode.hasFile(slashJoin('Resources', 'WeblessPluginViewController.xib'))).toBeTruthy();
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.h'))).toBeTruthy();
-                expect(xcode.hasFile(slashJoin('Plugins','org.test.plugins.weblessplugin','WeblessPluginCommand.m'))).toBeTruthy();
-                expect(xcode.hasFile('usr/lib/libsqlite3.dylib')).toBeTruthy();
+                done();
             });
-        });
+        }, 60000);
     });
 
     describe('uninstallation', function() {
         describe('of <source-file> elements', function() {
-            it('should call into xcodeproj\'s removeSourceFile appropriately when element has no target-dir', function(){
+            it('Test 027 : should call into xcodeproj\'s removeSourceFile appropriately when element has no target-dir', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir === undefined; });
                 shell.cp('-rf', ios_config_xml_project, temp);
                 var spy = spyOn(proj_files.xcode, 'removeSourceFile');
                 ios['source-file'].uninstall(source[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.m'));
             });
-            it('should call into xcodeproj\'s removeSourceFile appropriately when element a target-dir', function(){
+            it('Test 028 : should call into xcodeproj\'s removeSourceFile appropriately when element a target-dir', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir !== undefined; });
                 shell.cp('-rf', ios_config_xml_project, temp);
                 var spy = spyOn(proj_files.xcode, 'removeSourceFile');
                 ios['source-file'].uninstall(source[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.m'));
             });
-            it('should rm the file from the right target location when element has no target-dir', function(){
+            it('Test 029 : should rm the file from the right target location when element has no target-dir', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir === undefined; });
                 shell.cp('-rf', ios_config_xml_project, temp);
 
@@ -350,7 +350,7 @@ describe('ios project handler', function() {
                 ios['source-file'].uninstall(source[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id));
             });
-            it('should rm the file from the right target location when element has a target-dir', function(){
+            it('Test 030 : should rm the file from the right target location when element has a target-dir', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.targetDir !== undefined; });
                 shell.cp('-rf', ios_config_xml_project, temp);
                 var spy = spyOn(shell, 'rm');
@@ -358,7 +358,7 @@ describe('ios project handler', function() {
                 ios['source-file'].uninstall(source[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'targetDir'));
             });
-            it('should call into xcodeproj\'s removeFramework appropriately when element framework=true set', function(){
+            it('Test 031 : should call into xcodeproj\'s removeFramework appropriately when element framework=true set', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.framework; });
                 shell.cp('-rf', ios_config_xml_project, temp);
                 var spy = spyOn(proj_files.xcode, 'removeFramework');
@@ -372,14 +372,14 @@ describe('ios project handler', function() {
             beforeEach(function() {
                 shell.cp('-rf', ios_config_xml_project, temp);
             });
-            it('should call into xcodeproj\'s removeHeaderFile appropriately when element has no target-dir', function(){
+            it('Test 032 : should call into xcodeproj\'s removeHeaderFile appropriately when element has no target-dir', function(){
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir === undefined; });
                 var spy = spyOn(proj_files.xcode, 'removeHeaderFile');
 
                 ios['header-file'].uninstall(headers[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'DummyPluginCommand.h'));
             });
-            it('should call into xcodeproj\'s removeHeaderFile appropriately when element a target-dir', function(){
+            it('Test 033 : should call into xcodeproj\'s removeHeaderFile appropriately when element a target-dir', function(){
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir !== undefined; });
 
                 var spy = spyOn(proj_files.xcode, 'removeHeaderFile');
@@ -387,7 +387,7 @@ describe('ios project handler', function() {
                 ios['header-file'].uninstall(headers[0], temp, dummy_id, null, proj_files);
                 expect(spy).toHaveBeenCalledWith(slashJoin('Plugins', dummy_id, 'targetDir', 'TargetDirTest.h'));
             });
-            it('should rm the file from the right target location', function(){
+            it('Test 034 : should rm the file from the right target location', function(){
                 var headers = copyArray(valid_headers).filter(function(s) { return s.targetDir !== undefined; });
                 var spy = spyOn(shell, 'rm');
 
@@ -400,14 +400,14 @@ describe('ios project handler', function() {
             beforeEach(function() {
                 shell.cp('-rf', ios_config_xml_project, temp);
             });
-            it('should call into xcodeproj\'s removeResourceFile', function(){
+            it('Test 035 : should call into xcodeproj\'s removeResourceFile', function(){
                 var resources = copyArray(valid_resources);
                 var spy = spyOn(proj_files.xcode, 'removeResourceFile');
 
                 ios['resource-file'].uninstall(resources[0], temp, 'pluginid', null, proj_files);
                 expect(spy).toHaveBeenCalledWith(path.join('Resources', 'DummyPlugin.bundle'));
             });
-            it('should rm the file from the right target location', function(){
+            it('Test 036 : should rm the file from the right target location', function(){
                 var resources = copyArray(valid_resources);
                 var spy = spyOn(shell, 'rm');
 
@@ -420,7 +420,7 @@ describe('ios project handler', function() {
                 shell.cp('-rf', ios_config_xml_project, temp);
             });
 
-            it('should call into xcodeproj\'s removeFramework', function(){
+            it('Test 037 : should call into xcodeproj\'s removeFramework', function(){
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'removeFramework');
 
@@ -433,7 +433,7 @@ describe('ios project handler', function() {
             // * framework that shouldn't be added/removed
 
             describe('with custom="true" attribute', function () {
-                it('should rm the file from the right target location', function(){
+                it('Test 038 : should rm the file from the right target location', function(){
                     var frameworks = copyArray(valid_custom_frameworks);
                     var spy = spyOn(shell, 'rm');
 

--- a/cordova-lib/spec-plugman/platforms/tizen.spec.js
+++ b/cordova-lib/spec-plugman/platforms/tizen.spec.js
@@ -37,13 +37,13 @@ var tizen = require('../../src/plugman/platforms/tizen'),
 
 describe('Tizen project handler', function() {
 	describe('www_dir method', function() {
-		it('should append www to the directory passed in', function() {
+		it('Test 001 : should append www to the directory passed in', function() {
 			expect(tizen.www_dir(path.sep)).toEqual(path.join(path.sep, 'www'));
 		});
 	});
 	describe('Manipulating project files', function() {
 		describe('package_name method', function() {
-			it('should return the id of the config.xml root element', function() {
+			it('Test 002 : should return the id of the config.xml root element', function() {
 				expect(tizen.package_name(tizen_project)).toEqual('TizenTestPackage');
 			});
 		});

--- a/cordova-lib/spec-plugman/platforms/windows.spec.js
+++ b/cordova-lib/spec-plugman/platforms/windows.spec.js
@@ -131,8 +131,6 @@ beforeEach(function () {
             });
 
             function validateInstalledProjects(tag, elementToInstall, xpath, supportedPlatforms) {
-                //jasmine.getEnv().currentSpec.removeAllSpies();
-                
 
                 var projects = copyArray(proj_files.projects);
                 if (platform === 'windows') {
@@ -203,12 +201,10 @@ beforeEach(function () {
 
                 projectsAddedToSpies.forEach(function (spy) {
                     expect(spy).toHaveBeenCalled();
-                    spy.calls.reset();
                 });
 
                 projectsNotAddedToSpies.forEach(function (spy) {
                     expect(spy).not.toHaveBeenCalled();
-                    spy.calls.reset();
                 });
             }
 
@@ -452,12 +448,10 @@ beforeEach(function () {
 
                 projectsAddedToSpies.forEach(function (spy) {
                     expect(spy).toHaveBeenCalledWith(xmlPath, incText, targetConditions);
-                    spy.calls.reset();
                 });
 
                 projectsNotAddedToSpies.forEach(function (spy) {
                     expect(spy).not.toHaveBeenCalled();
-                    spy.calls.reset();
                 });
             }
 

--- a/cordova-lib/spec-plugman/platforms/windows.spec.js
+++ b/cordova-lib/spec-plugman/platforms/windows.spec.js
@@ -65,7 +65,7 @@ beforeEach(function () {
                     }
                     return result;
                 }
-            }
+            };
         }
     }); 
 });
@@ -487,7 +487,6 @@ beforeEach(function () {
                             var incText = resourcefiles[0].target;
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
                             validateUninstalledProjects('resource-file', resourcefiles[0], path, incText, targetConditions, ['all']);
-
                             done();
                         });
                 });
@@ -497,11 +496,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Content';
-
-                            incText = resourcefiles[1].target;
-                            targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                            var incText = resourcefiles[1].target;
+                            var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('resource-file', resourcefiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
-
                             done();
                         });
                 });
@@ -511,11 +508,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Content';
-
-                            incText = resourcefiles[2].target;
-                            targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                            var incText = resourcefiles[2].target;
+                            var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('resource-file', resourcefiles[2], path, incText, targetConditions, ['phone']);
-
                             done();
                         });
                 });
@@ -525,10 +520,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Content';
-                            incText = resourcefiles[3].target;
-                            targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x64'};
+                            var incText = resourcefiles[3].target;
+                            var targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x64'};
                             validateUninstalledProjects('resource-file', resourcefiles[3], path, incText, targetConditions, ['windows8']);
-
                             done();
                         });
                 });
@@ -556,8 +550,8 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/SDKReference';
-                            incText = 'TestSDK2, Version=1.0';
-                            targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                            var incText = 'TestSDK2, Version=1.0';
+                            var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
                             done();
                         });
@@ -569,10 +563,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/SDKReference';
-                            incText = 'TestSDK3, Version=1.0';
-                            targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                            var incText = 'TestSDK3, Version=1.0';
+                            var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[2], path, incText, targetConditions, ['phone']);
-
                             done();
                         });
                 });
@@ -583,10 +576,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/SDKReference';
-                            incText = 'TestSDK4, Version=1.0';
-                            targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x86'};
+                            var incText = 'TestSDK4, Version=1.0';
+                            var targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x86'};
                             validateUninstalledProjects('lib-file', libfiles[3], path, incText, targetConditions, ['windows8']);
-
                             done();
                         });
                 });
@@ -604,7 +596,6 @@ beforeEach(function () {
                             var incText = 'dummy1';
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                             validateUninstalledProjects('framework', frameworks[0], path, incText, targetConditions, ['all']);
-
                             done();
                         });
                 }, 6000);
@@ -615,10 +606,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Reference';
-                            incText = 'dummy2';
-                            targetConditions = {versions: '>=8.0', deviceTarget: undefined, arch: undefined};
+                            var incText = 'dummy2';
+                            var targetConditions = {versions: '>=8.0', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[1], path, incText, targetConditions, ['all']);
-
                             done();
                         });
                 }, 6000);
@@ -629,10 +619,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Reference';
-                            incText = 'dummy3';
-                            targetConditions = {versions: undefined, deviceTarget: 'windows', arch: undefined};
+                            var incText = 'dummy3';
+                            var targetConditions = {versions: undefined, deviceTarget: 'windows', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[2], path, incText, targetConditions, ['windows', 'windows8', 'windows10']);
-
                             done();
                         });
                 }, 6000);
@@ -643,10 +632,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Reference';
-                            incText = 'dummy4';
-                            targetConditions = {versions: '8.1', deviceTarget: 'phone', arch: 'ARM'};
+                            var incText = 'dummy4';
+                            var targetConditions = {versions: '8.1', deviceTarget: 'phone', arch: 'ARM'};
                             validateUninstalledProjects('framework', frameworks[3], path, incText, targetConditions, ['phone']);
-
                             done();
                         });
                 }, 6000);
@@ -657,10 +645,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Reference';
-                            incText = 'dummy5';
-                            targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
+                            var incText = 'dummy5';
+                            var targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[4], path, incText, targetConditions, ['phone']);
-
                             done();
                         });
                 }, 6000);
@@ -671,10 +658,9 @@ beforeEach(function () {
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var path = 'ItemGroup/Reference';
-                            incText = 'dummy6';
-                            targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
+                            var incText = 'dummy6';
+                            var targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[5], path, incText, targetConditions, ['windows', 'windows10', 'phone']);
-
                             done();
                         });
                 }, 6000);
@@ -703,7 +689,7 @@ beforeEach(function () {
                         .then(function () {
                             var xmlPath = 'ItemGroup/ProjectReference';
                             var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy2.vcxproj');
-                            targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
+                            var targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[7], xmlPath, incText, targetConditions, ['windows8']);
                             done();
                         });
@@ -716,9 +702,8 @@ beforeEach(function () {
                         .then(function () {
                             var xmlPath = 'ItemGroup/ProjectReference';
                             var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy3.vcxproj');
-                            targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
+                            var targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[8], xmlPath, incText, targetConditions, ['windows', 'windows8', 'windows10']);
-
                             done();
                         });
                 }, 60000);
@@ -730,7 +715,7 @@ beforeEach(function () {
                         .then(function () {
                             var xmlPath = 'ItemGroup/ProjectReference';
                             var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy4.vcxproj');
-                            targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
+                            var targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
                             validateUninstalledProjects('framework', frameworks[9], xmlPath, incText, targetConditions, ['windows', 'phone']);
                             done();
                         });

--- a/cordova-lib/spec-plugman/platforms/windows.spec.js
+++ b/cordova-lib/spec-plugman/platforms/windows.spec.js
@@ -50,18 +50,25 @@ function copyArray(arr) {
 }
 
 beforeEach(function () {
-    this.addMatchers({
-        toContainXmlPath: function (xpath) {
-            var xml = this.actual;
-            var notText = this.isNot ? 'not ' : '';
-            this.message = function () {
-                return 'Expected xml \'' + et.tostring(xml) + '\' ' + notText + 'to contain elements matching \'' + xpath + '\'.';
-            };
+    jasmine.addMatchers({
+        toContainXmlPath: function () {
+            return {
+                compare: function(actual, expected) {
+                    var xml = actual;
+                    var result = {};
+                    result.pass = xml.find(expected) !== null;
 
-            return xml.find(xpath) !== null;
-        }    });
+                    if(result.pass) {
+                        result.message = 'Expected xml \'' + et.tostring(xml) + '\' ' +' not to contain elements matching \'' + expected + '\'.';
+                    } else {
+                        result.message = 'Expected xml \'' + et.tostring(xml) + '\' ' +' to contain elements matching \'' + expected + '\'.';
+                    }
+                    return result;
+                }
+            }
+        }
+    }); 
 });
-
 ['windows', 'windows8'].forEach(function (platform) {
     var windows_project = path.join(__dirname, '..', 'projects', platform);
 
@@ -93,21 +100,24 @@ beforeEach(function () {
         });
 
         describe('www_dir method', function () {
-            it('should return cordova-windows project www location using www_dir', function () {
+            it('Test 001 : should return cordova-windows project www location using www_dir', function (done) {
                 expect(windows.www_dir(path.sep)).toEqual(path.sep + 'www');
+                done();
             });
         });
         describe('package_name method', function () {
-            it('should return a windows project\'s proper package name', function () {
+            it('Test 002 : should return a windows project\'s proper package name', function (done) {
                 expect(windows.package_name(windows_project)).toEqual('CordovaApp');
+                done();
             });
         });
 
         describe('parseProjectFile method', function () {
-            it('should throw if project is not an windows project', function () {
+            it('Test 003 : should throw if project is not an windows project', function (done) {
                 expect(function () {
                     windows.parseProjectFile(cordovaProjectWindowsPlatformDir);
-                }).toThrow(windows.InvalidProjectPathError);
+                }).toThrow(new Error (windows.InvalidProjectPathError));
+                done();
             });
         });
 
@@ -121,7 +131,8 @@ beforeEach(function () {
             });
 
             function validateInstalledProjects(tag, elementToInstall, xpath, supportedPlatforms) {
-                jasmine.getEnv().currentSpec.removeAllSpies();
+                //jasmine.getEnv().currentSpec.removeAllSpies();
+                
 
                 var projects = copyArray(proj_files.projects);
                 if (platform === 'windows') {
@@ -182,7 +193,7 @@ beforeEach(function () {
 
                 projects.forEach(function (project) {
                     if (projectsAddedTo.indexOf(path.basename(project.location)) > -1) {
-                        projectsAddedToSpies.push(spyOn(project, 'appendToRoot').andCallFake(appendToRootFake));
+                        projectsAddedToSpies.push(spyOn(project, 'appendToRoot').and.callFake(appendToRootFake));
                     } else {
                         projectsNotAddedToSpies.push(spyOn(project, 'appendToRoot'));
                     }
@@ -192,34 +203,39 @@ beforeEach(function () {
 
                 projectsAddedToSpies.forEach(function (spy) {
                     expect(spy).toHaveBeenCalled();
+                    spy.calls.reset();
                 });
 
                 projectsNotAddedToSpies.forEach(function (spy) {
                     expect(spy).not.toHaveBeenCalled();
+                    spy.calls.reset();
                 });
             }
 
             describe('of <source-file> elements', function () {
-                it('should copy stuff from one location to another by calling common.copyFile', function () {
+                it('Test 004 : should copy stuff from one location to another by calling common.copyFile', function (done) {
                     var source = copyArray(valid_source);
                     var s = spyOn(common, 'copyFile');
                     windows['source-file'].install(source[0], dummyplugin, cordovaProjectWindowsPlatformDir, dummy_id, null, proj_files);
                     expect(s).toHaveBeenCalledWith(dummyplugin, 'src/windows/dummer.js', cordovaProjectWindowsPlatformDir, path.join('plugins', 'org.test.plugins.dummyplugin', 'dummer.js'), false);
+                    done();
                 });
-                it('should throw if source-file src cannot be found', function () {
+                it('Test 005 : should throw if source-file src cannot be found', function (done) {
                     var source = copyArray(invalid_source);
                     expect(function () {
                         windows['source-file'].install(source[1], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('"' + path.resolve(faultyplugin, 'src/windows/NotHere.js') + '" not found!');
+                    }).toThrow(new Error ('"' + path.resolve(faultyplugin, 'src/windows/NotHere.js') + '" not found!'));
+                    done();
                 });
-                it('should throw if source-file target already exists', function () {
+                it('Test 006 : should throw if source-file target already exists', function (done) {
                     var source = copyArray(valid_source);
                     var target = path.join(cordovaProjectWindowsPlatformDir, 'plugins', dummy_id, 'dummer.js');
                     shell.mkdir('-p', path.dirname(target));
                     fs.writeFileSync(target, 'some bs', 'utf-8');
                     expect(function () {
                         windows['source-file'].install(source[0], dummyplugin, cordovaProjectWindowsPlatformDir, dummy_id, null, proj_files);
-                    }).toThrow('"' + target + '" already exists!');
+                    }).toThrow(new Error ('"' + target + '" already exists!'));
+                    done();
                 });
             });
 
@@ -229,32 +245,43 @@ beforeEach(function () {
 
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should write to correct project files when conditions are specified', function () {
+                it('Test 007 : should write to correct project files when conditions are specified', function (done) {
                     var xpath = 'Content[@Include="' + resourceFiles[0].target + '"][@Condition="\'$(Platform)\'==\'x86\'"]';
                     validateInstalledProjects('resource-file', resourceFiles[0], xpath, ['all']);
-
-                    xpath = 'Content[@Include="' + resourceFiles[1].target + '"]';
-                    validateInstalledProjects('resource-file', resourceFiles[1], xpath, ['windows', 'phone', 'windows10']);
-
-                    xpath = 'Content[@Include="' + resourceFiles[2].target + '"]';
-                    validateInstalledProjects('resource-file', resourceFiles[2], xpath, ['phone']);
-
-                    xpath = 'Content[@Include="' + resourceFiles[3].target + '"][@Condition="\'$(Platform)\'==\'x64\'"]';
-                    validateInstalledProjects('resource-file', resourceFiles[3], xpath, ['windows8']);
+                    done();
                 });
 
-                it('should throw if conditions are invalid', function () {
+                it('Test 008 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Content[@Include="' + resourceFiles[1].target + '"]';
+                    validateInstalledProjects('resource-file', resourceFiles[1], xpath, ['windows', 'phone', 'windows10']);
+                    done();
+                });
+
+                it('Test 009 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Content[@Include="' + resourceFiles[2].target + '"]';
+                    validateInstalledProjects('resource-file', resourceFiles[2], xpath, ['phone']);
+                    done();
+                });
+
+                it('Test 010 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Content[@Include="' + resourceFiles[3].target + '"][@Condition="\'$(Platform)\'==\'x64\'"]';
+                    validateInstalledProjects('resource-file', resourceFiles[3], xpath, ['windows8']);
+                    done();
+                });
+
+                it('Test 011 : should throw if conditions are invalid', function (done) {
                     expect(function () {
                         windows['resource-file'].install(invalidResourceFiles[0], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid arch attribute (must be "x86", "x64" or "ARM"): x85');
+                    }).toThrow(new Error ('Invalid arch attribute (must be "x86", "x64" or "ARM"): x85'));
 
                     expect(function () {
                         windows['resource-file'].install(invalidResourceFiles[1], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid versions attribute (must be a valid semantic version range): 8.0a');
+                    }).toThrow(new Error ('Invalid versions attribute (must be a valid semantic version range): 8.0a'));
 
                     expect(function () {
                         windows['resource-file'].install(invalidResourceFiles[2], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid device-target attribute (must be "all", "phone", "windows" or "win"): daphne');
+                    }).toThrow(new Error ('Invalid device-target attribute (must be "all", "phone", "windows" or "win"): daphne'));
+                    done();
                 });
             });
 
@@ -264,32 +291,50 @@ beforeEach(function () {
 
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should write to correct project files when conditions are specified', function () {
+                it('Test 012 : should write to correct project files when conditions are specified', function (done) {
                     var xpath = 'SDKReference[@Include="TestSDK1, Version=1.0"][@Condition="\'$(Platform)\'==\'x86\'"]';
                     validateInstalledProjects('lib-file', libfiles[0], xpath, ['all']);
-
-                    xpath = 'SDKReference[@Include="TestSDK2, Version=1.0"]';
-                    validateInstalledProjects('lib-file', libfiles[1], xpath, ['windows', 'phone', 'windows10']);
-
-                    xpath = 'SDKReference[@Include="TestSDK3, Version=1.0"]';
-                    validateInstalledProjects('lib-file', libfiles[2], xpath, ['phone']);
-
-                    xpath = 'SDKReference[@Include="TestSDK4, Version=1.0"]';
-                    validateInstalledProjects('lib-file', libfiles[3], xpath, ['windows8']);
+                    done();
                 });
 
-                it('should throw if conditions are invalid', function () {
+                it('Test 013 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'SDKReference[@Include="TestSDK2, Version=1.0"]';
+                    validateInstalledProjects('lib-file', libfiles[1], xpath, ['windows', 'phone', 'windows10']);
+                    done();
+                });
+                
+                it('Test 014 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'SDKReference[@Include="TestSDK3, Version=1.0"]';
+                    validateInstalledProjects('lib-file', libfiles[2], xpath, ['phone']);
+                    done();
+                });
+
+                it('Test 015 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'SDKReference[@Include="TestSDK4, Version=1.0"]';
+                    validateInstalledProjects('lib-file', libfiles[3], xpath, ['windows8']);
+                    done();
+                });
+
+                it('Test 016 : should throw if conditions are invalid', function (done) {
                     expect(function () {
                         windows['lib-file'].install(invalidLibFiles[0], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid arch attribute (must be "x86", "x64" or "ARM"): x85');
+                    }).toThrow(new Error('Invalid arch attribute (must be "x86", "x64" or "ARM"): x85'));
 
+                    done();
+                });
+                
+                it('Test 017 : should throw if conditions are invalid', function (done) {
                     expect(function () {
                         windows['lib-file'].install(invalidLibFiles[1], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid versions attribute (must be a valid semantic version range): 8.0a');
-
+                    }).toThrow(new Error ('Invalid versions attribute (must be a valid semantic version range): 8.0a'));
+                    done();
+                });
+                
+                it('Test 018 : should throw if conditions are invalid', function (done) {
                     expect(function () {
                         windows['lib-file'].install(invalidLibFiles[2], faultyplugin, cordovaProjectWindowsPlatformDir, faulty_id, null, proj_files);
-                    }).toThrow('Invalid device-target attribute (must be "all", "phone", "windows" or "win"): daphne');
+                    }).toThrow(new Error ('Invalid device-target attribute (must be "all", "phone", "windows" or "win"): daphne'));
+                    done();
                 });
             });
 
@@ -298,42 +343,67 @@ beforeEach(function () {
 
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should write to correct project files when conditions are specified', function () {
+                it('Test 019 : should write to correct project files when conditions are specified', function (done) {
                     var xpath = 'Reference[@Include="dummy1"][@Condition="\'$(Platform)\'==\'x64\'"]/HintPath';
                     validateInstalledProjects('framework', frameworks[0], xpath, ['all']);
-
-                    xpath = 'Reference[@Include="dummy2"]/HintPath';
+                    done();
+                });
+                it('Test 020 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Reference[@Include="dummy2"]/HintPath';
                     validateInstalledProjects('framework', frameworks[1], xpath, ['all']);
-
-                    xpath = 'Reference[@Include="dummy3"]/HintPath';
+                    done();
+                });
+                
+                it('Test 021 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Reference[@Include="dummy3"]/HintPath';
                     validateInstalledProjects('framework', frameworks[2], xpath, ['windows', 'windows8', 'windows10']);
-
-                    xpath = 'Reference[@Include="dummy4"][@Condition="\'$(Platform)\'==\'ARM\'"]/HintPath';
+                    done();
+                });
+                
+                it('Test 022 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Reference[@Include="dummy4"][@Condition="\'$(Platform)\'==\'ARM\'"]/HintPath';
                     validateInstalledProjects('framework', frameworks[3], xpath, ['phone']);
+                    done();
+                });
 
-                    xpath = 'Reference[@Include="dummy5"]/HintPath';
+                it('Test 023 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Reference[@Include="dummy5"]/HintPath';
                     validateInstalledProjects('framework', frameworks[4], xpath, ['phone']);
+                    done();
+                });
 
-                    xpath = 'Reference[@Include="dummy6"]/HintPath';
+                it('Test 024 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'Reference[@Include="dummy6"]/HintPath';
                     validateInstalledProjects('framework', frameworks[5], xpath, ['windows', 'windows10', 'phone']);
+                    done();
                 });
             });
 
             describe('of <framework> elements of type \'projectReference\'', function () {
                 var frameworks = copyArray(valid_frameworks);
 
-                it('should write to correct project files when conditions are specified', function () {
+                it('Test 025 : should write to correct project files when conditions are specified', function (done) {
                     var xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy1.vcxproj') + '"][@Condition="\'$(Platform)\'==\'x64\'"]';
                     validateInstalledProjects('framework', frameworks[6], xpath, ['all']);
-
-                    xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy2.vcxproj') + '"]';
+                    done();
+                });
+                
+                it('Test 026 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy2.vcxproj') + '"]';
                     validateInstalledProjects('framework', frameworks[7], xpath, ['windows8']);
-
-                    xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy3.vcxproj') + '"]';
+                    done();
+                });
+                
+                it('Test 027 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy3.vcxproj') + '"]';
                     validateInstalledProjects('framework', frameworks[8], xpath, ['windows', 'windows8', 'windows10']);
-
-                    xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy4.vcxproj') + '"][@Condition="\'$(Platform)\'==\'x86\'"]';
+                    done();
+                });
+                
+                it('Test 028 : should write to correct project files when conditions are specified', function (done) {
+                    var xpath = 'ProjectReference[@Include="' + windowsJoin(dummyplugin, 'src', 'windows', 'dummy4.vcxproj') + '"][@Condition="\'$(Platform)\'==\'x86\'"]';
                     validateInstalledProjects('framework', frameworks[9], xpath, ['windows', 'phone']);
+                    done();
                 });
             });
         });
@@ -349,7 +419,7 @@ beforeEach(function () {
             });
 
             function validateUninstalledProjects(tag, elementToUninstall, xmlPath, incText, targetConditions, supportedPlatforms) {
-                jasmine.getEnv().currentSpec.removeAllSpies();
+                //jasmine.getEnv().currentSpec.removeAllSpies();
 
                 var projects = copyArray(proj_files.projects);
                 if (platform === 'windows') {
@@ -369,6 +439,8 @@ beforeEach(function () {
 
                 projects.forEach(function (project) {
                     var spy = spyOn(project, 'removeItemGroupElement');
+                    
+
                     if (projectsAddedTo.indexOf(path.basename(project.location)) > -1) {
                         projectsAddedToSpies.push(spy);
                     } else {
@@ -380,15 +452,17 @@ beforeEach(function () {
 
                 projectsAddedToSpies.forEach(function (spy) {
                     expect(spy).toHaveBeenCalledWith(xmlPath, incText, targetConditions);
+                    spy.calls.reset();
                 });
 
                 projectsNotAddedToSpies.forEach(function (spy) {
                     expect(spy).not.toHaveBeenCalled();
+                    spy.calls.reset();
                 });
             }
 
             describe('of <source-file> elements', function () {
-                it('should remove stuff by calling common.removeFile', function (done) {
+                it('Test 029 : should remove stuff by calling common.removeFile', function (done) {
                     var s = spyOn(common, 'removeFile');
 
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
@@ -404,7 +478,7 @@ beforeEach(function () {
             describe('of <resource-file> elements', function () {
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should remove from correct project files when conditions specified', function (done) {
+                it('Test 030 : should remove from correct project files when conditions specified', function (done) {
                     var resourcefiles = copyArray(valid_resourceFiles);
 
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
@@ -414,14 +488,43 @@ beforeEach(function () {
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
                             validateUninstalledProjects('resource-file', resourcefiles[0], path, incText, targetConditions, ['all']);
 
+                            done();
+                        });
+                });
+                it('Test 031 : should remove from correct project files when conditions specified', function (done) {
+                    var resourcefiles = copyArray(valid_resourceFiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Content';
+
                             incText = resourcefiles[1].target;
                             targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('resource-file', resourcefiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
+
+                            done();
+                        });
+                });
+                it('Test 032 : should remove from correct project files when conditions specified', function (done) {
+                    var resourcefiles = copyArray(valid_resourceFiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Content';
 
                             incText = resourcefiles[2].target;
                             targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('resource-file', resourcefiles[2], path, incText, targetConditions, ['phone']);
 
+                            done();
+                        });
+                });
+                it('Test 033 : should remove from correct project files when conditions specified', function (done) {
+                    var resourcefiles = copyArray(valid_resourceFiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Content';
                             incText = resourcefiles[3].target;
                             targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x64'};
                             validateUninstalledProjects('resource-file', resourcefiles[3], path, incText, targetConditions, ['windows8']);
@@ -434,7 +537,7 @@ beforeEach(function () {
             describe('of <lib-file> elements', function () {
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should remove from correct project files when conditions specified', function (done) {
+                it('Test 034 : should remove from correct project files when conditions specified', function (done) {
                     var libfiles = copyArray(valid_libfiles);
 
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
@@ -443,15 +546,43 @@ beforeEach(function () {
                             var incText = 'TestSDK1, Version=1.0';
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x86'};
                             validateUninstalledProjects('lib-file', libfiles[0], path, incText, targetConditions, ['all']);
+                            done();
+                        });
+                });
 
+                it('Test 035 : should remove from correct project files when conditions specified', function (done) {
+                    var libfiles = copyArray(valid_libfiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/SDKReference';
                             incText = 'TestSDK2, Version=1.0';
                             targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[1], path, incText, targetConditions, ['windows', 'phone', 'windows10']);
+                            done();
+                        });
+                });
 
+                it('Test 036 : should remove from correct project files when conditions specified', function (done) {
+                    var libfiles = copyArray(valid_libfiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/SDKReference';
                             incText = 'TestSDK3, Version=1.0';
                             targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('lib-file', libfiles[2], path, incText, targetConditions, ['phone']);
 
+                            done();
+                        });
+                });
+
+                it('Test 037 : should remove from correct project files when conditions specified', function (done) {
+                    var libfiles = copyArray(valid_libfiles);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/SDKReference';
                             incText = 'TestSDK4, Version=1.0';
                             targetConditions = {versions: '8.0', deviceTarget: 'windows', arch: 'x86'};
                             validateUninstalledProjects('lib-file', libfiles[3], path, incText, targetConditions, ['windows8']);
@@ -464,7 +595,7 @@ beforeEach(function () {
             describe('of <framework> elements', function () {
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should remove from correct project files when conditions specified', function (done) {
+                it('Test 038 : should remove from correct project files when conditions specified', function (done) {
                     var frameworks = copyArray(valid_frameworks);
 
                     install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
@@ -474,59 +605,136 @@ beforeEach(function () {
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                             validateUninstalledProjects('framework', frameworks[0], path, incText, targetConditions, ['all']);
 
+                            done();
+                        });
+                }, 6000);
+
+                it('Test 039 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Reference';
                             incText = 'dummy2';
                             targetConditions = {versions: '>=8.0', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[1], path, incText, targetConditions, ['all']);
 
+                            done();
+                        });
+                }, 6000);
+
+                it('Test 040 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Reference';
                             incText = 'dummy3';
                             targetConditions = {versions: undefined, deviceTarget: 'windows', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[2], path, incText, targetConditions, ['windows', 'windows8', 'windows10']);
 
+                            done();
+                        });
+                }, 6000);
+
+                it('Test 041 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Reference';
                             incText = 'dummy4';
                             targetConditions = {versions: '8.1', deviceTarget: 'phone', arch: 'ARM'};
                             validateUninstalledProjects('framework', frameworks[3], path, incText, targetConditions, ['phone']);
 
+                            done();
+                        });
+                }, 6000);
+
+                it('Test 042 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Reference';
                             incText = 'dummy5';
                             targetConditions = {versions: undefined, deviceTarget: 'phone', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[4], path, incText, targetConditions, ['phone']);
 
+                            done();
+                        });
+                }, 6000);
+
+                it('Test 043 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var path = 'ItemGroup/Reference';
                             incText = 'dummy6';
                             targetConditions = {versions: '>=8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[5], path, incText, targetConditions, ['windows', 'windows10', 'phone']);
 
                             done();
                         });
-                });
+                }, 6000);
             });
 
             describe('of <framework> elements of type \'projectReference\'', function () {
                 // This could be separated into individual specs, but that results in a lot of copying and deleting the
                 // project files, which is not needed.
-                it('should remove from correct project files when conditions specified', function (done) {
+                it('Test 044 : should remove from correct project files when conditions specified', function (done) {
                     var frameworks = copyArray(valid_frameworks);
 
-                    install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                    return install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
                         .then(function () {
                             var xmlPath = 'ItemGroup/ProjectReference';
                             var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy1.vcxproj');
                             var targetConditions = {versions: undefined, deviceTarget: undefined, arch: 'x64'};
                             validateUninstalledProjects('framework', frameworks[6], xmlPath, incText, targetConditions, ['all']);
+                            done();
+                        });
+                }, 60000);
 
-                            incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy2.vcxproj');
+                it('Test 045 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    return install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var xmlPath = 'ItemGroup/ProjectReference';
+                            var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy2.vcxproj');
                             targetConditions = {versions: '<8.1', deviceTarget: undefined, arch: undefined};
                             validateUninstalledProjects('framework', frameworks[7], xmlPath, incText, targetConditions, ['windows8']);
+                            done();
+                        });
+                }, 60000);
 
-                            incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy3.vcxproj');
+                it('Test 046 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    return install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var xmlPath = 'ItemGroup/ProjectReference';
+                            var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy3.vcxproj');
                             targetConditions = {versions: undefined, deviceTarget: 'win', arch: undefined};
                             validateUninstalledProjects('framework', frameworks[8], xmlPath, incText, targetConditions, ['windows', 'windows8', 'windows10']);
 
-                            incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy4.vcxproj');
-                            targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
-                            validateUninstalledProjects('framework', frameworks[9], xmlPath, incText, targetConditions, ['windows', 'phone']);
-
                             done();
                         });
-                });
+                }, 60000);
+
+                it('Test 047 : should remove from correct project files when conditions specified', function (done) {
+                    var frameworks = copyArray(valid_frameworks);
+
+                    return install('windows', cordovaProjectWindowsPlatformDir, dummyplugin, cordovaProjectPluginsDir, {})
+                        .then(function () {
+                            var xmlPath = 'ItemGroup/ProjectReference';
+                            var incText = windowsJoin(cordovaProjectPluginsDir , dummy_id, 'src', 'windows', 'dummy4.vcxproj');
+                            targetConditions = {versions: '8.1', deviceTarget: 'all', arch: 'x86'};
+                            validateUninstalledProjects('framework', frameworks[9], xmlPath, incText, targetConditions, ['windows', 'phone']);
+                            done();
+                        });
+                }, 60000);
             });
         });
     });

--- a/cordova-lib/spec-plugman/platforms/wp8.spec.js
+++ b/cordova-lib/spec-plugman/platforms/wp8.spec.js
@@ -60,21 +60,21 @@ describe('wp8 project handler', function() {
     });
 
     describe('www_dir method', function() {
-        it('should return cordova-wp8 project www location using www_dir', function() {
+        it('Test 001 : should return cordova-wp8 project www location using www_dir', function() {
             expect(wp8.www_dir(path.sep)).toEqual(path.sep + 'www');
         });
     });
     describe('package_name method', function() {
-        it('should return a wp8 project\'s proper package name', function() {
+        it('Test 002 : should return a wp8 project\'s proper package name', function() {
             expect(wp8.package_name(wp8_project)).toEqual('{F3A8197B-6B16-456D-B5F4-DD4F04AC0BEC}');
         });
     });
 
     describe('parseProjectFile method', function() {
-        it('should throw if project is not an wp8 project', function() {
+        it('Test 003 : should throw if project is not an wp8 project', function() {
             expect(function() {
                 wp8.parseProjectFile(temp);
-            }).toThrow('does not appear to be a Windows Phone project (no .csproj file)');
+            }).toThrow(new Error ('does not appear to be a Windows Phone project (no .csproj file)'));
         });
     });
 
@@ -94,41 +94,40 @@ describe('wp8 project handler', function() {
             beforeEach(function() {
                 shell.cp('-rf', path.join(wp8_project, '*'), temp);
             });
-            it('should copy stuff from one location to another by calling common.copyFile', function() {
+            it('Test 004 : should copy stuff from one location to another by calling common.copyFile', function() {
                 var source = copyArray(valid_source);
                 var s = spyOn(common, 'copyFile');
                 wp8['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
                 expect(s).toHaveBeenCalledWith(dummyplugin, 'src/wp8/DummyPlugin.cs', temp, path.join('Plugins', 'org.test.plugins.dummyplugin', 'DummyPlugin.cs'), false);
             });
-            it('should throw if source-file src cannot be found', function() {
+            it('Test 005 : should throw if source-file src cannot be found', function() {
                 var source = copyArray(invalid_source);
                 expect(function() {
                     wp8['source-file'].install(source[1], faultyplugin, temp, faulty_id, null, proj_files);
-                }).toThrow('"' + path.resolve(faultyplugin, 'src/wp8/NotHere.cs') + '" not found!');
+                }).toThrow(new Error('"' + path.resolve(faultyplugin, 'src/wp8/NotHere.cs') + '" not found!'));
             });
-            it('should throw if source-file target already exists', function() {
+            it('Test 006 : should throw if source-file target already exists', function() {
                 var source = copyArray(valid_source);
                 var target = path.join(temp, 'Plugins', dummy_id, 'DummyPlugin.cs');
                 shell.mkdir('-p', path.dirname(target));
                 fs.writeFileSync(target, 'some bs', 'utf-8');
                 expect(function() {
                     wp8['source-file'].install(source[0], dummyplugin, temp, dummy_id, null, proj_files);
-                }).toThrow('"' + target + '" already exists!');
+                }).toThrow(new Error ('"' + target + '" already exists!'));
             });
         });
         describe('of <config-changes> elements', function() {
             beforeEach(function() {
                 shell.cp('-rf', path.join(wp8_project, '*'), temp);
             });
-            it('should process and pass the after parameter to graftXML', function () {
-                var graftXML = spyOn(xml_helpers, 'graftXML').andCallThrough();
-
-                runs(function () { installPromise(install('wp8', temp, dummyplugin, plugins_dir, {})); });
-                waitsFor(function () { return done; }, 'install promise never resolved', 500);
-                runs(function () {
+            it('Test 007 : should process and pass the after parameter to graftXML', function (done) {
+                var graftXML = spyOn(xml_helpers, 'graftXML').and.callThrough();
+                return install('wp8', temp, dummyplugin, plugins_dir, {})
+                .then(function() {
                     expect(graftXML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Array), '/Deployment/App', 'Tokens');
                     expect(graftXML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Array), '/Deployment/App/Extensions', 'Extension');
                     expect(graftXML).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Array), '/Deployment/App/Extensions', 'FileTypeAssociation;Extension');
+                    done();
                 });
             });
         });
@@ -144,7 +143,7 @@ describe('wp8 project handler', function() {
             shell.rm('-rf', temp);
         });
         describe('of <source-file> elements', function() {
-            it('should remove stuff by calling common.removeFile', function(done) {
+            it('Test 009 : should remove stuff by calling common.removeFile', function(done) {
                 var s = spyOn(common, 'removeFile');
                 install('wp8', temp, dummyplugin, plugins_dir, {})
                 .then(function() {

--- a/cordova-lib/spec-plugman/platforms/wp8.spec.js
+++ b/cordova-lib/spec-plugman/platforms/wp8.spec.js
@@ -79,11 +79,6 @@ describe('wp8 project handler', function() {
     });
 
     describe('installation', function() {
-        var done;
-        function installPromise(f) {
-            done = false;
-            f.then(function() { done = true; }, function(err) { done = err; });
-        }
         beforeEach(function() {
             shell.mkdir('-p', temp);
         });

--- a/cordova-lib/spec-plugman/registry/registry.spec.js
+++ b/cordova-lib/spec-plugman/registry/registry.spec.js
@@ -29,12 +29,13 @@ describe('registry', function() {
     beforeEach(function() {
         done = false;
     });
+
     function registryPromise(shouldSucceed, f) {
-        waitsFor(function() { return done; }, 'promise never resolved', 500);
-        return f.then(function() {
+        return f
+        .then(function() {
           done = true;
           expect(shouldSucceed).toBe(true);
-        }, function(err) {
+        }).fail(function(err){
           done = err;
           expect(shouldSucceed).toBe(false);
         });
@@ -52,33 +53,44 @@ describe('registry', function() {
         afterEach(function() {
             shell.rm('-rf', tmp_plugin);
         });
-        it('should generate a package.json from a plugin.xml', function() {
-            registryPromise(true, manifest.generatePackageJsonFromPluginXml(tmp_plugin).then(function() {
+        it('Test 001 : should generate a package.json from a plugin.xml', function(done) {
+            return registryPromise(true, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
+            .then(function() {
                 expect(fs.existsSync(tmp_package_json));
                 var packageJson = JSON.parse(fs.readFileSync(tmp_package_json));
                 expect(packageJson.name).toEqual('com.cordova.engine');
                 expect(packageJson.version).toEqual('1.0.0');
                 expect(packageJson.engines).toEqual(
                     [ { name : 'cordova', version : '>=2.3.0' }, { name : 'cordova-plugman', version : '>=0.10.0' }, { name : 'mega-fun-plugin', version : '>=1.0.0' }, { name : 'mega-boring-plugin', version : '>=3.0.0' } ]);
-            }));
-        });
-        it('should raise an error if name does not follow com.domain.* format', function() {
+                done();
+            });
+        }, 6000);
+        it('Test 002 : should raise an error if name does not follow com.domain.* format', function(done) {
             var xmlData = fs.readFileSync(tmp_plugin_xml).toString().replace('id="com.cordova.engine"', 'id="engine"');
             fs.writeFileSync(tmp_plugin_xml, xmlData);
-            registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin));
+            return registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
+            .then(function(){
+                done();
+            })
         });
-        it('should generate a package.json if name uses org.apache.cordova.* for a whitelisted plugin', function() {
+        // Expect the package.json to NOT exist
+        it('Test 003 : should generate a package.json if name uses org.apache.cordova.* for a whitelisted plugin', function(done) {
             var xmlData = fs.readFileSync(tmp_plugin_xml).toString().replace('id="com.cordova.engine"', 'id="org.apache.cordova.camera"');
             fs.writeFileSync(tmp_plugin_xml, xmlData);
-            registryPromise(true, manifest.generatePackageJsonFromPluginXml(tmp_plugin).then(function() {
-                expect(!fs.existsSync(tmp_package_json));
-            }));
-        });
-        it('should raise an error if name uses org.apache.cordova.* for a non-whitelisted plugin', function() {
+            return registryPromise(true, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
+            .then(function(result) {
+                expect(fs.existsSync(tmp_package_json)).toBe(true);
+                done();
+            });
+        }, 6000);
+        it('Test 004 : should raise an error if name uses org.apache.cordova.* for a non-whitelisted plugin', function(done) {
             var xmlData = fs.readFileSync(tmp_plugin_xml).toString().replace('id="com.cordova.engine"', 'id="org.apache.cordova.myinvalidplugin"');
             fs.writeFileSync(tmp_plugin_xml, xmlData);
-            registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin));
-        });
+            return registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
+            .then(function(){
+                done();
+            })
+        }, 6000);
     });
     describe('actions', function() {
         var fakeLoad, fakeNPMCommands;
@@ -99,11 +111,11 @@ describe('registry', function() {
             };
 
             registry.settings = fakeSettings;
-            fakeLoad = spyOn(npm, 'load').andCallFake(function () { arguments[arguments.length - 1](null, true); });
+            fakeLoad = spyOn(npm, 'load').and.callFake(function () { arguments[arguments.length - 1](null, true); });
 
             fakeNPMCommands = {};
             ['config', 'adduser', 'cache', 'publish', 'unpublish', 'search'].forEach(function(cmd) {
-                fakeNPMCommands[cmd] = jasmine.createSpy(cmd).andCallFake(fakeNPM);
+                fakeNPMCommands[cmd] = jasmine.createSpy(cmd).and.callFake(fakeNPM);
             });
 
             npm.commands = fakeNPMCommands;
@@ -111,19 +123,21 @@ describe('registry', function() {
             npm.config.get = function(){};
             npm.config.del = function(){};
         });
-        it('should run config', function() {
+        it('Test 005 : should run config', function(done) {
             var params = ['set', 'registry', 'http://registry.cordova.io'];
-            registryPromise(true, registry.config(params).then(function() {
+            return registryPromise(true, registry.config(params).then(function() {
                 expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Object),jasmine.any(Function));
                 expect(fakeNPMCommands.config).toHaveBeenCalledWith(params, jasmine.any(Function));
+                done();
             }));
-        });
-        it('should run search', function() {
+        }, 6000);
+        it('Test 006 : should run search', function(done) {
             var params = ['dummyplugin', 'plugin'];
-            registryPromise(true, registry.search(params).then(function() {
+            return registryPromise(true, registry.search(params).then(function() {
                 expect(fakeLoad).toHaveBeenCalledWith(jasmine.any(Object),jasmine.any(Function));
                 expect(fakeNPMCommands.search).toHaveBeenCalledWith(params, true, jasmine.any(Function));
+                done();
             }));
-        });
+        }, 6000);
     });
 });

--- a/cordova-lib/spec-plugman/registry/registry.spec.js
+++ b/cordova-lib/spec-plugman/registry/registry.spec.js
@@ -71,7 +71,7 @@ describe('registry', function() {
             return registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
             .then(function(){
                 done();
-            })
+            });
         });
         // Expect the package.json to NOT exist
         it('Test 003 : should generate a package.json if name uses org.apache.cordova.* for a whitelisted plugin', function(done) {
@@ -89,7 +89,7 @@ describe('registry', function() {
             return registryPromise(false, manifest.generatePackageJsonFromPluginXml(tmp_plugin))
             .then(function(){
                 done();
-            })
+            });
         }, 6000);
     });
     describe('actions', function() {

--- a/cordova-lib/spec-plugman/search.spec.js
+++ b/cordova-lib/spec-plugman/search.spec.js
@@ -22,7 +22,7 @@ var search = require('../src/plugman/search'),
 
 describe('search', function() {
     it('should search a plugin', function() {
-        var sSearch = spyOn(registry, 'search').andReturn(Q());
+        var sSearch = spyOn(registry, 'search').and.returnValue(Q());
         search(new Array('myplugin', 'keyword'));
         expect(sSearch).toHaveBeenCalledWith(['myplugin', 'keyword']);
     });

--- a/cordova-lib/spec-plugman/search.spec.js
+++ b/cordova-lib/spec-plugman/search.spec.js
@@ -21,7 +21,7 @@ var search = require('../src/plugman/search'),
     registry = require('../src/plugman/registry/registry');
 
 describe('search', function() {
-    it('should search a plugin', function() {
+    it('Test 001 : should search a plugin', function() {
         var sSearch = spyOn(registry, 'search').and.returnValue(Q());
         search(new Array('myplugin', 'keyword'));
         expect(sSearch).toHaveBeenCalledWith(['myplugin', 'keyword']);

--- a/cordova-lib/spec-plugman/uninstall.spec.js
+++ b/cordova-lib/spec-plugman/uninstall.spec.js
@@ -78,7 +78,7 @@ function uninstallPromise(f) {
 describe('plugman uninstall start', function() {
     beforeEach(function () {
         var origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
-        spyOn(xmlHelpers, 'parseElementtreeSync').andCallFake(function(path) {
+        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function(path) {
             if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
             return origParseElementtreeSync(path);
         });
@@ -121,17 +121,17 @@ describe('uninstallPlatform', function() {
     var fsWrite;
 
     beforeEach(function() {
-        proc = spyOn(actions.prototype, 'process').andReturn(Q());
-        fsWrite = spyOn(fs, 'writeFileSync').andReturn(true);
-        rm = spyOn(shell, 'rm').andReturn(true);
-        spyOn(shell, 'cp').andReturn(true);
+        proc = spyOn(actions.prototype, 'process').and.returnValue(Q());
+        fsWrite = spyOn(fs, 'writeFileSync').and.returnValue(true);
+        rm = spyOn(shell, 'rm').and.returnValue(true);
+        spyOn(shell, 'cp').and.returnValue(true);
         done = false;
     });
     describe('success', function() {
 
         it('should get PlatformApi instance for platform and invoke its\' removePlugin method', function(done) {
-            var platformApi = { removePlugin: jasmine.createSpy('removePlugin').andReturn(Q()) };
-            var getPlatformApi = spyOn(platforms, 'getPlatformApi').andReturn(platformApi);
+            var platformApi = { removePlugin: jasmine.createSpy('removePlugin').and.returnValue(Q()) };
+            var getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
 
             uninstall.uninstallPlatform('android', project, dummy_id)
             .then(function() {
@@ -144,21 +144,21 @@ describe('uninstallPlatform', function() {
 
         it('should return propagate value returned by PlatformApi removePlugin method', function(done) {
             var platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
-            spyOn(platforms, 'getPlatformApi').andReturn(platformApi);
+            spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
 
             var existsSyncOrig = fs.existsSync;
-            spyOn(fs, 'existsSync').andCallFake(function (file) {
+            spyOn(fs, 'existsSync').and.callFake(function (file) {
                 if (file.indexOf(dummy_id) >= 0) return true;
                 return existsSyncOrig.call(fs, file);
             });
 
             var fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
-            fakeProvider.get.andReturn(dummyPluginInfo);
+            fakeProvider.get.and.returnValue(dummyPluginInfo);
 
             function validateReturnedResultFor(values, expectedResult) {
                 return values.reduce(function (promise, value) {
                     return promise.then(function () {
-                        platformApi.removePlugin.andReturn(Q(value));
+                        platformApi.removePlugin.and.returnValue(Q(value));
                         return uninstall.uninstallPlatform('android', project, dummy_id, null,
                             { pluginInfoProvider: fakeProvider, platformVersion: '9.9.9' });
                     })
@@ -220,8 +220,8 @@ describe('uninstallPlugin', function() {
     var rm, fsWrite, rmstack = [], emit;
 
     beforeEach(function() {
-        fsWrite = spyOn(fs, 'writeFileSync').andReturn(true);
-        rm = spyOn(shell, 'rm').andCallFake(function(f,p) { rmstack.push(p); return true; });
+        fsWrite = spyOn(fs, 'writeFileSync').and.returnValue(true);
+        rm = spyOn(shell, 'rm').and.callFake(function(f,p) { rmstack.push(p); return true; });
         rmstack = [];
         emit = spyOn(events, 'emit');
         done = false;
@@ -302,8 +302,8 @@ describe('uninstall', function() {
     var fsWrite, rm;
 
     beforeEach(function() {
-        fsWrite = spyOn(fs, 'writeFileSync').andReturn(true);
-        rm = spyOn(shell, 'rm').andReturn(true);
+        fsWrite = spyOn(fs, 'writeFileSync').and.returnValue(true);
+        rm = spyOn(shell, 'rm').and.returnValue(true);
         done = false;
     });
 

--- a/cordova-lib/spec-plugman/uninstall.spec.js
+++ b/cordova-lib/spec-plugman/uninstall.spec.js
@@ -177,12 +177,12 @@ describe('uninstallPlatform', function() {
             .fin(done);
         });
 
-        describe('with dependencies', function() {
+    describe('with dependencies', function() {
             var emit;
             beforeEach(function() {
                 emit = spyOn(events, 'emit');
             });
-            it('should uninstall "dangling" dependencies', function() {
+            it('should uninstall "dangling" dependencies', function(done) {
                 runs(function() {
                     uninstallPromise(uninstall.uninstallPlatform('android', project, 'A'));
                 });
@@ -195,24 +195,27 @@ describe('uninstallPlatform', function() {
     });
 
     describe('failure', function() {
-        it('should throw if platform is unrecognized', function() {
-            runs(function() {
-                uninstallPromise( uninstall.uninstallPlatform('atari', project, 'SomePlugin') );
+        it('should throw if platform is unrecognized', function(done) {
+            uninstall.uninstallPlatform('atari', project, 'SomePlugin').then(function(result){
+                expect(false).toBe(true);
+                done();
+            },
+            function err(errMsg) {
+                expect(errMsg.toString()).toContain('atari not supported.');
+                done();
             });
-            waitsFor(function() { return done; }, 'promise never resolved', 200);
-            runs(function() {
-                expect(''+done).toContain('atari not supported.');
+        }, 6000);
+
+        it('should throw if plugin is missing', function(done) {
+            uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist').then(function(result){
+                expect(false).toBe(true);
+                done();
+            },
+            function err(errMsg) {
+                expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
+                done();
             });
-        });
-        it('should throw if plugin is missing', function() {
-            runs(function() {
-                uninstallPromise( uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist') );
-            });
-            waitsFor(function() { return done; }, 'promise never resolved', 200);
-            runs(function() {
-                expect(''+done).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-            });
-        });
+        }, 6000);
     });
 });
 
@@ -244,7 +247,7 @@ describe('uninstallPlugin', function() {
             });
         });
 
-        it('should fail if plugin is a required dependency', function() {
+        it('should fail if plugin is a required dependency', function(done) {
             runs(function() {
                 uninstallPromise( uninstall.uninstallPlugin('C', plugins_install_dir) );
             });
@@ -281,7 +284,7 @@ describe('uninstallPlugin', function() {
             });
         });
 
-        it('should not remove dependent plugin if it was installed after as top-level', function() {
+        it('should not remove dependent plugin if it was installed after as top-level', function(done) {
             runs(function() {
                 uninstallPromise( uninstall.uninstallPlugin('A', plugins_install_dir3) );
             });
@@ -308,31 +311,34 @@ describe('uninstall', function() {
     });
 
     describe('failure', function() {
-        it('should throw if platform is unrecognized', function() {
-            runs(function() {
-                uninstallPromise(uninstall('atari', project, 'SomePlugin'));
+        it('should throw if platform is unrecognized', function(done) {
+            uninstall('atari', project, 'SomePlugin').then(function(result){
+                expect(false).toBe(true);
+                done();
+            },
+            function err(errMsg) {
+                expect(clone).toHaveBeenCalledWith(url, temp, dir, ref, undefined);
+                expect(save_metadata).toHaveBeenCalled();
+                done();
             });
-            waitsFor(function() { return done; }, 'promise never resolved', 200);
-            runs(function() {
-                expect(''+done).toContain('atari not supported.');
+        }, 6000);
+
+        it('should throw if plugin is missing', function(done) {
+            uninstall('android', project, 'SomePluginThatDoesntExist').then(function(result){
+                expect(false).toBe(true);
+                done();
+            },
+            function err(errMsg) {
+                expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
+                done();
             });
-        });
-        it('should throw if plugin is missing', function() {
-            runs(function() {
-                uninstallPromise(uninstall('android', project, 'SomePluginThatDoesntExist'));
-            });
-            waitsFor(function() { return done; }, 'promise never resolved', 200);
-            runs(function() {
-                expect(''+done).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-            });
-        });
+        }, 6000);
     });
 });
 
 describe('end', function() {
     it('end', function() {
         done = false;
-
         promise.then(function(){
             return uninstall('android', project, plugins['org.test.plugins.dummyplugin']);
         }).then(function(){
@@ -350,7 +356,6 @@ describe('end', function() {
             shell.rm('-rf', project, project2, project3);
             done = true;
         });
-
         waitsFor(function() { return done; }, 'promise never resolved', 500);
     });
 });

--- a/cordova-lib/spec-plugman/util/csproj.spec.js
+++ b/cordova-lib/spec-plugman/util/csproj.spec.js
@@ -23,12 +23,12 @@ var wp8_project     = path.join(__dirname, '..', 'projects', 'wp8'),
     example_csproj  = path.join(wp8_project, 'CordovaAppProj.csproj');
 
 describe('csproj', function() {
-    it('should throw if passed in an invalid xml file path ref', function() {
+    it('Test 001 : should throw if passed in an invalid xml file path ref', function() {
         expect(function() {
             new csproj('blahblah');
         }).toThrow();
     });
-    it('should successfully parse a valid csproj file into an xml document', function() {
+    it('Test 002 : should successfully parse a valid csproj file into an xml document', function() {
         var doc;
         expect(function() {
             doc = new csproj(example_csproj);
@@ -50,22 +50,22 @@ describe('csproj', function() {
 
         describe('add method', function() {
             var test_csproj = new csproj(example_csproj);
-            it('should properly add .xaml files', function() {
+            it('Test 003 : should properly add .xaml files', function() {
                 test_csproj.addSourceFile(page_test);
                 expect(test_csproj.xml.getroot().find('.//Page[@Include="src\\UI\\PageTest.xaml"]')).toBeTruthy();
                 expect(test_csproj.xml.getroot().find('.//Page[@Include="src\\UI\\PageTest.xaml"]/Generator').text).toEqual('MSBuild:Compile');
                 expect(test_csproj.xml.getroot().find('.//Page[@Include="src\\UI\\PageTest.xaml"]/SubType').text).toEqual('Designer');
             });
-            it('should properly add .xaml.cs files', function() {
+            it('Test 004 : should properly add .xaml.cs files', function() {
                 test_csproj.addSourceFile(page_test_cs);
                 expect(test_csproj.xml.getroot().find('.//Compile[@Include="src\\UI\\PageTest.xaml.cs"]')).toBeTruthy();
                 expect(test_csproj.xml.getroot().find('.//Compile[@Include="src\\UI\\PageTest.xaml.cs"]/DependentUpon').text).toEqual('PageTest.xaml');
             });
-            it('should properly add .cs files', function() {
+            it('Test 005 : should properly add .cs files', function() {
                 test_csproj.addSourceFile(file_test);
                 expect(test_csproj.xml.getroot().find('.//Compile[@Include="src\\FileTest.cs"]')).toBeTruthy();
             });
-            it('should properly add content files', function() {
+            it('Test 006 : should properly add content files', function() {
                 test_csproj.addSourceFile(content_test);
                 expect(test_csproj.xml.getroot().find('.//Content[@Include="src\\Content.img"]')).toBeTruthy();
             });
@@ -73,23 +73,23 @@ describe('csproj', function() {
 
         describe('remove method', function() {
             var test_csproj = new csproj(example_csproj);
-            it('should properly remove .xaml pages', function() {
+            it('Test 007 : should properly remove .xaml pages', function() {
                 test_csproj.removeSourceFile(page_test);
                 expect(test_csproj.xml.getroot().find('.//Page[@Include="src\\UI\\PageTest.xaml"]')).toBeFalsy();
             });
-            it('should properly remove .xaml.cs files', function() {
+            it('Test 008 : should properly remove .xaml.cs files', function() {
                 test_csproj.removeSourceFile(page_test_cs);
                 expect(test_csproj.xml.getroot().find('.//Compile[@Include="src\\UI\\PageTest.xaml.cs"]')).toBeFalsy();
             });
-            it('should properly remove .cs files', function() {
+            it('Test 009 : should properly remove .cs files', function() {
                 test_csproj.removeSourceFile(file_test);
                 expect(test_csproj.xml.getroot().find('.//Compile[@Include="src\\FileTest.cs"]')).toBeFalsy();
             });
-            it('should properly remove content files', function() {
+            it('Test 010 : should properly remove content files', function() {
                 test_csproj.removeSourceFile(content_test);
                 expect(test_csproj.xml.getroot().find('.//Content[@Include="src\\Content.img"]')).toBeFalsy();
             });
-            it('should remove all empty ItemGroup\'s', function() {
+            it('Test 011 : should remove all empty ItemGroup\'s', function() {
                 test_csproj.removeSourceFile(page_test);
                 test_csproj.removeSourceFile(page_test_cs);
                 test_csproj.removeSourceFile(lib_test);

--- a/cordova-lib/spec-plugman/util/dependencies.spec.js
+++ b/cordova-lib/spec-plugman/util/dependencies.spec.js
@@ -24,7 +24,7 @@ var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 
 describe('dependency module', function() {
     describe('generateDependencyInfo method', function() {
-        it('should return a list of top-level plugins based on what is inside a platform.json file', function() {
+        it('Test 001 : should return a list of top-level plugins based on what is inside a platform.json file', function() {
             var tlps = {
                 'hello':'',
                 'isitme':'',
@@ -38,11 +38,11 @@ describe('dependency module', function() {
             Object.keys(tlps).forEach(function(k) {
                 pluginInfoProvider.put({id:k, dir: path.join('plugins_dir', k), getDependencies: function() {return[];}});
             });
-            spyOn(xml_helpers, 'parseElementtreeSync').andReturn({findall:function(){}});
+            spyOn(xml_helpers, 'parseElementtreeSync').and.returnValue({findall:function(){}});
             var obj = dependencies.generateDependencyInfo(platformJson, 'plugins_dir', pluginInfoProvider);
             expect(obj.top_level_plugins).toEqual(Object.keys(tlps));
         });
-        it('should return a dependency graph for the plugins', function() {
+        it('Test 002 : should return a dependency graph for the plugins', function() {
             var tlps = {
                 'A':'',
                 'B':''

--- a/cordova-lib/spec-plugman/wrappers.spec.js
+++ b/cordova-lib/spec-plugman/wrappers.spec.js
@@ -34,13 +34,13 @@ describe('callback wrapper', function() {
             });
 
             it('should work with no callback and success', function() {
-                raw.andReturn(Q());
+                raw.and.returnValue(Q());
                 plugman[call]();
                 expect(raw).toHaveBeenCalled();
             });
 
             it('should call the callback on success', function(done) {
-                raw.andReturn(Q(1));
+                raw.and.returnValue(Q(1));
                 plugman[call](function(err) {
                     expect(err).toBeUndefined();
                     done();
@@ -49,7 +49,7 @@ describe('callback wrapper', function() {
 
             it('should call the callback with the error on failure', function(done) {
                 var err = new Error('junk');
-                raw.andCallFake(function() { return Q.reject(err); });
+                raw.and.callFake(function() { return Q.reject(err); });
                 plugman[call](function(err) {
                     expect(err).toEqual(err);
                     done();

--- a/cordova-lib/spec-plugman/wrappers.spec.js
+++ b/cordova-lib/spec-plugman/wrappers.spec.js
@@ -33,13 +33,13 @@ describe('callback wrapper', function() {
                 raw = spyOn(plugman.raw, call);
             });
 
-            it('should work with no callback and success', function() {
+            it('Test 001 : should work with no callback and success', function() {
                 raw.and.returnValue(Q());
                 plugman[call]();
                 expect(raw).toHaveBeenCalled();
             });
 
-            it('should call the callback on success', function(done) {
+            it('Test 002 : should call the callback on success', function(done) {
                 raw.and.returnValue(Q(1));
                 plugman[call](function(err) {
                     expect(err).toBeUndefined();
@@ -47,7 +47,7 @@ describe('callback wrapper', function() {
                 });
             });
 
-            it('should call the callback with the error on failure', function(done) {
+            it('Test 003 : should call the callback with the error on failure', function(done) {
                 var err = new Error('junk');
                 raw.and.callFake(function() { return Q.reject(err); });
                 plugman[call](function(err) {

--- a/cordova-lib/spec/support/jasmine.json
+++ b/cordova-lib/spec/support/jasmine.json
@@ -1,0 +1,13 @@
+{
+    "spec_dir": "spec",
+    "spec_files": [
+    	"../spec-cordova/**/*[sS]pec.js",
+    	"../spec-plugman/**/*[sS]pec.js"
+    ],
+    "helpers": [
+      "../spec-cordova/helpers.js",
+      "../spec-cordova/helper.js"
+    ],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?

Updates tests in cordova-lib to use jasmine instead of jasmine-node.
### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
