### PR TITLE
CB-14033 Support symbolic dir links on Windows

### DIFF
--- a/integration-tests/plugman_fetch.spec.js
+++ b/integration-tests/plugman_fetch.spec.js
@@ -94,7 +94,7 @@ describe('fetch', function () {
         });
         it('Test 003 : should create a symlink if used with `link` param', function () {
             return fetch(test_plugin, temp, { link: true }).then(function () {
-                expect(sym).toHaveBeenCalledWith(test_plugin, path.join(temp, test_plugin_id), 'dir');
+                expect(sym).toHaveBeenCalledWith(test_plugin, path.join(temp, test_plugin_id), 'junction');
             });
         });
 
@@ -152,23 +152,13 @@ describe('fetch', function () {
             return Q(pluginDir);
         });
 
-        if (/^win/.test(process.platform)) {
-            it('Test 020 : should copy all but the /demo/ folder', function () {
-                var cp = spyOn(shell, 'cp');
-                return fetch(srcDir, appDir).then(function () {
-                    expect(cp).toHaveBeenCalledWith('-R', path.join(srcDir, 'asset.txt'), path.join(appDir, 'test-recursive'));
-                    expect(cp).not.toHaveBeenCalledWith('-R', srcDir, path.join(appDir, 'test-recursive'));
-                });
-            });
-        } else {
-            it('Test 021 : should skip copy to avoid recursive error', function () {
+        it('Test 021 : should skip copy to avoid recursive error', function () {
 
-                var cp = spyOn(shell, 'cp').and.callFake(function () {});
+            var cp = spyOn(shell, 'cp').and.callFake(function () {});
 
-                return fetch(srcDir, appDir).then(function () {
-                    expect(cp).not.toHaveBeenCalled();
-                });
+            return fetch(srcDir, appDir).then(function () {
+                expect(cp).not.toHaveBeenCalled();
             });
-        }
+        });
     });
 });

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -279,39 +279,15 @@ function copyPlugin (pinfo, plugins_dir, link) {
     shell.rm('-rf', dest);
 
     if (!link && dest.indexOf(path.resolve(plugin_dir) + path.sep) === 0) {
-
-        if (/^win/.test(process.platform)) {
-            /*
-                [CB-10423]
-                This is a special case. On windows we cannot create a symlink unless we are run as admin
-                The error that we have is because src contains dest, so we end up with a recursive folder explosion
-                This code avoids copy the one folder that will explode, and allows plugins to contain a demo project
-                and to install the plugin via `cordova plugin add ../`
-            */
-            var resolvedSrcPath = path.resolve(plugin_dir);
-            var filenames = fs.readdirSync(resolvedSrcPath);
-            var relPath = path.relative(resolvedSrcPath, dest);
-            var relativeRootFolder = relPath.split('\\')[0];
-            filenames.splice(filenames.indexOf(relativeRootFolder), 1);
-            shell.mkdir('-p', dest);
-            events.emit('verbose', 'Copying plugin "' + resolvedSrcPath + '" => "' + dest + '"');
-            events.emit('verbose', 'Skipping folder "' + relativeRootFolder + '"');
-
-            filenames.forEach(function (elem) {
-                shell.cp('-R', path.join(resolvedSrcPath, elem), dest);
-            });
-            return dest;
-        } else {
-            events.emit('verbose', 'Copy plugin destination is child of src. Forcing --link mode.');
-            link = true;
-        }
+        events.emit('verbose', 'Copy plugin destination is child of src. Forcing --link mode.');
+        link = true;
     }
 
     if (link) {
         var isRelativePath = plugin_dir.charAt(1) !== ':' && plugin_dir.charAt(0) !== path.sep;
         var fixedPath = isRelativePath ? path.join(path.relative(plugins_dir, process.env.PWD || process.cwd()), plugin_dir) : plugin_dir;
         events.emit('verbose', 'Linking "' + dest + '" => "' + fixedPath + '"');
-        fs.symlinkSync(fixedPath, dest, 'dir');
+        fs.symlinkSync(fixedPath, dest, 'junction');
     } else {
         shell.mkdir('-p', dest);
         events.emit('verbose', 'Copying plugin "' + plugin_dir + '" => "' + dest + '"');

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -654,7 +654,7 @@ function copyPlugin (plugin_src_dir, plugins_dir, link, pluginInfoProvider) {
     if (link) {
         events.emit('verbose', 'Symlinking from location "' + plugin_src_dir + '" to location "' + dest + '"');
         shell.mkdir('-p', path.dirname(dest));
-        fs.symlinkSync(plugin_src_dir, dest, 'dir');
+        fs.symlinkSync(plugin_src_dir, dest, 'junction');
     } else {
         shell.mkdir('-p', dest);
         events.emit('verbose', 'Copying from location "' + plugin_src_dir + '" to location "' + dest + '"');


### PR DESCRIPTION
### Platforms affected
Windows

### What does this PR do?
This uses junctions whenever creating directory symlinks on Windows since that does not require any special privileges.

### What testing has been done on this change?
Tests on AppVeyor CI

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
