### PR TITLE
CB-12250 CB-12409 iOS: Fix bug with escaping properties from plist file

### DIFF
--- a/cordova-common/spec/plist-helpers.spec.js
+++ b/cordova-common/spec/plist-helpers.spec.js
@@ -1,0 +1,42 @@
+var plistHelpers = require('../src/util/plist-helpers');
+
+
+describe('prunePLIST', function() {
+    var doc =  {
+        FirstConfigKey: {
+            FirstPreferenceName: '*',
+            SecondPreferenceName: 'a + b',
+            ThirdPreferenceName: 'x-msauth-$(CFBundleIdentifier:rfc1034identifier)'
+        },
+
+        SecondConfigKey: {
+            FirstPreferenceName: 'abc'
+        }
+    };
+
+    var xml = '<dict>' +
+                '<key>FirstPreferenceName</key>' +
+                '<string>*</string>'  +
+                '<key>SecondPreferenceName</key>' +
+                '<string>a + b</string>'  +
+                '<key>ThirdPreferenceName</key>' +
+                '<string>x-msauth-$(CFBundleIdentifier:rfc1034identifier)</string>'  +
+              '</dict>';
+
+    var selector = 'FirstConfigKey';
+
+    it('Test 01: should remove property from plist file using provided selector', function(done) {
+        var pruneStatus = plistHelpers.prunePLIST(doc, xml, selector);
+
+        expect(pruneStatus).toBeTruthy();
+        expect(doc).toEqual(
+            {
+                SecondConfigKey: {
+                    FirstPreferenceName: 'abc'
+                }
+            }
+        );
+
+        done();
+    });
+});

--- a/cordova-common/src/util/plist-helpers.js
+++ b/cordova-common/src/util/plist-helpers.js
@@ -84,7 +84,7 @@ function nodeEqual(node1, node2) {
     if (typeof node1 != typeof node2)
         return false;
     else if (typeof node1 == 'string') {
-        node2 = escapeRE(node2).replace(new RegExp('\\$[a-zA-Z0-9-_]+','gm'),'(.*?)');
+        node2 = escapeRE(node2).replace(/\\\$\S+/gm,'(.*?)');
         return new RegExp('^' + node2 + '$').test(node1);
     }
     else {
@@ -97,5 +97,5 @@ function nodeEqual(node1, node2) {
 
 // escape string for use in regex
 function escapeRE(str) {
-    return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '$&');
+    return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }

--- a/cordova-lib/src/plugman/util/plist-helpers.js
+++ b/cordova-lib/src/plugman/util/plist-helpers.js
@@ -84,7 +84,7 @@ function nodeEqual(node1, node2) {
     if (typeof node1 != typeof node2)
         return false;
     else if (typeof node1 == 'string') {
-        node2 = escapeRE(node2).replace(new RegExp('\\$[a-zA-Z0-9-_]+','gm'),'(.*?)');
+        node2 = escapeRE(node2).replace(/\\\$\S+/gm,'(.*?)');
         return new RegExp('^' + node2 + '$').test(node1);
     }
     else {
@@ -97,5 +97,5 @@ function nodeEqual(node1, node2) {
 
 // escape string for use in regex
 function escapeRE(str) {
-    return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '$&');
+    return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
This PR fixes some bugs with removing properties from `.plist` file

### What testing has been done on this change?
auto-test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
