### PR TITLE
CB-12683: improved error messaging for when a plugin doesn't have pac…

### DIFF
--- a/cordova-lib/spec-plugman/plugins/pkgjson-test-plugin/package.json
+++ b/cordova-lib/spec-plugman/plugins/pkgjson-test-plugin/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pkgjson-test-plugin",
+  "version": "1.3.0",
+  "description": "Empty plugin used as part of the tests",
+  "cordova": {
+    "id": "pkgjson-test-plugin",
+    "platforms": []
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://git-wip-us.apache.org/repos/asf/cordova-lib.git"
+  },
+  "author": "Apache Software Foundation",
+  "license": "Apache-2.0",
+  "engines": {
+    "cordovaDependencies": {
+      "0.0.0": {
+        "cordova-android": "<2.1.0"
+      },
+      "1.1.2": {
+        "cordova-android": ">=2.1.0 <4.0.0"
+      },
+      "1.3.0": {
+        "cordova-android": "4.0.0"
+      }
+    }
+  }
+}

--- a/cordova-lib/spec-plugman/plugins/pkgjson-test-plugin/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/pkgjson-test-plugin/plugin.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plugin id="pkgjson-test-plugin" version="0.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+    <name>cordova-lib-test-plugin</name>
+</plugin>

--- a/cordova-lib/src/plugman/fetch.js
+++ b/cordova-lib/src/plugman/fetch.js
@@ -117,10 +117,13 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
         // If it's not a network URL, it's either a local path or a plugin ID.
         var plugin_dir = cordovaUtil.fixRelativePath(path.join(plugin_src, options.subdir));
         return Q.when().then(function() {
-
+            // check if it is a local path
             if (fs.existsSync(plugin_dir)) {
-
                 if (options.fetch) {
+                    if (!fs.existsSync(path.join(plugin_dir, 'package.json'))) {
+                        return Q.reject(new CordovaError('Invalid Plugin! '+ plugin_dir + ' needs a valid package.json'));
+                    }
+
                     projectRoot = path.join(plugins_dir, '..');
                     //Plugman projects need to go up two directories to reach project root. 
                     //Plugman projects have an options.projectRoot variable
@@ -136,8 +139,12 @@ function fetchPlugin(plugin_src, plugins_dir, options) {
                                 path: directory
                             }
                         };
+                    }).fail(function(error) {
+                        //something went wrong with cordova-fetch
+                        return Q.reject(new CordovaError(error.message));
                     });
                 } else {
+                    //nofetch
                     return {
                         pinfo: pluginInfoProvider.get(plugin_dir),
                         fetchJsonSource: {


### PR DESCRIPTION
…kage.json

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
