### PR TITLE
CB-12766 Consistently write JSON with 2 spaces indentation

### DIFF
--- a/cordova-common/spec/PlatformJson.spec.js
+++ b/cordova-common/spec/PlatformJson.spec.js
@@ -112,9 +112,9 @@ describe('PlatformJson class', function() {
             it('Test 009 : should generate text metadata containing list of installed modules', function () {
                 var meta = platformJson.addPluginMetadata(fakePlugin).generateMetadata();
                 expect(typeof meta).toBe('string');
-                expect(meta.indexOf(JSON.stringify(platformJson.root.modules, null, 4))).toBeGreaterThan(0);
-                // expect(meta).toMatch(JSON.stringify(platformJson.root.modules, null, 4));
-                expect(meta).toMatch(JSON.stringify(platformJson.root.plugin_metadata, null, 4));
+                expect(meta.indexOf(JSON.stringify(platformJson.root.modules, null, 2))).toBeGreaterThan(0);
+                // expect(meta).toMatch(JSON.stringify(platformJson.root.modules, null, 2));
+                expect(meta).toMatch(JSON.stringify(platformJson.root.plugin_metadata, null, 2));
             });
         });
     });

--- a/cordova-common/src/PlatformJson.js
+++ b/cordova-common/src/PlatformJson.js
@@ -39,7 +39,7 @@ PlatformJson.load = function(plugins_dir, platform) {
 
 PlatformJson.prototype.save = function() {
     shelljs.mkdir('-p', path.dirname(this.filePath));
-    fs.writeFileSync(this.filePath, JSON.stringify(this.root, null, 4), 'utf-8');
+    fs.writeFileSync(this.filePath, JSON.stringify(this.root, null, 2), 'utf-8');
 };
 
 /**
@@ -195,10 +195,10 @@ PlatformJson.prototype.makeTopLevel = function(pluginId) {
 PlatformJson.prototype.generateMetadata = function () {
     return [
         'cordova.define(\'cordova/plugin_list\', function(require, exports, module) {',
-        'module.exports = ' + JSON.stringify(this.root.modules, null, 4) + ';',
+        'module.exports = ' + JSON.stringify(this.root.modules, null, 2) + ';',
         'module.exports.metadata = ',
         '// TOP OF METADATA',
-        JSON.stringify(this.root.plugin_metadata, null, 4) + ';',
+        JSON.stringify(this.root.plugin_metadata, null, 2) + ';',
         '// BOTTOM OF METADATA',
         '});' // Close cordova.define.
     ].join('\n');

--- a/cordova-lib/spec-plugman/projects/android/cordova/node_modules/cordova-common/src/PlatformJson.js
+++ b/cordova-lib/spec-plugman/projects/android/cordova/node_modules/cordova-common/src/PlatformJson.js
@@ -39,7 +39,7 @@ PlatformJson.load = function(plugins_dir, platform) {
 
 PlatformJson.prototype.save = function() {
     shelljs.mkdir('-p', path.dirname(this.filePath));
-    fs.writeFileSync(this.filePath, JSON.stringify(this.root, null, 4), 'utf-8');
+    fs.writeFileSync(this.filePath, JSON.stringify(this.root, null, 2), 'utf-8');
 };
 
 /**
@@ -195,10 +195,10 @@ PlatformJson.prototype.makeTopLevel = function(pluginId) {
 PlatformJson.prototype.generateMetadata = function () {
     return [
         'cordova.define(\'cordova/plugin_list\', function(require, exports, module) {',
-        'module.exports = ' + JSON.stringify(this.root.modules, null, 4) + ';',
+        'module.exports = ' + JSON.stringify(this.root.modules, null, 2) + ';',
         'module.exports.metadata = ',
         '// TOP OF METADATA',
-        JSON.stringify(this.root.plugin_metadata, null, 4) + ';',
+        JSON.stringify(this.root.plugin_metadata, null, 2) + ';',
         '// BOTTOM OF METADATA',
         '});' // Close cordova.define.
     ].join('\n');

--- a/cordova-lib/src/cordova/config.js
+++ b/cordova-lib/src/cordova/config.js
@@ -63,7 +63,7 @@ config.read = function get_config(project_root) {
 
 config.write = function set_config(project_root, json) {
     var configPath = path.join(project_root, '.cordova', 'config.json');
-    var contents = JSON.stringify(json, null, 4);
+    var contents = JSON.stringify(json, null, 2);
     configCache[project_root] = contents;
     // Don't write the file for an empty config.
     if (contents != '{}' || fs.existsSync(configPath)) {

--- a/cordova-lib/src/cordova/metadata/webos_parser.js
+++ b/cordova-lib/src/cordova/metadata/webos_parser.js
@@ -105,7 +105,7 @@ webos_parser.prototype.update_from_config = function(config) {
         }
     }
 
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, '\t'));
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 
     return Q();
 };
@@ -177,7 +177,7 @@ webos_parser.prototype.update_www = function() {
                 if(index<0) {
                     obj.assets.push('./' + assets[i]);
                 }
-                fs.writeFileSync(deploy, JSON.stringify(obj, null, '\t'));
+                fs.writeFileSync(deploy, JSON.stringify(obj, null, 2));
             }
         } catch(e) {
             console.error('Unable to update deploy.json: ' + e);

--- a/cordova-lib/src/cordova/platform.js
+++ b/cordova-lib/src/cordova/platform.js
@@ -273,7 +273,7 @@ function addHelper(cmd, hooksRunner, projectRoot, targets, opts) {
             // Save to package.json.
             if (modifiedPkgJson === true) {
                 pkgJson.cordova.platforms = pkgJson.cordova.platforms.sort();
-                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
             }
         });
     }).then(function(){
@@ -446,7 +446,7 @@ function remove(hooksRunner, projectRoot, targets, opts) {
             });
             //Write out new package.json if changes have been made.
             if(modifiedPkgJson === true) {
-                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
             }
         }
     }).then(function() {

--- a/cordova-lib/src/cordova/platform_metadata.js
+++ b/cordova-lib/src/cordova/platform_metadata.js
@@ -94,7 +94,7 @@ function save(projectRoot, platform, version) {
         data = getJson(platformJsonFile);
     }
     data[platform] = version;
-    fs.writeFileSync(platformJsonFile, JSON.stringify(data, null, 4), 'utf-8');
+    fs.writeFileSync(platformJsonFile, JSON.stringify(data, null, 2), 'utf-8');
 }
 
 function remove(projectRoot, platform){
@@ -105,7 +105,7 @@ function remove(projectRoot, platform){
     }
     var data = getJson(platformJsonFile);
     delete data[platform];
-    fs.writeFileSync(platformJsonFile, JSON.stringify(data, null, 4), 'utf-8');
+    fs.writeFileSync(platformJsonFile, JSON.stringify(data, null, 2), 'utf-8');
 }
 
 module.exports.getPlatformVersions = getVersions;

--- a/cordova-lib/src/cordova/plugin.js
+++ b/cordova-lib/src/cordova/plugin.js
@@ -225,7 +225,7 @@ module.exports = function plugin(command, targets, opts) {
                                     events.emit('log','Adding '+pluginInfo.id+ ' to package.json');
 
                                     // Write to package.json
-                                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
                                 }
 
                                 var src = parseSource(target, opts);
@@ -334,7 +334,7 @@ module.exports = function plugin(command, targets, opts) {
                                     // Remove plugin from package.json
                                     delete pkgJson.cordova.plugins[target];
                                     //Write out new package.json with plugin removed correctly.
-                                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
                                 }
                             }
                             
@@ -424,12 +424,12 @@ function determinePluginTarget(projectRoot, cfg, target, fetchOptions) {
                     pkgJson.dependencies[parsedSpec.package] = parsedSpec.version;
                 }
                 if(fetchOptions.save === true) {
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
                 }
             } else if (!semver.satisfies(noSymbolVersion, pkgJson.dependencies[parsedSpec.package])) {
                 pkgJson.dependencies[parsedSpec.package] = parsedSpec.version;
                 if (fetchOptions.save === true) {
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
                 }
             }
         }

--- a/cordova-lib/src/cordova/restore-util.js
+++ b/cordova-lib/src/cordova/restore-util.js
@@ -80,7 +80,7 @@ function installPlatformsFromConfigXML(platforms, opts) {
             if(cfg.name()) {
                 pkgJson.displayName = cfg.name();
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
         }
 
         configPlatforms = engines.map(function(Engine) {
@@ -186,7 +186,7 @@ function installPlatformsFromConfigXML(platforms, opts) {
                 }
                 pkgJson.dependencies[prefixKey] = mergedPlatformSpecs[key];
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
         }
         if (modifiedConfigXML === true) {
             cfg.write();
@@ -338,7 +338,7 @@ function installPluginsFromConfigXML(args) {
             for(key in mergedPluginSpecs) {
                 pkgJson.dependencies[key] = mergedPluginSpecs[key];
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 4), 'utf8');
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
         }
     }
     // Write config.xml (only if plugins exist in package.json).

--- a/cordova-lib/src/plugman/browserify.js
+++ b/cordova-lib/src/plugman/browserify.js
@@ -157,8 +157,8 @@ module.exports = function doBrowserify (project, platformApi, pluginInfoProvider
         // instead of generating intermediate file on FS
         var cordova_plugins = new Readable();
         cordova_plugins.push(
-            'module.exports = ' + JSON.stringify(modulesMetadata, null, 4) + ';\n' +
-            'module.exports.metadata = ' + JSON.stringify(pluginMetadata, null, 4) + ';\n', 'utf8');
+            'module.exports = ' + JSON.stringify(modulesMetadata, null, 2) + ';\n' +
+            'module.exports.metadata = ' + JSON.stringify(pluginMetadata, null, 2) + ';\n', 'utf8');
         cordova_plugins.push(null);
 
         var bootstrap = new Readable();

--- a/cordova-lib/src/plugman/registry/manifest.js
+++ b/cordova-lib/src/plugman/registry/manifest.js
@@ -98,7 +98,7 @@ function generatePackageJsonFromPluginXml(plugin_path) {
 
         // Write package.json
         var package_json_path = path.resolve(plugin_path, 'package.json');
-        fs.writeFileSync(package_json_path, JSON.stringify(package_json, null, 4), 'utf8');
+        fs.writeFileSync(package_json_path, JSON.stringify(package_json, null, 2), 'utf8');
         return package_json;
     });
 }

--- a/cordova-lib/src/plugman/util/metadata.js
+++ b/cordova-lib/src/plugman/util/metadata.js
@@ -56,13 +56,13 @@ exports.save_fetch_metadata = function(pluginsDir, pluginId, data) {
     var metadataJson = getJson(pluginsDir);
     metadataJson[pluginId] = data;
     var fetchJsonPath = path.join(pluginsDir, 'fetch.json');
-    fs.writeFileSync(fetchJsonPath, JSON.stringify(metadataJson, null, 4), 'utf-8');
+    fs.writeFileSync(fetchJsonPath, JSON.stringify(metadataJson, null, 2), 'utf-8');
 };
 
 exports.remove_fetch_metadata = function(pluginsDir, pluginId){
     var metadataJson = getJson(pluginsDir);
     delete metadataJson[pluginId];
     var fetchJsonPath = path.join(pluginsDir, 'fetch.json');
-    fs.writeFileSync(fetchJsonPath, JSON.stringify(metadataJson, null, 4), 'utf-8');
+    fs.writeFileSync(fetchJsonPath, JSON.stringify(metadataJson, null, 2), 'utf-8');
 };
 


### PR DESCRIPTION
### Platforms affected
None really.

### What does this PR do?
JSON was written with 4 spaces indentation and even a tab at some
point. Most NodeJS tools write their JSON configuration with an
indentation of 2 spaces. Most notably npm does this, which writes to
package.json, as does Cordova. This caused unnecessary changes in
package.json.

### What testing has been done on this change?
None, this is mostly stylistic.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
