### PR TITLE
CB-12337 Resolve symbolic links in project root

### DIFF
--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -146,7 +146,7 @@ function isCordova(dir) {
 
 // Cd to project root dir and return its path. Throw CordovaError if not in a Corodva project.
 function cdProjectRoot() {
-    var projectRoot = this.isCordova();
+    var projectRoot = convertToRealPathSafe(this.isCordova());
     if (!projectRoot) {
         throw new CordovaError('Current working directory is not a Cordova-based project.');
     }


### PR DESCRIPTION
### Platforms affected
All?

### What does this PR do?

If project path had symlinks its absolute value was different from that returned by `__dirname` inside project-local modules. So when it was joined with various dirs like `www` the two absolute paths were merged resulting in an invalid path.

This should make commands like `cordova emulate android` work on Windows for projects with symlinks in path.

There may be other places where similar measures need to be taken.

### What testing has been done on this change?
Tested locally on my project.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
