### PR TITLE
CB-14148 remove nonsense "www" platform from Cordova listing

### DIFF
--- a/spec/cordova/build.spec.js
+++ b/spec/cordova/build.spec.js
@@ -22,7 +22,7 @@ var HooksRunner = require('../../src/hooks/HooksRunner');
 var Q = require('q');
 var util = require('../../src/cordova/util');
 
-var supported_platforms = Object.keys(platforms).filter(function (p) { return p !== 'www'; });
+var supported_platforms = Object.keys(platforms);
 
 describe('build command', function () {
     var is_cordova;

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -38,20 +38,10 @@ describe('platforms object', function () {
         expect(typeof platforms.getPlatformApi).toBe('function');
     });
 
-    it('should have correct number of platform properties', function () {
-        expect(Object.keys(platforms).length).toBe(5);
-    });
-
-    it('should include the supported platforms', function () {
-        expect(platforms.android).toBeDefined();
-        expect(platforms.browser).toBeDefined();
-        expect(platforms.ios).toBeDefined();
-        expect(platforms.osx).toBeDefined();
-        expect(platforms.windows).toBeDefined();
-    });
-
-    it('should *not* include nonsense "www" platform (CB-14148)', function () {
-        expect(platforms.www).not.toBeDefined();
+    it('should have all and only the supported platforms', function () {
+        expect(Object.keys(platforms)).toEqual(jasmine.arrayWithExactContents([
+            'android', 'browser', 'ios', 'osx', 'windows'
+        ]));
     });
 });
 

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -39,8 +39,7 @@ describe('platforms object', function () {
     });
 
     it('should have correct number of platform properties', function () {
-        // CB-14148 TODO includes nonsense "www" platform:
-        expect(Object.keys(platforms).length).toBe(6);
+        expect(Object.keys(platforms).length).toBe(5);
     });
 
     it('should include the supported platforms', function () {
@@ -49,8 +48,10 @@ describe('platforms object', function () {
         expect(platforms.ios).toBeDefined();
         expect(platforms.osx).toBeDefined();
         expect(platforms.windows).toBeDefined();
-        // REPRODUCE CB-14148:
-        expect(platforms.www).toBeDefined();
+    });
+
+    it('should *not* include nonsense "www" platform (CB-14148)', function () {
+        expect(platforms.www).not.toBeDefined();
     });
 });
 

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -32,6 +32,28 @@ var PLATFORM_SYMLINK = path.join(os.tmpdir(), 'cordova_windows_symlink');
 
 shell.ln('-sf', PLATFORM_WITH_API, PLATFORM_SYMLINK);
 
+describe('platforms object', function () {
+    it('should have getPlatformApi function as a property', function () {
+        expect(platforms.getPlatformApi).toBeDefined();
+        expect(typeof platforms.getPlatformApi).toBe('function');
+    });
+
+    it('should have correct number of platform properties', function () {
+        // CB-14148 TODO includes nonsense "www" platform:
+        expect(Object.keys(platforms).length).toBe(6);
+    });
+
+    it('should include the supported platforms', function () {
+        expect(platforms.android).toBeDefined();
+        expect(platforms.browser).toBeDefined();
+        expect(platforms.ios).toBeDefined();
+        expect(platforms.osx).toBeDefined();
+        expect(platforms.windows).toBeDefined();
+        // REPRODUCE CB-14148:
+        expect(platforms.www).toBeDefined();
+    });
+});
+
 describe('getPlatformApi method', function () {
     var isCordova;
 
@@ -94,5 +116,9 @@ describe('getPlatformApi method', function () {
 
     it('should throw for unknown platform', function () {
         expect(function () { platforms.getPlatformApi('invalid_platform'); }).toThrow();
+    });
+
+    it('should throw for nonsense www platform', function () {
+        expect(function () { platforms.getPlatformApi('www'); }).toThrow();
     });
 });

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -19,13 +19,6 @@
         "apiCompatibleSince": "5.0.0",
         "deprecated": false
     },
-    "www": {
-        "hostos": [],
-        "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-app-hello-world.git",
-        "source": "git",
-        "version": "^3.12.0",
-        "deprecated": false
-    },
     "windows": {
         "hostos": ["win32"],
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

- Remove nonsense "www" platform from listing in `cordova platform ls`
- Verify proper attributes and behavior of `platforms` object

### What testing has been done on this change?

- Verified that the nonsense "www" member is removed in spec
- Verified working properly in local copy of `cordova-lib` and `cordova-cli` projects
- __Verified__ that `npm test` completely passes (in CI)

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.