### PR TITLE
CB-12189 windows: Add `implementation` attribute to frameworks

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -323,7 +323,8 @@ function PluginInfo(dirname) {
                 versions: el.attrib.versions,
                 targetDir: el.attrib['target-dir'],
                 deviceTarget: el.attrib['device-target'] || el.attrib.target,
-                arch: el.attrib.arch
+                arch: el.attrib.arch,
+                implementation: el.attrib.implementation
             };
             return ret;
         });


### PR DESCRIPTION
The attribute is windows-specific and allows to specify implementation for WinMD components, written in C++

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
