### PR TITLE
CB-13501 : added support for node 8 and cleaned up eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,8 @@ git:
 node_js:
   - "4"
   - "6"
+  - "8"
 install:
-  - git clone https://github.com/apache/cordova-js --depth 10
-  - git clone https://github.com/apache/cordova-fetch --depth 10
-  - git clone https://github.com/apache/cordova-serve --depth 10
-  - git clone https://github.com/apache/cordova-common --depth 10
-  - (cd cordova-js && npm install && npm link .)
-  - (cd cordova-common && npm install && npm link .)
-  - (cd cordova-serve && npm install && npm link .)
-  - (cd cordova-fetch && npm link cordova-common && npm install && npm link .)
-  - (npm link cordova-serve && npm link cordova-fetch && npm link cordova-common && npm link cordova-js)
   - npm install
   # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent
   # module's 'node_modules' In our case 'cordova-common' -> jshint' -> 'cli' dependency

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,31 +5,10 @@ environment:
   matrix:
   - nodejs_version: "4"
   - nodejs_version: "6"
+  - nodejs_version: "8"
   
 install:
   - ps: Install-Product node $env:nodejs_version
-  - git clone https://github.com/apache/cordova-js --depth 10
-  - git clone https://github.com/apache/cordova-common --depth 10
-  - git clone https://github.com/apache/cordova-fetch --depth 10
-  - git clone https://github.com/apache/cordova-serve --depth 10
-  - cd cordova-js
-  - npm install
-  - npm link .
-  - cd ../cordova-common
-  - npm install
-  - npm link .
-  - cd ../cordova-serve
-  - npm install
-  - npm link .
-  - cd ../cordova-fetch
-  - npm link cordova-common
-  - npm install
-  - npm link .
-  - cd ../
-  - npm link cordova-js
-  - npm link cordova-fetch
-  - npm link cordova-common
-  - npm link cordova-serve
   - npm install
   # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent
   # module's 'node_modules' In our case 'cordova-common' -> jshint' -> 'cli' dependency

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "aliasify": "^2.1.0",
     "cordova-common": "2.1.1",
     "cordova-create": "~1.1.0",
-    "cordova-fetch": "1.2.0",
+    "cordova-fetch": "1.2.1",
     "cordova-js": "4.2.2",
     "cordova-serve": "^2.0.0",
     "dep-graph": "1.1.0",

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -312,8 +312,9 @@ describe('util module', function () {
 
         describe('getPlatformApiFunction', function () {
             it('Test 027 : should throw error informing user to update platform', function () {
-                expect(function () { util.getPlatformApiFunction('some/path', 'android'); }).toThrow(new Error // eslint-disable-line func-call-spacing
-                ('Uncaught, unspecified "error" event. ( Using this version of Cordova with older version of cordova-android is deprecated. Upgrade to cordova-android@5.0.0 or newer.)'));
+                expect(function () { util.getPlatformApiFunction('some/path', 'android'); }).toThrowError(
+                    /(Uncaught, unspecified|Unhandled) "error" event. \( Using this version of Cordova with older version of cordova-android is deprecated\. Upgrade to cordova-android@5\.0\.0 or newer.\)/
+                );
             });
 
             it('Test 028 : should throw error if platform is not supported', function () {

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -240,9 +240,8 @@ function determinePluginTarget (projectRoot, cfg, target, fetchOptions) {
     // If parsedSpec.version satisfies pkgJson version, no writing to pkg.json. Only write when
     // it does not satisfy.
     /* if (parsedSpec.version) {
-        
         if (pkgJson && pkgJson.dependencies && pkgJson.dependencies[parsedSpec.package]) {
-            //it can only go in here if 
+            //it can only go in here if
             var noSymbolVersion = parsedSpec.version;
             if (parsedSpec.version.charAt(0) === '^' || parsedSpec.version.charAt(0) === '~') {
                 noSymbolVersion = parsedSpec.version.slice(1);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Added support for node 8 and fixed eslint error

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
