### PR TITLE
CB-6143: Change plugman.emit() to events.emit()

### DIFF
--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -24,7 +24,6 @@ var uninstall = require('../src/plugman/uninstall'),
     actions = require('cordova-common').ActionStack,
     PluginInfo = require('cordova-common').PluginInfo,
     events = require('cordova-common').events,
-    plugman = require('../src/plugman/plugman'),
     common  = require('../spec/common'),
     platforms = require('../src/platforms/platforms'),
     xmlHelpers = require('cordova-common').xmlHelpers,
@@ -325,7 +324,7 @@ describe('end', function() {
             return uninstall('android', project, plugins['A']);
         }).fin(function(err){
             if(err)
-                plugman.emit('error', err);
+                events.emit('error', err);
             shell.rm('-rf', project, project2, project3);
             done();
         });

--- a/src/plugman/browserify.js
+++ b/src/plugman/browserify.js
@@ -25,7 +25,6 @@ var path               = require('path'),
     fs                 = require('fs'),
     childProcess       = require('child_process'),
     events             = require('cordova-common').events,
-    plugman            = require('./plugman'),
     bundle             = require('cordova-js/tasks/lib/bundle-browserify'),
     writeLicenseHeader = require('cordova-js/tasks/lib/write-license-header'),
     Q                  = require('q'),
@@ -48,7 +47,7 @@ function generateFinalBundle(platform, libraryRelease, outReleaseFile, commitId,
 
     outReleaseFileStream.on('finish', function() {
         var newtime = new Date().valueOf() - time;
-        plugman.emit('verbose', 'generated cordova.' + platform + '.js @ ' + commitId + ' in ' + newtime + 'ms');
+        events.emit('verbose', 'generated cordova.' + platform + '.js @ ' + commitId + ' in ' + newtime + 'ms');
         deferred.resolve();
         // TODO clean up all the *.browserify files
     });


### PR DESCRIPTION
### Platforms affected
all

### What does this PR do?
https://issues.apache.org/jira/browse/CB-6143
Changes remaining `plugman.emit()` calls to `events.emit()` for consistency and to fix a build error when building a browserified app.

### What testing has been done on this change?
`npm test`, built an android app, built a browserified android app

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
