### PR TITLE
CB-14243: change dash to underscore for save-exact key reference

### DIFF
--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -87,7 +87,7 @@ function add (projectRoot, hooksRunner, opts) {
                         pluginInfoProvider: pluginInfoProvider,
                         variables: opts.cli_variables,
                         is_top_level: true,
-                        save_exact: opts['save-exact'] || false,
+                        save_exact: opts['save_exact'] || false,
                         production: opts.production
                     };
 
@@ -122,7 +122,7 @@ function add (projectRoot, hooksRunner, opts) {
                             usePlatformWww: true,
                             nohooks: opts.nohooks,
                             force: opts.force,
-                            save_exact: opts['save-exact'] || false,
+                            save_exact: opts['save_exact'] || false,
                             production: opts.production
                         };
 


### PR DESCRIPTION
### Platforms affected
This affects how plugins are added for both Android and IOS.

### What does this PR do?
This PR fixes CB-14243. Cordova-lib is ignoring save-exact b/c the wrong key name is being used to reference it in the options object that is propagated from cli.js.

### What testing has been done on this change?
Unit tests have been run and are passing.

### Checklist
✅Reported an issue in the JIRA database
✅Commit message follows the format: "CB-14243: {message}"
✅ Unit Tests pass
