### PR TITLE
CB-11233 - Support installing frameworks into 'Embedded Binaries' section of the Xcode project

### DIFF
--- a/cordova-common/src/PluginInfo/PluginInfo.js
+++ b/cordova-common/src/PluginInfo/PluginInfo.js
@@ -319,6 +319,7 @@ function PluginInfo(dirname) {
                 type: el.attrib.type,
                 parent: el.attrib.parent,
                 custom: isStrTrue(el.attrib.custom),
+                embed: isStrTrue(el.attrib.embed),
                 src: el.attrib.src,
                 spec: el.attrib.spec,
                 weak: isStrTrue(el.attrib.weak),


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Support the "embed" attribute for the `<framework>` tag of plugin.xml to facilitate installing custom iOS frameworks into the Embedded Binaries section of the Xcode project for the iOS platform

### What testing has been done on this change?

Unit tests are in the iOS platform, through the Platform API, see: https://github.com/apache/cordova-ios/pull/299

### Checklist

- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-XXXX"
- [X] Added automated test coverage as appropriate for this change.
