### PR TITLE
CB-12674 : Added deprecation notice for blackberry10 and ubuntu

### DIFF
--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -106,6 +106,10 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
                     platform = null;
                 }
 
+                if(platform === 'ubuntu' || platform === 'blackberry10') {
+                    events.emit(platform + ' has been deprecated and will be removed in the next major release of cordova.');
+                }
+
                 if(fs.existsSync(path.join(projectRoot,'package.json'))) {
                     pkgJson = cordova_util.requireNoCache(path.join(projectRoot, 'package.json'));
                 }

--- a/cordova-lib/src/platforms/platformsConfig.json
+++ b/cordova-lib/src/platforms/platformsConfig.json
@@ -31,14 +31,14 @@
         "handler_file": "../plugman/platforms/ubuntu",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-ubuntu.git",
         "version": "~4.3.4",
-        "deprecated": false
+        "deprecated": true
     },
     "blackberry10": {
         "parser_file": "../cordova/metadata/blackberry10_parser",
         "handler_file": "../plugman/platforms/blackberry10",
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-blackberry.git",
         "version": "~3.8.0",
-        "deprecated": false
+        "deprecated": true
     },
     "www": {
         "hostos": [],


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?

Added deprecation notice for blackberry10 and ubuntu.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
