### PR TITLE
CB-12383 Fix cordova_plugins metadata definition

### DIFF
--- a/cordova-lib/src/plugman/browserify.js
+++ b/cordova-lib/src/plugman/browserify.js
@@ -157,8 +157,8 @@ module.exports = function doBrowserify (project, platformApi, pluginInfoProvider
         // instead of generating intermediate file on FS
         var cordova_plugins = new Readable();
         cordova_plugins.push(
-            'module.exports.metadata = ' + JSON.stringify(pluginMetadata, null, 4) + ';\n' +
-            'module.exports = ' + JSON.stringify(modulesMetadata, null, 4) + ';\n', 'utf8');
+            'module.exports = ' + JSON.stringify(modulesMetadata, null, 4) + ';\n' +
+            'module.exports.metadata = ' + JSON.stringify(pluginMetadata, null, 4) + ';\n', 'utf8');
         cordova_plugins.push(null);
 
         var bootstrap = new Readable();


### PR DESCRIPTION
Define parent object first
[Jira issue](https://issues.apache.org/jira/browse/CB-12383)

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Tested on windows and android with this code:
```
    onDeviceReady: function() {
        this.receivedEvent('deviceready');

        navigator.notification.alert(cordova.require("cordova/plugin_list").metadata);
    },
```

### What does this PR do?
Makes `require("cordova/plugin_list").metadata` also available with browserify.

### What testing has been done on this change?
Manual tests, run cordova-lib auto tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
