### PR TITLE
CB-12705: Pass plugin info to project-level plugin hooks

### DIFF
--- a/cordova-lib/spec-cordova/HooksRunner.spec.js
+++ b/cordova-lib/spec-cordova/HooksRunner.spec.js
@@ -453,7 +453,8 @@ describe('HooksRunner', function() {
                             if(call.args[0] == 'before_plugin_uninstall' ||
                                 call.args[0] == 'before_plugin_install' ||
                                 call.args[0] == 'after_plugin_install') {
-                                if(call.args[1] && call.args[1].plugin) {
+                                if(call.args[1]) {
+                                    expect(call.args[1].plugin).toBeDefined();
                                     if(call.args[1].plugin.platform == 'android') {
                                         expect(JSON.stringify(androidPluginOpts) ===
                                             JSON.stringify(call.args[1])).toBe(true);

--- a/cordova-lib/src/hooks/HooksRunner.js
+++ b/cordova-lib/src/hooks/HooksRunner.js
@@ -178,7 +178,9 @@ function runScriptViaModuleLoader(script, context) {
     }
     var scriptFn = require(script.fullPath);
     context.scriptLocation = script.fullPath;
-    context.opts.plugin = script.plugin;
+    if(script.plugin) {
+        context.opts.plugin = script.plugin;
+    }
 
     // We can't run script if it is a plain Node script - it will run its commands when we require it.
     // This is not a desired case as we want to pass context, but added for compatibility.


### PR DESCRIPTION
### Platforms affected
Cordova-cli and maybe plugman

### What does this PR do?
Makes sure plugin information is passed to project-level `before_plugin_uninstall`, `before_plugin_install`, and `after_plugin_install` hooks.

### What testing has been done on this change?
Other than modifying the test spec for `HooksRunner.js`, I created a small test project with `before_plugin_uninstall`, `before_plugin_install`, and `after_plugin_install` js-hooks configured in `config.xml` which print the context to console. They now output plugin information just like they do for plugin hooks.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
