### PR TITLE
CB-12261: Fix subdirectories deprecated warning always shows and stop fetch for…

### DIFF
--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -69,7 +69,7 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                 options.subdir = result[2];
             //if --fetch was used, throw error for subdirectories
 
-            if(options.subdir) {
+            if (options.subdir && options.subdir !== '.') {
                 events.emit('warn', 'support for subdirectories is deprecated and will be removed in Cordova@7');
                 if (options.fetch) {
                     return Q.reject(new CordovaError('--fetch does not support subdirectories'));


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
Fix the issue created by CB-11979, the subdirectories deprecated warning always shows and stop fetch

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

_Not sure how the test should be written since the original PR does not comes with a test._
