### PR TITLE
CB-13463 : prevent package.json update with --nosave (for plugins)

### DIFF
--- a/integration-tests/pkgJson-restore.spec.js
+++ b/integration-tests/pkgJson-restore.spec.js
@@ -262,7 +262,7 @@ describe('tests platform/spec restore with --save', function () {
             return cordovaPlatform('add', 'browser', {'save': true, 'fetch': true});
         }).then(function () {
             // Run cordova prepare with fetch.
-            return prepare({'fetch': true});
+            return prepare({'save': true, 'fetch': true});
         }).then(function () {
             // Config.xml spec is modified.
             var cfg3 = new ConfigParser(configXmlPath);
@@ -762,7 +762,7 @@ describe('update config.xml to use the variable found in pkg.json', function () 
 
         emptyPlatformList().then(function () {
             // Run cordova prepare.
-            return prepare({'fetch': true});
+            return prepare({'fetch': true, 'save':true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);
@@ -847,7 +847,7 @@ describe('update pkg.json to include plugin and variable found in config.xml', f
 
         emptyPlatformList().then(function () {
             // Run cordova prepare.
-            return prepare({'fetch': true});
+            return prepare({'fetch': true, 'save': true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);
@@ -949,7 +949,7 @@ describe('update pkg.json AND config.xml to include all plugins and merge unique
 
         emptyPlatformList().then(function () {
             // Run cordova prepare.
-            return prepare({'fetch': true});
+            return prepare({'fetch': true, 'save': true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);
@@ -981,9 +981,9 @@ describe('update pkg.json AND config.xml to include all plugins and merge unique
             expect(pkgJson.cordova.plugins['cordova-plugin-camera']).toEqual({ variable_1: ' ', variable_2: ' ', variable_3: 'value_3' });
             // Expect config.xml to have the plugins from pkg.json.
             expect(Object.keys(configPlugins).length === 3);
-            expect(configPlugins.indexOf('cordova-plugin-device')).toEqual(0);
+            expect(configPlugins.indexOf('cordova-plugin-device')).toEqual(2);
             expect(configPlugins.indexOf('cordova-plugin-splashscreen')).toEqual(1);
-            expect(configPlugins.indexOf('cordova-plugin-camera')).toEqual(2);
+            expect(configPlugins.indexOf('cordova-plugin-camera')).toEqual(0);
             // Expect all 3 plugins to be restored.
             expect(path.join(pluginsFolderPath13, 'cordova-plugin-device')).toExist();
             expect(path.join(pluginsFolderPath13, 'cordova-plugin-camera')).toExist();
@@ -1079,7 +1079,7 @@ describe('update pkg.json AND config.xml to include all plugins/merge variables 
 
         emptyPlatformList().then(function () {
             // Run cordova prepare
-            return prepare({'fetch': true});
+            return prepare({'save': true});
         }).then(function () {
             // Delete any previous caches of require(package.json)
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);
@@ -1110,9 +1110,9 @@ describe('update pkg.json AND config.xml to include all plugins/merge variables 
             }
             // Config.xml now has the camera, splashscreen, and device plugin
             expect(Object.keys(configPlugins).length === 3);
-            expect(configPlugins.indexOf('cordova-plugin-splashscreen')).toEqual(0);
-            expect(configPlugins.indexOf('cordova-plugin-camera')).toEqual(1);
-            expect(configPlugins.indexOf('cordova-plugin-device')).toEqual(2);
+            expect(configPlugins.indexOf('cordova-plugin-splashscreen')).toEqual(2);
+            expect(configPlugins.indexOf('cordova-plugin-camera')).toEqual(0);
+            expect(configPlugins.indexOf('cordova-plugin-device')).toEqual(1);
             // Pkg.json has all 3 plugins with the correct specs
             expect(Object.keys(pkgJson.cordova.plugins).length === 3);
             expect(pkgJson.cordova.plugins['cordova-plugin-camera']).toBeDefined();
@@ -1199,7 +1199,7 @@ describe('update config.xml to include the plugin that is in pkg.json', function
 
         emptyPlatformList().then(function () {
             // Run cordova prepare.
-            return prepare({'fetch': true});
+            return prepare({'fetch': false, 'save':true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -329,7 +329,7 @@ function installPluginsFromConfigXML (args) {
             }
         });
         // If pkg.json plugins have been modified, write to it.
-        if (modifiedPkgJson === true) {
+        if (modifiedPkgJson === true && args.save !== false) {
             pkgJson.cordova.plugins = comboObject;
             if (pkgJson.dependencies === undefined) {
                 pkgJson.dependencies = {};
@@ -366,7 +366,7 @@ function installPluginsFromConfigXML (args) {
         }
     });
 
-    if (modifiedConfigXML === true) {
+    if (modifiedConfigXML === true && args.save !== false) {
         cfg.write();
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
 
Prevent package.json update with --nosave (for plugins)

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
