### PR TITLE
[CB-14145] npm audit in CI on 8.0.0 - TEST WIP DO NOT MERGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
 before_install: if [[ `npm -v` < 3 ]]; then npm i -g npm@3; fi
 install:
   - npm install
+  - npm audit
   # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent
   # module's 'node_modules' In our case 'cordova-common' -> jshint' -> 'cli' dependency
   # is moved to 'cordova-lib' and hence 'npm run jshint' on 'cordova-common' is failing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
+  - npm audit
   # Workaround for npm/npm#10343 when dependency of linked module is moved to dependent
   # module's 'node_modules' In our case 'cordova-common' -> jshint' -> 'cli' dependency
   # is moved to 'cordova-lib' and hence 'npm run jshint' on 'cordova-common' is failing


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Check that `npm audit` passes in AppVeyor CI & Travis CI, on `cordova-lib@8.0.0` (`8.0.x` branch).

NOTE: THIS IS a TEST WIP, EXPECTED TO FAIL on `cordova-lib@8.0.0` due to known `npm audit` issues.

This change is to be included by `git cherry-pick` on `master` and eventually on `8.0.x` branch to verify that `npm audit` issues to not come back in the future.

### What testing has been done on this change?

TBD

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~