### PR TITLE
CB-14166: (cli) Fixed issue when installing plugins on windows

### DIFF
--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -120,7 +120,6 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
             var parsedSpec = pluginSpec.parse(plugin_src);
             var P;
             var skipCopyingPlugin;
-            var specContainsSpecialCharacters = false;
             plugin_dir = path.join(plugins_dir, parsedSpec.id);
             // if the plugin has already been fetched, use it.
             if (fs.existsSync(plugin_dir)) {
@@ -135,16 +134,7 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                     projectRoot = options.projectRoot;
                 }
 
-                if (process.platform === 'win32' && parsedSpec.version) {
-                    var windowsShellSpecialCharacters = ['&', '\\', '<', '>', '^', '|'];
-                    specContainsSpecialCharacters = windowsShellSpecialCharacters.some(function (character) {
-                        return parsedSpec.version.indexOf(character);
-                    });
-                }
-
-                var fetchPluginSrc = specContainsSpecialCharacters ?
-                    parsedSpec.package + '@"' + parsedSpec.version + '"' : plugin_src;
-                P = fetch(fetchPluginSrc, projectRoot, options);
+                P = fetch(plugin_src, projectRoot, options);
                 skipCopyingPlugin = false;
             }
             return P


### PR DESCRIPTION
The npm package name is already wrapped in quotes to prevent special characters from being execute. However the additional win32 code was further injecting quotes around the version causing npm to return a EINVALIDTAGNAME error. The win32 code is redundant and seems to not be required.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows, CLI

### What does this PR do?
Fix plugin installation on windows platform

### What testing has been done on this change?
Ran it locally and error vanished

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
