### PR TITLE
[WIP] CB-14243 better save_exact fix (TODO needs unit test coverage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "globby": "^8.0.1",
     "istanbul": "^0.4.5",
     "jasmine": "^3.0.1",
+    "jasmine-spec-reporter": "^4.2.1",
     "rewire": "^4.0.1"
   },
   "scripts": {

--- a/spec/cordova/platform/check.spec.js
+++ b/spec/cordova/platform/check.spec.js
@@ -32,7 +32,7 @@ describe('cordova/platform/check', function () {
         spyOn(events, 'emit');
         spyOn(superspawn, 'spawn').and.callThrough();
         spyOn(shell, 'rm');
-        spyOn(cordova_util, 'listPlatforms');
+        spyOn(cordova_util, 'listPlatforms').and.returnValue(['ios']);
         spyOn(platform, 'add').and.returnValue(Q());
     });
 
@@ -48,14 +48,12 @@ describe('cordova/platform/check', function () {
 
     it('Should warn if install failed', function () {
         platform.add.and.returnValue(Q.reject());
-        cordova_util.listPlatforms.and.returnValue(['ios']);
         return platform_check(hooks_mock, projectRoot).then(function () {
             expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/current did not install/));
         });
     });
 
     it('Should warn if version-empty', function () {
-        cordova_util.listPlatforms.and.returnValue(['ios']);
         superspawn.spawn.and.returnValue(Q());
         return platform_check(hooks_mock, projectRoot).then(function () {
             expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/current version script failed to return a version/));
@@ -63,9 +61,7 @@ describe('cordova/platform/check', function () {
     });
 
     it('Should warn if version-failed', function () {
-        cordova_util.listPlatforms.and.returnValue(['ios']);
         spyOn(superspawn, 'maybeSpawn').and.returnValue(Q('version-failed'));
-        spyOn(Q.defer(), 'resolve').and.returnValue('version-failed');
         return platform_check(hooks_mock, projectRoot).then(function () {
             expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/current version script failed, and/));
         });

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -16,9 +16,6 @@
     specific language governing permissions and limitations
     under the License.
 */
-// TODO: remove this once eslint lands
-/* eslint-env jasmine */
-/* globals fail */
 
 var rewire = require('rewire');
 var remove = rewire('../../../src/cordova/plugin/remove');

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -27,6 +27,7 @@ jasmine.getEnv().addReporter(new SpecReporter({
         displayDuration: true
     },
     summary: {
-        displayDuration: true
+        displayDuration: true,
+        displayStacktrace: true
     }
 }));

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -17,3 +17,16 @@
     under the License.
 */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+
+jasmine.getEnv().clearReporters();
+jasmine.getEnv().addReporter(new SpecReporter({
+    spec: {
+        displayPending: true,
+        displayDuration: true
+    },
+    summary: {
+        displayDuration: true
+    }
+}));

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -47,6 +47,16 @@ module.exports.tmpDir = function (subdir) {
     return dir;
 };
 
+module.exports.setDefaultTimeout = timeout => {
+    const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    beforeEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
+    });
+    afterEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+};
+
 // Returns the platform that should be used for testing on this host platform.
 /*
 var host = os.platform();

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -19,7 +19,6 @@
 
 var path = require('path');
 var fs = require('fs');
-var shell = require('shelljs');
 var os = require('os');
 var ConfigParser = require('cordova-common').ConfigParser;
 
@@ -35,16 +34,9 @@ function getConfigPath (dir) {
     return path.join(dir, 'config.xml');
 }
 
-module.exports.tmpDir = function (subdir) {
-    var dir = path.join(os.tmpdir(), 'e2e-test');
-    if (subdir) {
-        dir = path.join(dir, subdir);
-    }
-    if (fs.existsSync(dir)) {
-        shell.rm('-rf', dir);
-    }
-    shell.mkdir('-p', dir);
-    return dir;
+module.exports.tmpDir = function (suffix = 'test') {
+    const dir = path.join(os.tmpdir(), `cordova-lib-${suffix}-`);
+    return fs.mkdtempSync(dir);
 };
 
 module.exports.setDefaultTimeout = timeout => {

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -146,25 +146,15 @@ module.exports.writeConfigContent = function (appPath, configContent) {
     fs.writeFileSync(configFile, configContent, 'utf-8');
 };
 
-// Add the toExist matcher.
-beforeEach(function () {
-    jasmine.addMatchers({
-        'toExist': function () {
-            return {
-                compare: function (actual, expected) {
-                    var result = {};
+const customMatchers = {
+    toExist: () => ({ compare (file) {
+        const pass = fs.existsSync(file);
+        const expectation = (pass ? 'not ' : '') + 'to exist';
+        return {
+            pass, message: `expected ${file} ${expectation}`
+        };
+    }})
+};
 
-                    result.pass = fs.existsSync(actual);
-
-                    if (result.pass) {
-                        result.message = 'expected ' + actual + ' to not exist';
-                    } else {
-                        result.message = 'expected ' + actual + ' to exist';
-                    }
-
-                    return result;
-                }
-            };
-        }
-    });
-});
+// Add our custom matchers
+beforeEach(() => jasmine.addMatchers(customMatchers));

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -87,7 +87,7 @@ function add (projectRoot, hooksRunner, opts) {
                         pluginInfoProvider: pluginInfoProvider,
                         variables: opts.cli_variables,
                         is_top_level: true,
-                        save_exact: opts['save_exact'] || false,
+                        save_exact: opts.save_exact || false,
                         production: opts.production
                     };
 
@@ -122,7 +122,7 @@ function add (projectRoot, hooksRunner, opts) {
                             usePlatformWww: true,
                             nohooks: opts.nohooks,
                             force: opts.force,
-                            save_exact: opts['save_exact'] || false,
+                            save_exact: opts.save_exact || false,
                             production: opts.production
                         };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Better fix for save_exact (`--save-exact`) flag issue _(followup to fix contributed in GH-631)_

XXX NOT TESTED

### What testing has been done on this change?

XXX TODO

- [ ] add unit test coverage to verify that the issue is fixed correctly and remains fixed correctly
- [x] verify that `cordova` CLI with `--save-exact` flag works correctly with this fix
- [ ] check that `npm test` succeeds on AppVeyor CI
- [ ] check that `npm test` succeeds on Travis CI

XXX FUTURE TODO: I suspect that there are some other CLI options not covered by the unit test. I think the easiest way to check is to try disabling some code and see if the test suite catches the effect.

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- ~~Added automated test coverage as appropriate for this change.~~