### PR TITLE
CB-14194: Don't cut off scope from package identifier

### DIFF
--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -129,7 +129,7 @@ function add (projectRoot, hooksRunner, opts) {
                         };
 
                         events.emit('verbose', 'Calling plugman.install on plugin "' + pluginInfo.dir + '" for platform "' + platform);
-                        return plugman.install(platform, platformRoot, path.basename(pluginInfo.dir), pluginPath, options)
+                        return plugman.install(platform, platformRoot, pluginInfo.id, pluginPath, options)
                             .then(function (didPrepare) {
                                 // If platform does not returned anything we'll need
                                 // to trigger a prepare after all plugins installed


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
When looking for the installation folder for a scoped npm package, include the scope in the search. Otherwise it will always fail.

### What testing has been done on this change?
I ran `npm test` and I built (`cordova prepare`) our own app with this code.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
