### PR TITLE
CB-12787: Fix plugin installation with --link option

### DIFF
--- a/cordova-fetch/index.js
+++ b/cordova-fetch/index.js
@@ -38,7 +38,7 @@ var isUrl = require('is-url');
  *
  */
 module.exports = function(target, dest, opts) {
-    var fetchArgs = ['install'];
+    var fetchArgs = opts.link ? ['link'] : ['install'];
     opts = opts || {};
     var tree1;
 

--- a/cordova-lib/src/cordova/util.js
+++ b/cordova-lib/src/cordova/util.js
@@ -230,12 +230,14 @@ function getInstalledPlatformsWithVersions(project_dir) {
 }
 
 // list the directories in the path, ignoring any files
-function findPlugins(pluginPath) {
+function findPlugins(pluginDir) {
     var plugins = [];
 
-    if (fs.existsSync(pluginPath)) {
-        plugins = fs.readdirSync(pluginPath).filter(function (fileName) {
-            return fileName != '.svn' && fileName != 'CVS' && isDirectory(path.join(pluginPath, fileName));
+    if (fs.existsSync(pluginDir)) {
+        plugins = fs.readdirSync(pluginDir).filter(function (fileName) {
+            var pluginPath = path.join(pluginDir, fileName);
+            var isPlugin = isDirectory(pluginPath) || isSymbolicLink(pluginPath);
+            return fileName != '.svn' && fileName != 'CVS' && isPlugin;
         });
     }
 
@@ -354,6 +356,20 @@ function ensurePlatformOptionsCompatible (platformOptions) {
 function isDirectory(dir) {
     try {
         return fs.lstatSync(dir).isDirectory();
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * Checks to see if the argument is a symbolic link
+ * 
+ * @param {string} dir - string representing path of directory
+ * @return {boolean}
+ */
+function isSymbolicLink(dir) {
+    try {
+        return fs.lstatSync(dir).isSymbolicLink();
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all

### What does this PR do?
Fix logic for installation plugins with `--link` option.
 - Use `npm link` instead of `npm install` during plugin fetch.
 - Find symbolic links in plugin's dir for plugin removal 

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
