### PR TITLE
CB-12738: Cordova ignores plugin dependency version on windows platform

### DIFF
--- a/cordova-fetch/spec/fetch.spec.js
+++ b/cordova-fetch/spec/fetch.spec.js
@@ -146,7 +146,7 @@ describe('platform fetch/uninstall test via npm & git tags with --save', functio
             expect(err).toBeUndefined();
         })
         .fin(done);
-    }, 100000);
+    }, 150000);
 });
 
 describe('plugin fetch/uninstall test with --save', function () {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
windows

### What does this PR do?
Steps to reproduce w\ `cordova-7.0.2-dev`:
1) `cordova create sample`
2) `cordova platform add android`
3) `cordova plugin add cordova-plugin-file-transfer`

`Cordova-plugin-file-transfer` has `cordova-plugin-file@^4.0.0` as dependency and it should install the latest version (`4.4.3`), but after installation, I get `4.0.0`. Cordova treats `^` symbol as special in windows shell when running `npm.cmd install` and ignores it. We should enclose version range with quotes in case of windows platform.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
