### PR TITLE
CB-8978: Add option to get resource-file from root

### DIFF
--- a/cordova-common/spec/ConfigParser/ConfigParser.spec.js
+++ b/cordova-common/spec/ConfigParser/ConfigParser.spec.js
@@ -313,6 +313,10 @@ describe('config.xml parser', function () {
                 expect(cfg.getFileResources('android').every(hasTargetPropertyDefined)).toBeTruthy();
                 expect(cfg.getFileResources('windows').every(hasArchPropertyDefined)).toBeTruthy();
             });
+
+            it('should find resources at the top level', function() {
+                expect(cfg.getFileResources('android', true).length).toBe(3);
+            });
         });
     });
 });

--- a/cordova-common/spec/fixtures/test-config.xml
+++ b/cordova-common/spec/fixtures/test-config.xml
@@ -106,6 +106,7 @@
         <icon src="res/windows/logo-small.scale-400_48.png" height="48" target="logo.png"/>
         <resource-file src="windowsconfig.json" target="windowsconfig.json" arch="x86" device-target="all" />
     </platform>
+    <resource-file src="top-level-file.txt" target="toplevel.txt" />
     <plugin name="org.apache.cordova.pluginwithvars">
         <variable name="var" value="varvalue" />
     </plugin>

--- a/cordova-common/src/ConfigParser/ConfigParser.js
+++ b/cordova-common/src/ConfigParser/ConfigParser.js
@@ -269,9 +269,11 @@ ConfigParser.prototype = {
     /**
      * Returns all resource-files for a specific platform.
      * @param  {string} platform Platform name
+     * @param  {boolean} includeGlobal Whether to return resource-files at the
+     *                                 root level.
      * @return {Resource[]}      Array of resource file objects.
      */
-    getFileResources: function(platform) {
+    getFileResources: function(platform, includeGlobal) {
         var fileResources = [];
 
         if (platform) { // platform specific resources
@@ -284,6 +286,19 @@ ConfigParser.prototype = {
                     deviceTarget: tag.attrib['device-target'],
                     arch: tag.attrib.arch
                 };
+            });
+        }
+
+        if (includeGlobal) {
+            this.doc.findall('resource-file').forEach(function(tag) {
+                fileResources.push({
+                    platform: platform || null,
+                    src: tag.attrib.src,
+                    target: tag.attrib.target,
+                    versions: tag.attrib.versions,
+                    deviceTarget: tag.attrib['device-target'],
+                    arch: tag.attrib.arch
+                });
             });
         }
 


### PR DESCRIPTION
Step 1 of resolving the first issue mentioned in https://github.com/apache/cordova-android/pull/321#issuecomment-294985346
Step 2 will be updating the `cleanFileResources` function to pass in the new option.

This is needed for cleaning the resource-file targets, since they are at the top level of the platform's config.xml.

/cc @shazron 

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS, Android

### What does this PR do?
Provides an option to return `resource-file` tags from the top level of config.xml, instead of only returning ones nested under a particular platform.

### What testing has been done on this change?
Added spec test to verify top-level resource-files are returned when the option is specified.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
