### PR TITLE
CB-13532: Find plugins in devDependencies

### DIFF
--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -177,6 +177,8 @@ function add (projectRoot, hooksRunner, opts) {
                             var parsedSpec = pluginSpec.parse(target);
                             if (pkgJson && pkgJson.dependencies && pkgJson.dependencies[pluginInfo.id]) {
                                 attributes.spec = pkgJson.dependencies[pluginInfo.id];
+                            } else if (pkgJson && pkgJson.devDependencies && pkgJson.devDependencies[pluginInfo.id]) {
+                                attributes.spec = pkgJson.devDependencies[pluginInfo.id];
                             } else {
                                 if (parsedSpec.scope) {
                                     attributes.spec = parsedSpec.package + '@' + ver;
@@ -232,6 +234,9 @@ function determinePluginTarget (projectRoot, cfg, target, fetchOptions) {
         if (pkgJson && pkgJson.dependencies && pkgJson.dependencies[id]) {
             events.emit('verbose', 'No version specified for ' + id + ', retrieving version from package.json');
             parsedSpec.version = pkgJson.dependencies[id];
+        } else if (pkgJson && pkgJson.devDependencies && pkgJson.devDependencies[id]) {
+            events.emit('verbose', 'No version specified for ' + id + ', retrieving version from package.json');
+            parsedSpec.version = pkgJson.devDependencies[id];
         } else {
             // If no version is specified, retrieve the version (or source) from config.xml.
             events.emit('verbose', 'No version specified for ' + id + ', retrieving version from config.xml');


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
Find and allow restoring plugins when they are located in package.json's devDependencies rather than dependencies.
The same change was already made for platforms: https://github.com/apache/cordova-lib/pull/607

### What testing has been done on this change?
Tested restoring plugins in a project with all cordova-related modules under devDependencies.

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-13532) in the JIRA database
- [x] Commit message follows the format
- [x] Added automated test coverage as appropriate for this change.
