### PR TITLE
CB-11233 - Support installing frameworks into "Embedded Binaries" section of the Xcode project

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -319,6 +319,7 @@ function PluginInfo(dirname) {
                 type: el.attrib.type,
                 parent: el.attrib.parent,
                 custom: isStrTrue(el.attrib.custom),
+                embed: isStrTrue(el.attrib.embed),
                 src: el.attrib.src,
                 spec: el.attrib.spec,
                 weak: isStrTrue(el.attrib.weak),

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -275,7 +275,7 @@ describe('ios project handler', function() {
 
                 frameworks = copyArray(valid_weak_frameworks);
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.join('src','ios','libsqlite3.dylib'), { customFramework: false, embed: false, link: true, weak: true });
+                expect(spy).toHaveBeenCalledWith('src/ios/libsqlite3.dylib', { customFramework: false, embed: false, link: true, weak: true });
 
             });
 

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -275,7 +275,7 @@ describe('ios project handler', function() {
 
                 frameworks = copyArray(valid_weak_frameworks);
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize(path.join('src','ios','libsqlite3.dylib')), { customFramework: false, embed: false, link: true, weak: true });
+                expect(spy).toHaveBeenCalledWith(path.join('src','ios','libsqlite3.dylib'), { customFramework: false, embed: false, link: true, weak: true });
 
             });
 

--- a/cordova-lib/spec-plugman/platforms/ios.spec.js
+++ b/cordova-lib/spec-plugman/platforms/ios.spec.js
@@ -41,7 +41,9 @@ var dummy_id = dummyPluginInfo.id;
 var valid_source = dummyPluginInfo.getSourceFiles('ios'),
     valid_headers = dummyPluginInfo.getHeaderFiles('ios'),
     valid_resources = dummyPluginInfo.getResourceFiles('ios'),
-    valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom; });
+    valid_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom && !(f.embed); }),
+    valid_embeddable_custom_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return f.custom && f.embed; }),
+    valid_weak_frameworks = dummyPluginInfo.getFrameworks('ios').filter(function(f) { return !(f.custom) && f.weak; });
 
 var faultyPluginInfo = new PluginInfo(faultyplugin);
 var faulty_id = faultyPluginInfo.id;
@@ -265,7 +267,16 @@ describe('ios project handler', function() {
                 var frameworks = copyArray(valid_custom_frameworks);
                 var spy = spyOn(proj_files.xcode, 'addFramework');
                 ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
-                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), {customFramework:true});
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/Custom.framework'), { customFramework: true, embed: false, link: true });
+
+                frameworks = copyArray(valid_embeddable_custom_frameworks);
+                ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
+                expect(spy).toHaveBeenCalledWith(path.normalize('SampleApp/Plugins/org.test.plugins.dummyplugin/CustomEmbeddable.framework'), { customFramework: true, embed: true, link: false });
+
+                frameworks = copyArray(valid_weak_frameworks);
+                ios['framework'].install(frameworks[0], dummyplugin, temp, dummy_id, null, proj_files);
+                expect(spy).toHaveBeenCalledWith(path.normalize(path.join('src','ios','libsqlite3.dylib')), { customFramework: false, embed: false, link: true, weak: true });
+
             });
 
             // TODO: Add more tests to cover the cases:

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin.xml
@@ -135,6 +135,7 @@
         <framework src="src/ios/libsqlite3.dylib" />
         <framework src="src/ios/libsqlite3.dylib" weak="true" />
         <framework src="src/ios/Custom.framework" custom="true" />
+        <framework src="src/ios/CustomEmbeddable.framework" custom="true" embed="true" />
     </platform>
 
     <!-- wp8 -->

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/someFheader.h

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib
@@ -1,0 +1,1 @@
+./org.test.plugins.dummyplugin/src/ios/CustomEmbeddable.framework/somebinlib

--- a/cordova-lib/src/plugman/platforms/ios.js
+++ b/cordova-lib/src/plugman/platforms/ios.js
@@ -178,7 +178,9 @@ module.exports = {
     'framework':{ // CB-5238 custom frameworks only
         install:function(obj, plugin_dir, project_dir, plugin_id, options, project) {
             var src = obj.src,
-                custom = obj.custom;
+                custom = !!(obj.custom), // convert to boolean (if truthy/falsy)
+                embed = !!(obj.embed), // convert to boolean (if truthy/falsy)
+                link = !embed; // either link or embed can be true, but not both. the other has to be false
 
             if (!custom) {
                 var keepFrameworks = keep_these_frameworks;
@@ -187,7 +189,7 @@ module.exports = {
                     keepFrameworks = keepFrameworks.concat(['CoreLocation.framework']);
                 }
                 if (keepFrameworks.indexOf(src) < 0) {
-                    project.xcode.addFramework(src, {weak: obj.weak});
+                    project.xcode.addFramework(src, { customFramework: false, embed: false, link: true, weak: obj.weak });
                     project.frameworks[src] = (project.frameworks[src] || 0) + 1;
                 }
                 return;
@@ -200,7 +202,7 @@ module.exports = {
             shell.mkdir('-p', path.dirname(targetDir));
             shell.cp('-R', srcFile, path.dirname(targetDir)); // frameworks are directories
             var project_relative = path.relative(project_dir, targetDir);
-            var pbxFile = project.xcode.addFramework(project_relative, {customFramework: true});
+            var pbxFile = project.xcode.addFramework(project_relative, { customFramework: true, embed: embed, link: link });
             if (pbxFile) {
                 project.xcode.addToPbxEmbedFrameworksBuildPhase(pbxFile);
             }


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Support the "embed" attribute for the `<framework>` tag of plugin.xml to facilitate installing custom iOS frameworks into the Embedded Binaries section of the Xcode project for the iOS platform

### What testing has been done on this change?

Added unit tests to `cordova-lib\spec-plugman\platforms\ios.spec.js`

### Other notes

Complementary PR: https://github.com/apache/cordova-ios/pull/299

### Checklist

- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-XXXX"
- [X] Added automated test coverage as appropriate for this change.
