### PR TITLE
CB-12786: Improve logic for searching plugin id in case of module already exists in node_modules

### DIFF
--- a/cordova-fetch/index.js
+++ b/cordova-fetch/index.js
@@ -148,9 +148,15 @@ function trimID(target) {
         target = parts[1];
     }
 
-    //If local path exists, set target to final directory
+    // If local path exists, try to get plugin id from package.json or set target to final directory
     if (fs.existsSync(target)) {
-        target = path.basename(target);
+        var pluginId, pkgJsonPath = path.join(target, 'package.json');
+
+        if (fs.existsSync(pkgJsonPath)) {
+            pluginId = JSON.parse(fs.readFileSync(pkgJsonPath)).name;
+        }
+
+        target = pluginId ? pluginId : path.basename(target);
     }
     
     //strip away everything after '@'


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all

### What does this PR do?
Steps to reproduce w/ `cordova-7.0.2-dev`
There is the issue with searching plugin id if the module already exists in node_modules.
1. `cordova create sample`
2. `cordova platform add android`
3. `cordova plugin add cordova-plugin-ms-adal`
4. `cordova plugin add ../azure-activedirectory-library-for-cordova` (use local folder)

Get error message:
```
cordova plugin add ..\azure-activedirectory-library-for-cordova\
Error: Failed to get absolute path to installed module
```
This error occurs since folder name in `node_modules` (`cordova-plugin-ms-adal`) differs from base name of installation folder (`azure-activedirectory-library-for-cordova`).

I'll create a new JIRA issue if this change is really needed.

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
