### PR TITLE
CB-12242 : Use yarn instead of npm

### DIFF
--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -89,7 +89,8 @@ function add (projectRoot, hooksRunner, opts) {
                         variables: opts.cli_variables,
                         is_top_level: true,
                         save_exact: opts['save-exact'] || false,
-                        production: opts.production
+                        production: opts.production,
+                        manager: opts.manager
                     };
 
                     return module.exports.determinePluginTarget(projectRoot, cfg, target, fetchOptions).then(function (resolvedTarget) {


### PR DESCRIPTION
### Platforms affected

All

### What does this PR do?

Allows user to select his package manager used by cordova-fetch, possible values are "npm" or "yarn", defaulting to "npm"

### What testing has been done on this change?

None, since we're just adding cordova arguments here

N.B. : src/cordova/plugin/util is still using fetch.isNpmInstalled()

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
