### PR TITLE
CB-14065: Drop support for Node 4 and add Node 10 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: node_js
 sudo: false
 git:
   depth: 10
+
 node_js:
-  - "4"
   - "6"
   - "8"
-# we don't test with npm 2.x
-before_install: if [[ `npm -v` < 3 ]]; then npm i -g npm@3; fi
+  - "10"
+
 install:
   - npm install
   # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,10 @@
 
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
-  
+  - nodejs_version: "10"
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "cordova-lib.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "dependencies": {
     "aliasify": "^2.1.0",


### PR DESCRIPTION
Also removed before_install from Travis configuration since Node 6 already comes with npm 3 there.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
