### PR TITLE
CB-14102: Fix tests use specified npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   #- (cd cordova-fetch && npm install && npm link ../cordova-common)
 
 before_install:
-  - npm -v | awk '/^5\.6\./ {  npm install -g npm@5.7.1  }'
+  - npm -v | awk '/^5\.6\./ { system("npm install xml2js@0.4.19") }'
 
 script:
   - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,8 @@ install:
   #- "(cd cordova-common && npm install)"
   #- (cd cordova-fetch && npm install && npm link ../cordova-common)
 
+before_install:
+  - npm -v | awk '/^5\.6\./ {  npm install -g npm@5.7.1  }'
+
 script:
   - "npm test"

--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -840,7 +840,7 @@ describe('During add, if add specifies a platform spec, use that one regardless 
         expect(engines).toEqual([ { name: 'ios', spec: '~4.2.1' } ]);
         emptyPlatformList().then(function () {
             // Add ios with --save and --fetch.
-            return cordova.platform('add', ['ios@4.3.0'], {'save': true, 'fetch': true});
+            return cordova.platform('add', ['ios@4.5.4'], {'save': true, 'fetch': true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

This is only test codes in order to pass the travis ci.

### What does this PR do?

1. Test ios platform version is changed to ios@4.5.4 instead of ios@4.3.0. ios@4.3.0 is too old for the latest cordova-cli and brings installing error.

2. Use npm 5.7.1 instead of 5.6.x. 
Because npm@5.6.x has an issue. 
The issue is on npm’s Github: https://github.com/npm/npm/issues/17379
As a result, `cordova plugin add` with github url brings error in test.

### What testing has been done on this change?

Using ios@4.54 instead of ios@4.3.0
Using npm@5.7.1 instead of default npm.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
