### PR TITLE
CB-12284 Include project root as additional root for static router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ temp
 .DS_Store
 spec-cordova/fixtures/projects/native
 spec-cordova/fixtures/projects/cordova
-.idea/*
+.idea
 .gitcore
 *.jar
 .vscode

--- a/cordova-serve/src/server.js
+++ b/cordova-serve/src/server.js
@@ -55,6 +55,13 @@ module.exports = function (opts) {
         app.use(express.static(opts.root));
     }
 
+    // If we have a project root, make that available as a static root also. This can be useful in cases where source
+    // files that have been transpiled (such as TypeScript) are located under the project root on a path that mirrors
+    // the the transpiled file's path under the platform root and is pointed to by a map file.
+    if (this.projectRoot) {
+        app.use(express.static(this.projectRoot));
+    }
+
     var that = this;
     server.listen(port).on('listening', function () {
         that.port = port;


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
With this change, cordova-serve includes the project root as an additional root for static routing. This is the final piece a middleware, so will only be utilized when a file isn't found through other means (the default static routing which points to the platform root, or other middleware that may have been injected by a third party).

This can be useful in cases where source files that have been transpiled (such as TypeScript files) are located under the project root on a path that mirrors the the transpiled file's path under the platform root, and is pointed to by a map file (otherwise when debugging in a browser, the browser won't be able to find the original source file).

### What testing has been done on this change?
Verified is resolved the problem reported in the bug, and lets you debug using original TypeScript sources in a TypeScript project, as long as the path to the TypeScript source relative to the project root mirrors the path to the generated JavaScript and map file relative to the www folder.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
