### PR TITLE
CB-12810 : keep existing formatting in package.json and fix eslint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cordova-js": "4.2.2",
     "cordova-serve": "^2.0.0",
     "dep-graph": "1.1.0",
+    "detect-indent": "^5.0.0",
     "elementtree": "0.1.6",
     "glob": "7.1.1",
     "init-package-json": "^1.2.0",

--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -284,6 +284,7 @@ describe('cordova/platform/addHelper', function () {
 
             describe('if the project contains a package.json', function () {
                 it('should write out the platform just added/updated to the cordova.platforms property of package.json', function (done) {
+                    spyOn(fs, 'readFileSync').and.returnValue('file');
                     fs.existsSync.and.callFake(function (filePath) {
                         if (path.basename(filePath) === 'package.json') {
                             return true;

--- a/spec/cordova/platform/remove.spec.js
+++ b/spec/cordova/platform/remove.spec.js
@@ -95,6 +95,7 @@ describe('cordova/platform/remove', function () {
         it('should remove from package.json', function (done) {
             package_json_mock.cordova = {'platforms': ['atari']};
             cordova_util.requireNoCache.and.returnValue(package_json_mock);
+            spyOn(fs, 'readFileSync').and.returnValue('file');
             fs.existsSync.and.callFake(function (filePath) {
                 if (path.basename(filePath) === 'package.json') {
                     return true;

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -167,6 +167,7 @@ describe('cordova/plugin/add', function () {
                     }
                 });
 
+                spyOn(fs, 'readFileSync').and.returnValue('file');
                 add(projectRoot, hook_mock, {plugins: ['cordova-plugin-device'], cli_variables: cli_plugin_variables, save: 'true'}).then(function () {
                     expect(fs.writeFileSync).toHaveBeenCalledWith(jasmine.any(String), JSON.stringify({'cordova': {'plugins': {'cordova-plugin-device': cli_plugin_variables}}, 'dependencies': {}}, null, 2), 'utf8');
                 }).fail(function (e) {

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -165,6 +165,7 @@ describe('cordova/plugin/remove', function () {
             });
 
             it('should remove provided plugins from package.json (if exists)', function (done) {
+                spyOn(fs, 'readFileSync').and.returnValue('file');
                 spyOn(cordova_util, 'requireNoCache').and.returnValue(package_json_mock);
                 remove.validatePluginId.and.returnValue('cordova-plugin-splashscreen');
                 fs.existsSync.and.returnValue(true);

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -34,6 +34,7 @@ var config = require('../config');
 var lazy_load = require('../lazy_load');
 var platformMetadata = require('../platform_metadata');
 var platforms = require('../../platforms/platforms');
+var detectIndent = require('detect-indent');
 
 module.exports = addHelper;
 module.exports.getVersionFromConfigFile = getVersionFromConfigFile;
@@ -269,8 +270,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                 });
                 // Save to package.json.
                 if (modifiedPkgJson === true) {
-                    pkgJson.cordova.platforms = pkgJson.cordova.platforms;
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+                    var file = fs.readFileSync(pkgJsonPath, 'utf8');
+                    var indent = detectIndent(file).indent || '  ';
+                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
                 }
             });
         }).then(function () {

--- a/src/cordova/platform/remove.js
+++ b/src/cordova/platform/remove.js
@@ -28,6 +28,7 @@ var config = require('../config');
 var platformMetadata = require('../platform_metadata');
 var promiseutil = require('../../util/promise-util');
 var platforms = require('../../platforms/platforms');
+var detectIndent = require('detect-indent');
 
 module.exports = remove;
 
@@ -72,7 +73,9 @@ function remove (hooksRunner, projectRoot, targets, opts) {
                 });
                 // Write out new package.json if changes have been made.
                 if (modifiedPkgJson === true) {
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+                    var file = fs.readFileSync(pkgJsonPath, 'utf8');
+                    var indent = detectIndent(file).indent || '  ';
+                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
                 }
             }
         }).then(function () {

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -34,6 +34,7 @@ var path = require('path');
 var fs = require('fs');
 var semver = require('semver');
 var url = require('url');
+var detectIndent = require('detect-indent');
 
 module.exports = add;
 module.exports.determinePluginTarget = determinePluginTarget;
@@ -159,7 +160,9 @@ function add (projectRoot, hooksRunner, opts) {
                             events.emit('log', 'Adding ' + pluginInfo.id + ' to package.json');
 
                             // Write to package.json
-                            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+                            var file = fs.readFileSync(pkgJsonPath, 'utf8');
+                            var indent = detectIndent(file).indent || '  ';
+                            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
                         }
 
                         var src = module.exports.parseSource(target, opts);

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -29,6 +29,7 @@ var Q = require('q');
 var path = require('path');
 var fs = require('fs');
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
+var detectIndent = require('detect-indent');
 
 module.exports = remove;
 module.exports.validatePluginId = validatePluginId;
@@ -107,7 +108,9 @@ function remove (projectRoot, targets, hooksRunner, opts) {
                                 // Remove plugin from package.json
                                 delete pkgJson.cordova.plugins[target];
                                 // Write out new package.json with plugin removed correctly.
-                                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+                                var file = fs.readFileSync(pkgJsonPath, 'utf8');
+                                var indent = detectIndent(file).indent || '  ';
+                                fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
                             }
                         }
                     }).then(function () {

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -27,6 +27,7 @@ var cordovaPlatform = require('./platform');
 var semver = require('semver');
 var platformsList = require('../platforms/platforms.js');
 var promiseutil = require('../util/promise-util');
+var detectIndent = require('detect-indent');
 
 exports.installPluginsFromConfigXML = installPluginsFromConfigXML;
 exports.installPlatformsFromConfigXML = installPlatformsFromConfigXML;
@@ -48,10 +49,14 @@ function installPlatformsFromConfigXML (platforms, opts) {
     var mergedPlatformSpecs = {};
     var key;
     var installAllPlatforms = !platforms || platforms.length === 0;
+    var file;
+    var indent;
 
     // Check if path exists and require pkgJsonPath.
     if (fs.existsSync(pkgJsonPath)) {
         pkgJson = require(pkgJsonPath);
+        file = fs.readFileSync(pkgJsonPath, 'utf8');
+        indent = detectIndent(file).indent || '  ';
     }
 
     if (pkgJson !== undefined && pkgJson.cordova !== undefined && pkgJson.cordova.platforms !== undefined) {
@@ -80,7 +85,7 @@ function installPlatformsFromConfigXML (platforms, opts) {
             if (cfg.name()) {
                 pkgJson.displayName = cfg.name();
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
         }
 
         configPlatforms = engines.map(function (Engine) {
@@ -185,7 +190,7 @@ function installPlatformsFromConfigXML (platforms, opts) {
                 }
                 pkgJson.dependencies[prefixKey] = mergedPlatformSpecs[key];
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
         }
         if (modifiedConfigXML === true) {
             cfg.write();
@@ -337,7 +342,9 @@ function installPluginsFromConfigXML (args) {
             for (key in mergedPluginSpecs) {
                 pkgJson.dependencies[key] = mergedPluginSpecs[key];
             }
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), 'utf8');
+            var file = fs.readFileSync(pkgJsonPath, 'utf8');
+            var indent = detectIndent(file).indent || '  ';
+            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
         }
     }
     // Write to config.xml (only if it is different from package.json in content)


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Updated indenting for pkgJson

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
