### PR TITLE
CB-12663: Install latest version of plugin in case of using dev cordova version

### DIFF
--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -863,6 +863,11 @@ function determinePluginVersionToFetch(pluginInfo, pluginMap, platformMap, cordo
 
 function getFailedRequirements(reqs, pluginMap, platformMap, cordovaVersion) {
     var failed = [];
+    var version = cordovaVersion;
+    if (semver.prerelease(version)) {
+        //  semver.inc with 'patch' type removes prereleased tag from version
+        version = semver.inc(version, 'patch');
+    }
 
     for (var req in reqs) {
         if(reqs.hasOwnProperty(req) && typeof req === 'string' && semver.validRange(reqs[req])) {
@@ -871,7 +876,7 @@ function getFailedRequirements(reqs, pluginMap, platformMap, cordovaVersion) {
 
             if(pluginMap[trimmedReq] && !semver.satisfies(pluginMap[trimmedReq], reqs[req])) {
                 badInstalledVersion = pluginMap[req];
-            } else if(trimmedReq === 'cordova' && !semver.satisfies(cordovaVersion, reqs[req])) {
+            } else if(trimmedReq === 'cordova' && !semver.satisfies(version, reqs[req])) {
                 badInstalledVersion = cordovaVersion;
             } else if(trimmedReq.indexOf('cordova-') === 0) {
                 // Might be a platform constraint


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
Semver couldn't verify if cordova version with prerelease tag satisfies to range specified in engine tag. 
This PR removes prereleased tag for comparing with range. It's about `cordova-plugin-inappbrowser` and `cordova-plugin-ms-adal` plugins.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
