### PR TITLE
CB-13451 (all platforms) "pkg not defined" exception when running plugman with createpackagejson command-line

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,1 @@
-spec/cordova/fixtures/**
-spec/plugman/projects/**
-spec/plugman/plugins/**
-spec/cordova/temp/**
+**/init-defaults.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,6 @@
-**/init-defaults.js
+spec/cordova/fixtures/*
+spec/plugman/projects/*
+spec/plugman/plugins/*
+spec/cordova/temp/*
+src/plugman/*
+

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
+src/plugman/init-defaults.js
 spec/cordova/fixtures/*
 spec/plugman/projects/*
 spec/plugman/plugins/*
 spec/cordova/temp/*
-src/plugman/*
 

--- a/spec/cordova/fixtures/platforms/cordova-browser/node_modules/qs/.eslintrc
+++ b/spec/cordova/fixtures/platforms/cordova-browser/node_modules/qs/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"root": true,
 
-	/* "extends": "@ljharb", */
+	"extends": "@ljharb",
 
 	"rules": {
 		"complexity": [2, 22],

--- a/spec/cordova/fixtures/platforms/cordova-browser/node_modules/qs/.eslintrc
+++ b/spec/cordova/fixtures/platforms/cordova-browser/node_modules/qs/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"root": true,
 
-	"extends": "@ljharb",
+	/* "extends": "@ljharb", */
 
 	"rules": {
 		"complexity": [2, 22],

--- a/src/plugman/init-defaults.js
+++ b/src/plugman/init-defaults.js
@@ -19,7 +19,7 @@
 
 /* global dirname */
 /* global config */
-/* global pkg */
+/* global package */
 /* global basename */
 /* global yes */
 /* global prompt */
@@ -55,17 +55,18 @@ function readDeps (test) {
     };
 }
 
-var name = pkg.name || defaults.id || basename;
+/* eslint-disable */
+var name = package.name || defaults.id || basename;
 exports.name = yes ? name : prompt('name', name);
 
-var version = pkg.version ||
+var version = package.version ||
               defaults.version ||
               config.get('init.version') ||
               config.get('init-version') ||
               '1.0.0';
 exports.version = yes ? version : prompt('version', version);
 
-if (!pkg.description) {
+if (!package.description) {
     if (defaults.description) {
         exports.description = defaults.description;
     } else {
@@ -73,7 +74,7 @@ if (!pkg.description) {
     }
 }
 
-if (!pkg.cordova) {
+if (!package.cordova) {
     exports.cordova = {};
     if (defaults.id) {
         exports.cordova.id = defaults.id;
@@ -83,15 +84,15 @@ if (!pkg.cordova) {
     }
 }
 
-if (!pkg.dependencies) {
+if (!package.dependencies) {
     exports.dependencies = readDeps(false);
 }
 
-if (!pkg.devDependencies) {
+if (!package.devDependencies) {
     exports.devDependencies = readDeps(true);
 }
 
-if (!pkg.repository) {
+if (!package.repository) {
     exports.repository = function (cb) {
         fs.readFile('.git/config', 'utf8', function (er, gconf) {
             if (er || !gconf) {
@@ -116,7 +117,7 @@ if (!pkg.repository) {
     };
 }
 
-if (!pkg.keywords) {
+if (!package.keywords) {
     if (defaults.keywords) {
         exports.keywords = defaults.keywords;
     } else {
@@ -129,14 +130,13 @@ if (!pkg.keywords) {
     }
 }
 
-if (!pkg.engines) {
+if (!package.engines) {
     if (defaults.engines && defaults.engines.length > 0) {
         exports.engines = defaults.engines;
     }
 }
 
-/* eslint-disable indent */
-if (!pkg.author) {
+if (!package.author) {
     exports.author = (config.get('init.author.name') ||
                      config.get('init-author-name')) ?
     {
@@ -149,10 +149,11 @@ if (!pkg.author) {
     }
         : prompt('author');
 }
-/* eslint-enable indent */
-var license = pkg.license ||
+var license = package.license ||
               defaults.license ||
               config.get('init.license') ||
               config.get('init-license') ||
               'ISC';
+/* eslint-enable */
+
 exports.license = yes ? license : prompt('license', license);

--- a/src/plugman/init-defaults.js
+++ b/src/plugman/init-defaults.js
@@ -55,7 +55,6 @@ function readDeps (test) {
     };
 }
 
-/* eslint-disable */
 var name = package.name || defaults.id || basename;
 exports.name = yes ? name : prompt('name', name);
 
@@ -154,6 +153,5 @@ var license = package.license ||
               config.get('init.license') ||
               config.get('init-license') ||
               'ISC';
-/* eslint-enable */
 
 exports.license = yes ? license : prompt('license', license);

--- a/src/plugman/init-defaults.js
+++ b/src/plugman/init-defaults.js
@@ -19,7 +19,7 @@
 
 /* global dirname */
 /* global config */
-/* global package */
+/* global pkg */
 /* global basename */
 /* global yes */
 /* global prompt */
@@ -55,17 +55,17 @@ function readDeps (test) {
     };
 }
 
-var name = package.name || defaults.id || basename;
+var name = pkg.name || defaults.id || basename;
 exports.name = yes ? name : prompt('name', name);
 
-var version = package.version ||
+var version = pkg.version ||
               defaults.version ||
               config.get('init.version') ||
               config.get('init-version') ||
               '1.0.0';
 exports.version = yes ? version : prompt('version', version);
 
-if (!package.description) {
+if (!pkg.description) {
     if (defaults.description) {
         exports.description = defaults.description;
     } else {
@@ -73,7 +73,7 @@ if (!package.description) {
     }
 }
 
-if (!package.cordova) {
+if (!pkg.cordova) {
     exports.cordova = {};
     if (defaults.id) {
         exports.cordova.id = defaults.id;
@@ -83,15 +83,15 @@ if (!package.cordova) {
     }
 }
 
-if (!package.dependencies) {
+if (!pkg.dependencies) {
     exports.dependencies = readDeps(false);
 }
 
-if (!package.devDependencies) {
+if (!pkg.devDependencies) {
     exports.devDependencies = readDeps(true);
 }
 
-if (!package.repository) {
+if (!pkg.repository) {
     exports.repository = function (cb) {
         fs.readFile('.git/config', 'utf8', function (er, gconf) {
             if (er || !gconf) {
@@ -116,7 +116,7 @@ if (!package.repository) {
     };
 }
 
-if (!package.keywords) {
+if (!pkg.keywords) {
     if (defaults.keywords) {
         exports.keywords = defaults.keywords;
     } else {
@@ -129,14 +129,14 @@ if (!package.keywords) {
     }
 }
 
-if (!package.engines) {
+if (!pkg.engines) {
     if (defaults.engines && defaults.engines.length > 0) {
         exports.engines = defaults.engines;
     }
 }
 
 /* eslint-disable indent */
-if (!package.author) {
+if (!pkg.author) {
     exports.author = (config.get('init.author.name') ||
                      config.get('init-author-name')) ?
     {
@@ -150,7 +150,7 @@ if (!package.author) {
         : prompt('author');
 }
 /* eslint-enable indent */
-var license = package.license ||
+var license = pkg.license ||
               defaults.license ||
               config.get('init.license') ||
               config.get('init-license') ||

--- a/src/plugman/init-defaults.js
+++ b/src/plugman/init-defaults.js
@@ -19,7 +19,7 @@
 
 /* global dirname */
 /* global config */
-/* global pkg */
+/* global package */
 /* global basename */
 /* global yes */
 /* global prompt */
@@ -55,17 +55,17 @@ function readDeps (test) {
     };
 }
 
-var name = pkg.name || defaults.id || basename;
+var name = package.name || defaults.id || basename;
 exports.name = yes ? name : prompt('name', name);
 
-var version = pkg.version ||
+var version = package.version ||
               defaults.version ||
               config.get('init.version') ||
               config.get('init-version') ||
               '1.0.0';
 exports.version = yes ? version : prompt('version', version);
 
-if (!pkg.description) {
+if (!package.description) {
     if (defaults.description) {
         exports.description = defaults.description;
     } else {
@@ -73,7 +73,7 @@ if (!pkg.description) {
     }
 }
 
-if (!pkg.cordova) {
+if (!package.cordova) {
     exports.cordova = {};
     if (defaults.id) {
         exports.cordova.id = defaults.id;
@@ -83,15 +83,15 @@ if (!pkg.cordova) {
     }
 }
 
-if (!pkg.dependencies) {
+if (!package.dependencies) {
     exports.dependencies = readDeps(false);
 }
 
-if (!pkg.devDependencies) {
+if (!package.devDependencies) {
     exports.devDependencies = readDeps(true);
 }
 
-if (!pkg.repository) {
+if (!package.repository) {
     exports.repository = function (cb) {
         fs.readFile('.git/config', 'utf8', function (er, gconf) {
             if (er || !gconf) {
@@ -116,7 +116,7 @@ if (!pkg.repository) {
     };
 }
 
-if (!pkg.keywords) {
+if (!package.keywords) {
     if (defaults.keywords) {
         exports.keywords = defaults.keywords;
     } else {
@@ -129,14 +129,14 @@ if (!pkg.keywords) {
     }
 }
 
-if (!pkg.engines) {
+if (!package.engines) {
     if (defaults.engines && defaults.engines.length > 0) {
         exports.engines = defaults.engines;
     }
 }
 
 /* eslint-disable indent */
-if (!pkg.author) {
+if (!package.author) {
     exports.author = (config.get('init.author.name') ||
                      config.get('init-author-name')) ?
     {
@@ -150,7 +150,7 @@ if (!pkg.author) {
         : prompt('author');
 }
 /* eslint-enable indent */
-var license = pkg.license ||
+var license = package.license ||
               defaults.license ||
               config.get('init.license') ||
               config.get('init-license') ||


### PR DESCRIPTION
A global js-lint pass on the cordova-lib codebase on the 30/8/2017 caused references to the global 'package' variable in init-default.js to be renamed to 'pkg’, presumably because the cordova-lib source doesn’t declare a global variable called ‘package’ but _does_ declare a global variable called ‘pkg’ (in src/cordova/info.js). However in this case, the ‘package’ variable refers to the one declared in the plugman source, specifically main.js, so it should have stayed as 'package’. To test the fix, run:

	plugman createpackagejson .

Without the fix, this will trigger the following exception: 'pkg is not defined'. Having patched in the fix, running the command line should work as expected, prompting the user with questions and then spitting out a package.json file.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Fixes an bug where an exception would be thrown when running 'plugman createpackagejson .'

### What testing has been done on this change?
The command in question ('plugman createpackagejson .') has been tested with and without the fix to confirm that the fix fixes the problem.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
