### PR TITLE
CB-12385: (win32/linux/darwin) auto open devtools in chrome for cordova-serve

### DIFF
--- a/cordova-serve/src/browser.js
+++ b/cordova-serve/src/browser.js
@@ -89,7 +89,7 @@ module.exports = function (opts) {
 function getBrowser(target, dataDir) {
     dataDir = dataDir || 'temp_chrome_user_data_dir_for_cordova';
 
-    var chromeArgs = ' --user-data-dir=/tmp/' + dataDir;
+    var chromeArgs = ' --auto-open-devtools-for-tabs --user-data-dir=/tmp/' + dataDir;
     var browsers = {
         'win32': {
             'ie': 'iexplore',


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
linux, win32, darwin

### What does this PR do?
Automatically open the devtools for developer

### What testing has been done on this change?
chrome on darwin has been tested.

### Checklist
- [ Y ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ Y ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
