### PR TITLE
CB-13303 : added save_exact and production opts

### DIFF
--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -87,7 +87,9 @@ function add (projectRoot, hooksRunner, opts) {
                         link: opts.link,
                         pluginInfoProvider: pluginInfoProvider,
                         variables: opts.cli_variables,
-                        is_top_level: true
+                        is_top_level: true,
+                        save_exact: opts['save-exact'] || false,
+                        production: opts.production
                     };
 
                     return module.exports.determinePluginTarget(projectRoot, cfg, target, fetchOptions).then(function (resolvedTarget) {
@@ -121,7 +123,9 @@ function add (projectRoot, hooksRunner, opts) {
                             // files platform_www directory, so they'll be applied to www on each prepare.
                             usePlatformWww: true,
                             nohooks: opts.nohooks,
-                            force: opts.force
+                            force: opts.force,
+                            save_exact: opts['save-exact'] || false,
+                            production: opts.production
                         };
 
                         events.emit('verbose', 'Calling plugman.install on plugin "' + pluginInfo.dir + '" for platform "' + platform);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?

Added save-exact and production opts

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
