### PR TITLE
Clean up messy HooksRunner tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ install:
 build: off
 
 test_script:
+  # Workaround for https://github.com/appveyor/ci/issues/2420
+  - set "PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core"
   - node --version
   - npm --version
   - "npm test"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "globby": "^8.0.1",
     "istanbul": "^0.4.5",
     "jasmine": "^3.0.1",
     "rewire": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dep-graph": "1.1.0",
     "detect-indent": "^5.0.0",
     "elementtree": "^0.1.7",
+    "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "init-package-json": "^1.2.0",
     "nopt": "4.0.1",


### PR DESCRIPTION
These tests tended to cause spurious fails on CI. After having done a complete cleanup, I don't find it surprising at all. I hope they are stable now.

Noteworthy changes include:
- Reset test files before each test
- Don't disguise setup/teardown as tests
- Compare objects instead of JSON strings
- Don't use reserved words as variable names
- Drop some duplicated/obsolete tests
- Fix linting errors
- Remove shelljs usage
- DRY and simplify code
- 200 LOC less