### PR TITLE
CB-12762 : point package.json repo items to github mirrors instead of…

### DIFF
--- a/cordova-common/package.json
+++ b/cordova-common/package.json
@@ -6,7 +6,7 @@
   "version": "2.0.4-dev",
   "repository": {
     "type": "git",
-    "url": "git://git-wip-us.apache.org/repos/asf/cordova-common.git"
+    "url": "https://github.com/apache/cordova-lib"
   },
   "bugs": {
     "url": "https://issues.apache.org/jira/browse/CB",

--- a/cordova-fetch/package.json
+++ b/cordova-fetch/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://git-wip-us.apache.org/repos/asf/cordova-lib.git"
+    "url": "https://github.com/apache/cordova-lib"
   },
   "keywords": [
     "cordova",

--- a/cordova-lib/package.json
+++ b/cordova-lib/package.json
@@ -6,7 +6,7 @@
   "version": "7.0.2-dev",
   "repository": {
     "type": "git",
-    "url": "git://git-wip-us.apache.org/repos/asf/cordova-lib.git"
+    "url": "https://github.com/apache/cordova-lib"
   },
   "bugs": {
     "url": "https://issues.apache.org/jira/browse/CB",

--- a/cordova-serve/package.json
+++ b/cordova-serve/package.json
@@ -5,7 +5,7 @@
   "main": "serve.js",
   "repository": {
     "type": "git",
-    "url": "git://git-wip-us.apache.org/repos/asf/cordova-lib.git"
+    "url": "https://github.com/apache/cordova-lib"
   },
   "keywords": [
     "cordova",


### PR DESCRIPTION
… apache repos site

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Point package.json repo items to github mirrors instead of apache repos site.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
