### PR TITLE
CB-12557: superspawn now returns both stdout and stderr in reject handler

### DIFF
--- a/cordova-common/spec/superspawn.spec.js
+++ b/cordova-common/spec/superspawn.spec.js
@@ -53,4 +53,39 @@ describe('spawn method', function() {
         });
     });
 
+    it('Test 004 : reject handler should pass in Error object with stdout and stderr properties', function(done) {
+        var cp = require('child_process');
+        spyOn(cp, 'spawn').and.callFake(function(cmd, args, opts) {
+            return {
+                stdout:{
+                    setEncoding: function(){},
+                    on: function(evt, handler) {
+                        // some sample stdout output
+                        handler('business as usual');
+                    }
+                },
+                stderr:{
+                    setEncoding: function(){},
+                    on: function(evt, handler) {
+                        // some sample stderr output
+                        handler('mayday mayday');
+                    }
+                },
+                on: function(evt, handler) {
+                    // What's passed to handler here is the exit code, so we can control
+                    // resolve/reject flow via this argument.
+                    handler(1); // this will trigger error flow
+                },
+                removeListener: function() {}
+            };
+        });
+        superspawn.spawn('this aggression', ['will', 'not', 'stand', 'man'], {})
+        .catch(function(err) {
+            expect(err).toBeDefined();
+            expect(err.stdout).toContain('usual');
+            expect(err.stderr).toContain('mayday');
+            done();
+        });
+    });
+
 });

--- a/cordova-common/src/superspawn.js
+++ b/cordova-common/src/superspawn.js
@@ -167,6 +167,12 @@ exports.spawn = function(cmd, args, opts) {
                 errMsg += ' Error output:\n' + capturedErr.trim();
             }
             var err = new Error(errMsg);
+            if (capturedErr) {
+                err.stderr = capturedErr;
+            }
+            if (capturedOut) {
+                err.stdout = capturedOut;
+            }
             err.code = code;
             d.reject(err);
         }


### PR DESCRIPTION
Please review @stevengill and @audreyso. 

### Platforms affected

All.

### What does this PR do?

This solves [CB-12557](https://issues.apache.org/jira/browse/CB-12557).

Some programs pump output to both stdout and stderr when exit codes are non-zero (i.e. `android`). It would be nice to get access to both streams in the reject handler.

In particular, to solve the suite of new issues arising from the updated Android SDK Tools in 25.3.1 ([CB-12554](https://issues.apache.org/jira/browse/CB-12554)), we need to detect when the `android` command exits with a non-zero status code _and_ contains particular language in `stdout`. This change to `superspawn` allows for that level of introspection.

### What testing has been done on this change?

Ran `npm test` on master branch, all tests pass. Then ran `npm test` on this branch, which includes a new test covering this case, all tests pass.

### Questions

Assuming this is OK, what would it take bump the version and release this to npm? [CB-12554](https://issues.apache.org/jira/browse/CB-12554) relies on this.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
