### PR TITLE
CB-12662 - update cordova-common dependency to 2.0.2

### DIFF
--- a/cordova-fetch/package.json
+++ b/cordova-fetch/package.json
@@ -21,7 +21,7 @@
     "email": "dev@cordova.apache.org"
   },
   "dependencies": {
-    "cordova-common": "2.0.0",
+    "cordova-common": "2.0.2",
     "dependency-ls": "^1.0.0",
     "is-url": "^1.2.1",
     "q": "^1.4.1",

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -19,7 +19,7 @@
   "engineStrict": true,
   "dependencies": {
     "aliasify": "^2.1.0",
-    "cordova-common": "2.0.0",
+    "cordova-common": "2.0.2",
     "cordova-create": "^1.0.1",
     "cordova-fetch": "1.0.2",
     "cordova-js": "4.2.1",


### PR DESCRIPTION
### Platforms affected

All.

### What does this PR do?

Update the cordova-common dep in cordova-lib and cordova-fetch to 2.0.2

### What testing has been done on this change?

CI tests for this PR.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
