### PR TITLE
restore.spec: Wait for prepare promise to resolve

### DIFF
--- a/integration-tests/pkgJson-restore.spec.js
+++ b/integration-tests/pkgJson-restore.spec.js
@@ -561,9 +561,10 @@ describe('update empty package.json to match config.xml', function () {
         // Expect that config.xml contains only android at this point.
         expect(configEngArray.indexOf('android')).toBeGreaterThan(-1);
         expect(configEngArray.length === 1);
-        // Run cordova prepare.
-        prepare();
+
         return emptyPlatformList().then(function () {
+            return prepare({ fetch: true });
+        }).then(function () {
             var cfg2 = new ConfigParser(configXmlPath);
             engines = cfg2.getEngines();
             engNames = engines.map(function (elem) {


### PR DESCRIPTION
One test in pkgJson-restore.spec did NOT wait for the promise returned
by `prepare` to be resolved before continuing with other tasks.
Especially on Windows this could lead to EBUSY failures during cleanup
and in turn to failures during following tests.

Note: The order of `emptyPlatformList()` and `prepare()` does not seem to matter. Thus I chose the variant that was used throughout all other tests.