### PR TITLE
Pin Jasmine to 3.1 to work around Promise issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "globby": "^8.0.1",
-    "jasmine": "^3.0.1",
+    "jasmine": "~3.1.0",
     "jasmine-spec-reporter": "^4.2.1",
     "nyc": "^12.0.2",
     "rewire": "^4.0.1"


### PR DESCRIPTION
A change in Jasmine 3.2 seems to be responsible for the recent CI failures. Pinning it to 3.1 for now.

See https://github.com/apache/cordova-ios/issues/393, https://github.com/jasmine/jasmine/issues/1590 and #636 