### PR TITLE
CB-14116: improve tests using ios@4.5.4, adjusting timeout params and improve p…

### DIFF
--- a/integration-tests/pkgJson-restore.spec.js
+++ b/integration-tests/pkgJson-restore.spec.js
@@ -24,7 +24,7 @@ var prepare = require('../src/cordova/prepare');
 var cordova_util = require('../src/cordova/util');
 var cordovaPlugin = require('../src/cordova/plugin');
 // cordova = require('../src/cordova/cordova'),
-var TIMEOUT = 60 * 1000;
+var TIMEOUT = 240 * 1000;
 
 /** Testing will check if "cordova prepare" is restoring platforms and plugins as expected.
 *   Uses different basePkgJson files depending on testing expecations of what (platforms/plugins/variables)
@@ -36,8 +36,10 @@ describe('tests platform/spec restore with --save', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson2');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 300 * 1000;
         shell.rm('-rf', project);
         // Copy then move because we need to copy everything, but that means it will copy the whole directory.
         // Using /* doesn't work because of hidden files.
@@ -45,10 +47,11 @@ describe('tests platform/spec restore with --save', function () {
         shell.mv(path.join(tmpDir, 'basePkgJson'), project);
         process.chdir(project);
         delete process.env.PWD;
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -274,18 +277,21 @@ describe('tests platform/spec restore with --save', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson2');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
         // Copy then move because we need to copy everything, but that means it will copy the whole directory.
         // Using /* doesn't work because of hidden files.
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -358,6 +364,7 @@ describe('files should not be modified if their platforms are identical', functi
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -367,10 +374,11 @@ describe('files should not be modified if their platforms are identical', functi
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson6'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson6'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -429,6 +437,7 @@ describe('update pkg.json to include platforms in config.xml', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -437,10 +446,11 @@ describe('update pkg.json to include platforms in config.xml', function () {
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson5'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson5'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -499,7 +509,7 @@ describe('update pkg.json to include platforms in config.xml', function () {
             expect(configEngArray.indexOf(androidPlatform)).toBeGreaterThan(-1);
             expect(configEngArray.indexOf(browserPlatform)).toBeGreaterThan(-1);
             // Platform specs from config.xml have been added to pkg.json.
-            expect(pkgJson.dependencies['cordova-browser']).toEqual('^5.0.0');
+            expect(pkgJson.dependencies['cordova-browser']).toEqual('^5.0.3');
             expect(pkgJson.dependencies['cordova-android']).toEqual('7.0.0');
         }).fail(function (err) {
             expect(err).toBeUndefined();
@@ -513,6 +523,7 @@ describe('update empty package.json to match config.xml', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -521,10 +532,11 @@ describe('update empty package.json to match config.xml', function () {
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson3'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson3'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -591,6 +603,7 @@ describe('update config.xml to include platforms in pkg.json', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -599,10 +612,11 @@ describe('update config.xml to include platforms in pkg.json', function () {
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson4'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson4'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -639,7 +653,7 @@ describe('update config.xml to include platforms in pkg.json', function () {
         expect(configEngArray.indexOf('browser')).toEqual(-1);
         expect(configEngArray.length === 1);
         // Pkg.json has cordova-browser in its dependencies.
-        expect(pkgJson.dependencies).toEqual({ 'cordova-ios': '^4.5.4', 'cordova-browser': '^5.0.0' });
+        expect(pkgJson.dependencies).toEqual({ 'cordova-ios': '^4.5.4', 'cordova-browser': '^5.0.3' });
         emptyPlatformList().then(function () {
             // Run cordova prepare.
             return prepare({ 'fetch': true });
@@ -659,11 +673,11 @@ describe('update config.xml to include platforms in pkg.json', function () {
             // Expect config.xml array to have 2 elements (platforms).
             expect(configEngArray.length === 2);
             // Check to make sure that 'browser' spec was added properly.
-            expect(engines).toEqual([ { name: 'ios', spec: '^4.5.4' }, { name: 'browser', spec: '^5.0.0' } ]);
+            expect(engines).toEqual([ { name: 'ios', spec: '^4.5.4' }, { name: 'browser', spec: '^5.0.3' } ]);
             // No change to pkg.json dependencies.
-            expect(pkgJson.dependencies).toEqual({ 'cordova-ios': '^4.5.4', 'cordova-browser': '^5.0.0' });
+            expect(pkgJson.dependencies).toEqual({ 'cordova-ios': '^4.5.4', 'cordova-browser': '^5.0.3' });
             expect(pkgJson.dependencies['cordova-ios']).toEqual('^4.5.4');
-            expect(pkgJson.dependencies['cordova-browser']).toEqual('^5.0.0');
+            expect(pkgJson.dependencies['cordova-browser']).toEqual('^5.0.3');
         }).fail(function (err) {
             expect(err).toBeUndefined();
         }).fin(done);
@@ -679,6 +693,7 @@ describe('update config.xml to use the variable found in pkg.json', function () 
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -687,10 +702,11 @@ describe('update config.xml to use the variable found in pkg.json', function () 
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson8'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson8'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -761,6 +777,7 @@ describe('update pkg.json to include plugin and variable found in config.xml', f
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -769,10 +786,11 @@ describe('update pkg.json to include plugin and variable found in config.xml', f
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson9'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson9'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -847,6 +865,7 @@ describe('update pkg.json AND config.xml to include all plugins and merge unique
     var tmpDir = helpers.tmpDir('plugin_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -855,10 +874,11 @@ describe('update pkg.json AND config.xml to include all plugins and merge unique
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson10'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson10'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -970,6 +990,7 @@ describe('update pkg.json AND config.xml to include all plugins/merge variables 
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -978,10 +999,11 @@ describe('update pkg.json AND config.xml to include all plugins/merge variables 
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson11'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson11'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -1113,6 +1135,7 @@ describe('update config.xml to include the plugin that is in pkg.json', function
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -1121,10 +1144,11 @@ describe('update config.xml to include the plugin that is in pkg.json', function
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson12'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson12'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
@@ -1212,6 +1236,7 @@ describe('platforms and plugins should be restored with config.xml even without 
     var tmpDir = helpers.tmpDir('platform_test_pkgjson');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
         shell.rm('-rf', tmpDir);
@@ -1221,10 +1246,11 @@ describe('platforms and plugins should be restored with config.xml even without 
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson13'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson13'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
     });
@@ -1345,18 +1371,21 @@ describe('tests platform/spec restore with --save', function () {
     var tmpDir = helpers.tmpDir('platform_test_pkgjson2');
     var project = path.join(tmpDir, 'project');
     var results;
+    var listener = function (res) { results = res; };
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
         // Copy then move because we need to copy everything, but that means it will copy the whole directory.
         // Using /* doesn't work because of hidden files.
         shell.cp('-R', path.join(__dirname, '..', 'spec', 'cordova', 'fixtures', 'basePkgJson'), tmpDir);
         shell.mv(path.join(tmpDir, 'basePkgJson'), project);
         process.chdir(project);
-        events.on('results', function (res) { results = res; });
+        events.on('results', listener);
     });
 
     afterEach(function () {
+        events.removeListener('results', listener);
         cordova_util.requireNoCache(path.join(process.cwd(), 'package.json'));
         process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);

--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -22,7 +22,7 @@ var shell = require('shelljs');
 var events = require('cordova-common').events;
 var ConfigParser = require('cordova-common').ConfigParser;
 var cordova = require('../src/cordova/cordova');
-var TIMEOUT = 60 * 1000;
+var TIMEOUT = 120 * 1000;
 var cordova_util = require('../src/cordova/util');
 var semver = require('semver');
 
@@ -45,6 +45,7 @@ describe('plugin end-to-end', function () {
     events.on('results', function (res) { results = res; });
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', project);
 
         // Copy then move because we need to copy everything, but that means it will copy the whole directory.
@@ -293,7 +294,7 @@ describe('plugin end-to-end', function () {
                 expect(err).toBeUndefined();
             }).fin(done);
     // Cordova prepare needs extra wait time to complete.
-    }, 60000);
+    }, TIMEOUT);
 
     // Test#025: has a pkg.json. Checks if local path is added to pkg.json for platform and plugin add.
     it('Test#025 : if you add a platform/plugin with local path, pkg.json gets updated', function (done) {
@@ -360,7 +361,7 @@ describe('plugin end-to-end', function () {
             }).fail(function (err) {
                 expect(err).toBeUndefined();
             }).fin(done);
-    }, 60000);
+    }, TIMEOUT);
 });
 
 // This group of tests checks if platforms are added and removed as expected from package.json.
@@ -370,7 +371,7 @@ describe('platform end-to-end with --save', function () {
     var results;
 
     beforeEach(function () {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30 * 1000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
 
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
@@ -588,6 +589,7 @@ describe('During add, if pkg.json has a platform/plugin spec, use that one.', fu
     var results;
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
 
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
@@ -635,7 +637,7 @@ describe('During add, if pkg.json has a platform/plugin spec, use that one.', fu
 
         // Pkg.json has ios and spec '^4.2.1' and splashscreen '^3.2.2'.
         expect(pkgJson.cordova.platforms).toEqual([ iosPlatform ]);
-        expect(pkgJson.dependencies).toEqual({ 'cordova-plugin-splashscreen': '^3.2.2', 'cordova-ios': '^4.2.1' });
+        expect(pkgJson.dependencies).toEqual({ 'cordova-plugin-splashscreen': '^3.2.2', 'cordova-ios': '^4.5.4' });
         // Config.xml has no platforms or plugins yet.
         expect(engines.length).toEqual(0);
         expect(configPlugins.length).toEqual(0);
@@ -680,7 +682,7 @@ describe('During add, if pkg.json has a platform/plugin spec, use that one.', fu
             expect(err).toBeUndefined();
         }).fin(done);
     // Cordova prepare needs extra wait time to complete.
-    }, 120000);
+    }, TIMEOUT * 2);
 });
 
 // Test #021 : use basePkgJson16 as config.xml contains platform/spec and plugin/spec pkg.json does not.
@@ -690,6 +692,7 @@ describe('During add, if config.xml has a platform/plugin spec and pkg.json does
     var results;
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
 
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
@@ -779,7 +782,7 @@ describe('During add, if config.xml has a platform/plugin spec and pkg.json does
             expect(err).toBeUndefined();
         }).fin(done);
     // Cordova prepare needs extra wait time to complete.
-    }, 60000);
+    }, TIMEOUT);
 });
 
 // Test #022 : use basePkgJson17 (config.xml and pkg.json each have ios platform with different specs).
@@ -789,6 +792,7 @@ describe('During add, if add specifies a platform spec, use that one regardless 
     var results;
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
         // Using /* doesn't work because of hidden files.
@@ -882,7 +886,7 @@ describe('During add, if add specifies a platform spec, use that one regardless 
             expect(err).toBeUndefined();
         }).fin(done);
     // Cordova prepare needs extra wait time to complete.
-    }, 60000);
+    }, TIMEOUT);
 });
 
 // No pkg.json included in test file.
@@ -893,6 +897,7 @@ describe('local path is added to config.xml without pkg.json', function () {
     var testRunRoot = process.cwd();
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
         shell.rm('-rf', tmpDir);
 
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
@@ -936,7 +941,7 @@ describe('local path is added to config.xml without pkg.json', function () {
             }).fail(function (err) {
                 expect(err).toBeUndefined();
             }).fin(done);
-    }, 60000);
+    }, TIMEOUT);
 
     // Test#027: has NO pkg.json. Checks if local path is added to config.xml and has no errors.
     it('Test#027 : if you add a plugin with local path, config.xml gets updated', function (done) {
@@ -961,5 +966,5 @@ describe('local path is added to config.xml without pkg.json', function () {
             }).fail(function (err) {
                 expect(err).toBeUndefined();
             }).fin(done);
-    }, 60000);
+    }, TIMEOUT);
 });

--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -22,7 +22,7 @@ var shell = require('shelljs');
 var events = require('cordova-common').events;
 var ConfigParser = require('cordova-common').ConfigParser;
 var cordova = require('../src/cordova/cordova');
-var TIMEOUT = 30 * 1000;
+var TIMEOUT = 60 * 1000;
 var cordova_util = require('../src/cordova/util');
 var semver = require('semver');
 
@@ -370,6 +370,7 @@ describe('platform end-to-end with --save', function () {
     var results;
 
     beforeEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30 * 1000;
         shell.rm('-rf', tmpDir);
 
         // cp then mv because we need to copy everything, but that means it'll copy the whole directory.
@@ -679,7 +680,7 @@ describe('During add, if pkg.json has a platform/plugin spec, use that one.', fu
             expect(err).toBeUndefined();
         }).fin(done);
     // Cordova prepare needs extra wait time to complete.
-    }, 60000);
+    }, 120000);
 });
 
 // Test #021 : use basePkgJson16 as config.xml contains platform/spec and plugin/spec pkg.json does not.
@@ -840,7 +841,7 @@ describe('During add, if add specifies a platform spec, use that one regardless 
         expect(engines).toEqual([ { name: 'ios', spec: '~4.2.1' } ]);
         emptyPlatformList().then(function () {
             // Add ios with --save and --fetch.
-            return cordova.platform('add', ['ios@4.3.0'], {'save': true, 'fetch': true});
+            return cordova.platform('add', ['ios@4.5.4'], {'save': true, 'fetch': true});
         }).then(function () {
             // Delete any previous caches of require(package.json).
             pkgJson = cordova_util.requireNoCache(pkgJsonPath);

--- a/spec/cordova/fixtures/basePkgJson15/package.json
+++ b/spec/cordova/fixtures/basePkgJson15/package.json
@@ -18,6 +18,6 @@
     },
     "dependencies": {
         "cordova-plugin-splashscreen": "^3.2.2",
-        "cordova-ios": "^4.2.1"
+        "cordova-ios": "^4.5.4"
     }
 }

--- a/spec/cordova/fixtures/basePkgJson4/package.json
+++ b/spec/cordova/fixtures/basePkgJson4/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "dependencies": {
         "cordova-ios": "^4.5.4",
-        "cordova-browser": "^5.0.0"
+        "cordova-browser": "^5.0.3"
     },
     "devDependencies": {},
     "scripts": {

--- a/spec/cordova/fixtures/basePkgJson5/config.xml
+++ b/spec/cordova/fixtures/basePkgJson5/config.xml
@@ -12,5 +12,5 @@
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <engine name="android" spec="7.0.0"/>
-    <engine name="browser" spec="^5.0.0"/>
+    <engine name="browser" spec="^5.0.3"/>
 </widget>


### PR DESCRIPTION
…lugin remove sequentially

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

all platforms

### What does this PR do?

1. For Test#022 on pkgJson.spec.js, using ios@4.5.4

2. Adjust timeout parameters in pkgJson.spec.js.

3.  Fixing errors in Test#006 on platform.spec.js.
`cordova plugin rm` spawns multiple `npm uninstall` commands simultaneously by `Q.all`.
However multiple npm commands simultaneously sometimes bring a following errors,
```
{ CordovaError: Error: npm: Command failed with exit code 254 Error output:
npm WARN checkPermissions Missing write access to /tmp/e2e-test/plugin_rm_test/hello/node_modules/cordova-android/node_modules/abbrev
npm WARN checkPermissions Missing write access to /tmp/e2e-test/plugin_rm_test/hello/node_modules/cordova-android/node_modules/android-versions
```
Then I  update uninstall.js by using sequential promises instead of `Q.all`.


### What testing has been done on this change?

on travis c.i. testing.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
