### PR TITLE
CB-11346 - Remove known platforms check for Platform API

### DIFF
--- a/cordova-lib/src/platforms/PlatformApiPoly.js
+++ b/cordova-lib/src/platforms/PlatformApiPoly.js
@@ -55,9 +55,6 @@ function PlatformApiPoly(platform, platformRootDir, events) {
     this.platform = platform;
     this.events = events || require('cordova-common').events;
 
-    if (!(platform in knownPlatforms))
-        throw new CordovaError('Unknown platform ' + platform);
-
     var ParserConstructor = require(knownPlatforms[platform].parser_file);
     this._parser = new ParserConstructor(this.root);
     this._handler = require(knownPlatforms[platform].handler_file);


### PR DESCRIPTION
### Platforms affected

CLI

### What does this PR do?

Removes platforms check. Right now only known platforms are installable.

### What testing has been done on this change?

None. Unit tests are coming.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
