### PR TITLE
CB-12944: Platform's spec is ignored in config.xml if package.json doesn't contain dependency for platform

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -170,6 +170,21 @@ describe('cordova/platform/addHelper', function () {
                 }).done(done);
             });
 
+            it('should use spec from config.xml if package.json does not contain dependency for platform', function (done) {
+                package_json_mock.dependencies = {};
+                cordova_util.requireNoCache.and.returnValue(package_json_mock);
+                fs.existsSync.and.callFake(function (filePath) {
+                    return path.basename(filePath) === 'package.json';
+                });
+
+                platform_addHelper('add', hooks_mock, projectRoot, ['windows'], {restoring: true}).then(function () {
+                    expect(platform_addHelper.getVersionFromConfigFile).toHaveBeenCalled();
+                }).fail(function (e) {
+                    fail('fail handler unexpectedly invoked');
+                    console.error(e);
+                }).done(done);
+            });
+
             it('should attempt to retrieve from config.xml if exists and package.json does not', function (done) {
                 platform_addHelper('add', hooks_mock, projectRoot, ['atari'], {restoring: true}).then(function () {
                     expect(platform_addHelper.getVersionFromConfigFile).toHaveBeenCalled();

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -111,7 +111,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                         } else if (pkgJson.dependencies[platform]) {
                             spec = pkgJson.dependencies[platform];
                         }
-                    } else if (platform && spec === undefined && cmd === 'add') {
+                    }
+
+                    if (platform && spec === undefined && cmd === 'add') {
                         events.emit('verbose', 'No version supplied. Retrieving version from config.xml...');
                         spec = module.exports.getVersionFromConfigFile(platform, cfg);
                     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all

### What does this PR do?
Steps to reproduce with cordova@7.0.2-dev:
1) Create app with package.json contains empty dependencies object: `"dependencies": {}`
(e.g. it's default for Visual Studio Cordova template)
2) Add entry into config.xml: `<engine name="windows" spec="https://github.com/apache/cordova-windows.git#4.4.x" />`
3) `cordova platform add windows`

So, if package.json dependencies keys don't include `windows or `cordova-windows`, we should look for a spec in config.xml. 

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
