### PR TITLE
CB-12606 Fix plugin dependency installation

### DIFF
--- a/cordova-lib/spec-plugman/install.spec.js
+++ b/cordova-lib/spec-plugman/install.spec.js
@@ -18,6 +18,7 @@
 */
 
 /* jshint sub:true */
+/* globals fail*/
 
 var helpers = require('../spec-cordova/helpers'),
     path = require('path'),
@@ -65,10 +66,11 @@ var helpers = require('../spec-cordova/helpers'),
         'C@1.0.0' : path.join(plugins_dir, 'dependencies', 'C@1.0.0'),
         'Test1' : path.join(plugins_dir, 'dependencies', 'Test1'),
         'Test2' : path.join(plugins_dir, 'dependencies', 'Test2'),
-        'Test3' : path.join(plugins_dir, 'dependencies', 'Test3')
+        'Test3' : path.join(plugins_dir, 'dependencies', 'Test3'),
+        'Test4' : path.join(plugins_dir, 'dependencies', 'Test4')
     },
     results = {},
-    TIMEOUT = 60000,
+    TIMEOUT = 90000,
     superspawn = require('cordova-common').superspawn;
 
 
@@ -649,11 +651,34 @@ describe('end-to-end plugin dependency tests', function() {
         }, TIMEOUT)
         .fin(done);
     }, TIMEOUT);
+
+    it('Test 033 : should use a dev version of a dependent plugin if it is already installed', function(done) {
+        //Test4 has this dependency in its plugin.xml:
+        //<dependency id="cordova-plugin-file" url="https://github.com/apache/cordova-plugin-file" />
+        cordova.raw.create('hello3')
+        .then(function() {
+            process.chdir(project);
+            return cordova.raw.platform('add', 'android', {'fetch': true});
+        })
+        .then(function() {
+            return cordova.raw.plugin('add', 'https://github.com/apache/cordova-plugin-file');
+        })
+        .then(function() {
+            return cordova.raw.plugin('add', plugins['Test4'], {'fetch': true});
+        })
+        .then(function() {
+            expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
+            expect(path.join(pluginsDir, 'Test4')).toExist();
+        }, function (error) {
+            fail(error);
+        })
+        .fin(done);
+    }, TIMEOUT);
 });
 
 describe('end', function() {
 
-    it('Test 033 : end', function() {
+    it('Test 034 : end', function() {
         shell.rm('-rf', temp_dir);
     }, TIMEOUT);
 });

--- a/cordova-lib/spec-plugman/plugins/dependencies/README.md
+++ b/cordova-lib/spec-plugman/plugins/dependencies/README.md
@@ -14,4 +14,5 @@ I -> C@1.0.0
 Test1 --> cordova-plugin-file@2.0.0
 Test2 --> cordova-plugin-file@2.X.0
 Test3 --> cordova-plugin-file@3.0.0
+Test4 --> cordova-plugin-file@https://github.com/apache/cordova-plugin-file
 

--- a/cordova-lib/spec-plugman/plugins/dependencies/Test4/package.json
+++ b/cordova-lib/spec-plugman/plugins/dependencies/Test4/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test4",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/cordova-lib/spec-plugman/plugins/dependencies/Test4/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/dependencies/Test4/plugin.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2013 Anis Kadri
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="Test4"
+    version="0.0.0">
+
+    <name>Plugin Test4</name>
+
+    <dependency id="cordova-plugin-file" url="https://github.com/apache/cordova-plugin-file" />
+
+    <asset src="www/plugin-test.js" target="plugin-test.js" />
+
+    <config-file target="config.xml" parent="/*">
+        <access origin="build.phonegap.com" />
+    </config-file>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="plugins">
+            <plugin name="Test4"
+                value="org.test.Test4.Test4"/>
+        </config-file>
+
+        <source-file src="src/android/Test4.java"
+                target-dir="src/com/phonegap/Test4" />
+    </platform>
+</plugin>

--- a/cordova-lib/spec-plugman/plugins/dependencies/Test4/src/android/Test4.java
+++ b/cordova-lib/spec-plugman/plugins/dependencies/Test4/src/android/Test4.java
@@ -1,0 +1,1 @@
+./dependencies/Test3/src/android/Test4.java

--- a/cordova-lib/spec-plugman/plugins/dependencies/Test4/www/plugin-test.js
+++ b/cordova-lib/spec-plugman/plugins/dependencies/Test4/www/plugin-test.js
@@ -1,0 +1,1 @@
+./dependencies/Test4/www/plugin-test.js

--- a/cordova-lib/src/plugman/install.js
+++ b/cordova-lib/src/plugman/install.js
@@ -558,7 +558,8 @@ function installDependency(dep, install, options) {
         if (options.force || 
             semver.satisfies(version_installed, version_required, /*loose=*/true) || 
             version_required === null || 
-            version_required === undefined ) {
+            version_required === undefined ||
+            version_required === '' ) {
             events.emit('log', 'Plugin dependency "' + (version_installed ? dep.id+'@'+version_installed : dep.id) + '" already fetched, using that version.');
         } else {
             var msg = 'Version of installed plugin: "' +


### PR DESCRIPTION
### Platforms affected
all

### What does this PR do?
Fixes a problem described here:
https://issues.apache.org/jira/browse/CB-12606
In short, cordova fails to cope with already installed plugin dependency, if this dependency is of version with "-dev" suffix.

### What testing has been done on this change?
Manually tested on Windows with Android platform. Added an automated test.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
