### PR TITLE
CB-12572: (windows) pin cordova-windows 5.0.0

### DIFF
--- a/cordova-lib/src/platforms/platformsConfig.json
+++ b/cordova-lib/src/platforms/platformsConfig.json
@@ -75,7 +75,7 @@
         "parser_file": "../cordova/metadata/windows_parser",
         "handler_file": "../plugman/platforms/windows",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",
-        "version": "~4.4.0",
+        "version": "~5.0.0",
         "apiCompatibleSince": "4.3.0",
         "deprecated": false
     },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Windows

### What does this PR do?

[CB-12572](https://issues.apache.org/jira/browse/CB-12572): use cordova-windows 5.0.0

This is needed to support Windows plugin WinMD+DLL combinations ([CB-12189](https://issues.apache.org/jira/browse/CB-12189)).

### What testing has been done on this change?

- Install cordova-lib with this change in a local checkout of cordova-cli
- Do npm install of the local cordova-cli in a test directory
- Use the local cordova-cli to add the Windows platform to a local checkout of <https://github.com/brodybits/cordova-dialogs-bootstrap-test>
- do `cordova platform ls` to verify that cordova-windows 5.0.0 was used
- Build and run as both desktop and mobile app (using Visual Studio 2015)

I do not think there is any need to update the automatic test suite. Please correct me in case I am mistaken.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] ~~Added automated test coverage as appropriate for this change.~~
