### PR TITLE
CB-13293 : if fetch has been called already, no need to fetch again

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -355,6 +355,16 @@ describe('cordova/platform/addHelper', function () {
                     fail('fail handler unexpectedly invoked');
                 }).done(done);
             }, 60000);
+
+            it('should not fetch if platform has already been fetched', function (done) {
+                fs.existsSync.and.returnValue('android');
+                platform_addHelper.downloadPlatform(projectRoot, 'android', '6.0.0', {fetch: true}).then(function () {
+                    expect(fetch_mock).not.toHaveBeenCalled();
+                    expect(events.emit).not.toHaveBeenCalled();
+                }).fail(function (e) {
+                    fail('fail handler unexpectedly invoked');
+                }).done(done);
+            }, 60000);
         });
     });
     describe('installPluginsForNewPlatform', function () {

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -291,7 +291,9 @@ function getVersionFromConfigFile (platform, cfg) {
 function downloadPlatform (projectRoot, platform, version, opts) {
     var target = version ? (platform + '@' + version) : platform;
     return Q().then(function () {
-        if (opts.fetch) {
+        var platformPath = path.join(projectRoot, 'platforms', platform);
+        var platformAlreadyAdded = fs.existsSync(platformPath);
+        if ((opts.fetch) && (!platformAlreadyAdded || platformAlreadyAdded === undefined || platformAlreadyAdded === null)) {
             // append cordova to platform
             if (platform in platforms) {
                 target = 'cordova-' + target;

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -293,7 +293,7 @@ function downloadPlatform (projectRoot, platform, version, opts) {
     return Q().then(function () {
         var platformPath = path.join(projectRoot, 'platforms', platform);
         var platformAlreadyAdded = fs.existsSync(platformPath);
-        if ((opts.fetch) && (!platformAlreadyAdded || platformAlreadyAdded === undefined || platformAlreadyAdded === null)) {
+        if ((opts.fetch) && (!platformAlreadyAdded)) {
             // append cordova to platform
             if (platform in platforms) {
                 target = 'cordova-' + target;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?

Prevent fetch from being called, if it has already been called.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
