### PR TITLE
Remove all usage of Q-specific methods on Promise instances

### DIFF
--- a/integration-tests/fetch.spec.js
+++ b/integration-tests/fetch.spec.js
@@ -57,7 +57,7 @@ describe('end-to-end plugin dependency tests', function () {
             }).then(function () {
                 expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                 return cordova.plugin('add', plugins['Test1']);
-            }).fail(function (err) {
+            }).catch(function (err) {
                 expect(err.message).toContain('does not satisfy dependency plugin requirement');
             });
     }, TIMEOUT);
@@ -118,7 +118,7 @@ describe('end-to-end plugin dependency tests', function () {
             .then(function () {
                 return cordova.plugin('add', plugins['Test3']);
             })
-            .fail(function (err) {
+            .catch(function (err) {
                 expect(path.join(pluginsDir, 'Test2')).toExist();
                 expect(path.join(pluginsDir, 'Test3')).not.toExist();
                 expect(err.message).toContain('does not satisfy dependency plugin requirement');

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -298,6 +298,11 @@ describe('uninstall', function () {
 });
 
 describe('end', function () {
+
+    afterEach(function () {
+        shell.rm('-rf', project, project2, project3);
+    });
+
     it('Test 013 : end', function () {
         return uninstall('android', project, plugins['org.test.plugins.dummyplugin'])
             .then(function () {
@@ -308,9 +313,6 @@ describe('end', function () {
             }).then(function () {
                 // dependencies on C,D ... should this only work with --recursive? prompt user..?
                 return uninstall('android', project, plugins['A']);
-            }).fin(function (err) {
-                if (err) { events.emit('error', err); }
-                shell.rm('-rf', project, project2, project3);
             });
     });
 });

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -303,7 +303,7 @@ describe('end', function () {
             .then(function () {
                 // Fails... A depends on
                 return uninstall('android', project, plugins['C']);
-            }).fail(function (err) {
+            }).catch(function (err) {
                 expect(err.stack).toMatch(/The plugin 'C' is required by \(A\), skipping uninstallation./);
             }).then(function () {
                 // dependencies on C,D ... should this only work with --recursive? prompt user..?

--- a/spec/cordova/build.spec.js
+++ b/spec/cordova/build.spec.js
@@ -85,17 +85,11 @@ describe('build command', function () {
             });
         });
 
-        it('Test 005 : should convert options from old format and warn user about this', function () {
-            function warnSpy (message) {
-                expect(message).toMatch('The format of cordova.* methods "options" argument was changed');
-            }
-
-            cordova.on('warn', warnSpy);
+        it('Test 005 : should convert options from old format', function () {
             return cordova.build({platforms: ['android'], options: ['--release', '--cdvBuildOpt=opt']}).then(function () {
                 var opts = {platforms: ['android'], options: jasmine.objectContaining({release: true, argv: ['--cdvBuildOpt=opt']}), verbose: false};
                 expect(prepare_spy).toHaveBeenCalledWith(opts);
                 expect(compile_spy).toHaveBeenCalledWith(opts);
-                cordova.off('warn', warnSpy);
             });
         });
     });

--- a/spec/cordova/compile.spec.js
+++ b/spec/cordova/compile.spec.js
@@ -81,19 +81,11 @@ describe('compile command', function () {
                 });
         });
 
-        it('Test 005 : should convert options from old format and warn user about this', function () {
-            function warnSpy (message) {
-                expect(message).toMatch('The format of cordova.* methods "options" argument was changed');
-            }
-
-            cordova.on('warn', warnSpy);
+        it('Test 005 : should convert options from old format', function () {
             return cordova.compile({platforms: ['blackberry10'], options: ['--release']})
                 .then(function () {
                     expect(getPlatformApi).toHaveBeenCalledWith('blackberry10');
                     expect(platformApi.build).toHaveBeenCalledWith({release: true, argv: []});
-                })
-                .fin(function () {
-                    cordova.off('warn', warnSpy);
                 });
         });
     });

--- a/spec/cordova/emulate.spec.js
+++ b/spec/cordova/emulate.spec.js
@@ -89,20 +89,12 @@ describe('emulate command', function () {
                     expect(platformApi.run).toHaveBeenCalledWith({ device: false, emulator: true, optionTastic: true, nobuild: true });
                 });
         });
-        it('Test 005 : should convert options from old format and warn user about this', function () {
-            function warnSpy (message) {
-                expect(message).toMatch('The format of cordova.* methods "options" argument was changed');
-            }
-
-            cordova.on('warn', warnSpy);
+        it('Test 005 : should convert options from old format', function () {
             return cordova.emulate({platforms: ['ios'], options: ['--optionTastic']})
                 .then(function () {
                     expect(prepare_spy).toHaveBeenCalledWith(jasmine.objectContaining({platforms: ['ios']}));
                     expect(getPlatformApi).toHaveBeenCalledWith('ios');
                     expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({emulator: true, argv: ['--optionTastic']}));
-                })
-                .fin(function () {
-                    cordova.off('warn', warnSpy);
                 });
         });
         describe('run parameters should not be altered by intermediate build command', function () {

--- a/spec/cordova/fixtures/projects/platformApi/platforms/windows/cordova/Api.js
+++ b/spec/cordova/fixtures/projects/platformApi/platforms/windows/cordova/Api.js
@@ -224,7 +224,7 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
         })
         // CB-11022 return non-falsy value to indicate
         // that there is no need to run prepare after
-        .thenResolve(true);
+        .then(_ => true);
 };
 
 /**
@@ -261,7 +261,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
         })
         // CB-11022 return non-falsy value to indicate
         // that there is no need to run prepare after
-        .thenResolve(true);
+        .then(_ => true);
 };
 
 /**

--- a/spec/cordova/run.spec.js
+++ b/spec/cordova/run.spec.js
@@ -88,20 +88,12 @@ describe('run command', function () {
             });
         });
         it('Test 006 : should convert parameters from old format and warn user about this', function () {
-            function warnSpy (message) {
-                expect(message).toMatch('The format of cordova.* methods "options" argument was changed');
-            }
-
-            cordova.on('warn', warnSpy);
             return cordova.run({platforms: ['blackberry10'], options: ['--password=1q1q']})
                 .then(function () {
                     expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ],
                         options: jasmine.objectContaining({argv: ['--password=1q1q']}),
                         verbose: false });
                     expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({argv: ['--password=1q1q']}));
-                })
-                .fin(function () {
-                    cordova.off('warn', warnSpy);
                 });
         });
 

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -136,7 +136,7 @@ describe('plugman install start', function () {
         var addPluginOrig = api.addPlugin;
         spyOn(api, 'addPlugin').and.callFake(function () {
             return addPluginOrig.apply(api, arguments)
-                .thenResolve(returnValues[returnValueIndex++]);
+                .then(_ => returnValues[returnValueIndex++]);
         });
 
         return install('android', project, plugins['org.test.plugins.dummyplugin'])

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -372,7 +372,7 @@ describe('install', function () {
                 return install('android', project, plugins['G'])
                     .then(function () {
                         common.spy.getInstall(emit);
-                    }).fail(function err (errMsg) {
+                    }).catch(function err (errMsg) {
                         expect(errMsg.toString()).toContain('Cyclic dependency from G to H');
                     });
             }, TIMEOUT);

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -297,7 +297,7 @@ function downloadPlatform (projectRoot, platform, version, opts) {
         }
         events.emit('log', 'Using cordova-fetch for ' + target);
         return fetch(target, projectRoot, opts);
-    }).fail(function (error) {
+    }).catch(function (error) {
         var message = 'Failed to fetch platform ' + target +
             '\nProbably this is either a connection problem, or platform spec is incorrect.' +
             '\nCheck your connection and platform name/version/URL.' +

--- a/src/cordova/platform/check.js
+++ b/src/cordova/platform/check.js
@@ -92,7 +92,7 @@ function check (hooksRunner, projectRoot) {
                         d_cur.resolve('broken');
                     });
 
-                Q.all([d_avail.promise, d_cur.promise]).spread(function (avail, v) {
+                Q.all([d_avail.promise, d_cur.promise]).then(([avail, v]) => {
                     var m;
                     var prefix = p + ' @ ' + (v || 'unknown');
                     switch (avail) {

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -134,7 +134,7 @@ function add (projectRoot, hooksRunner, opts) {
                                 if (!didPrepare) shouldRunPrepare = true;
                             });
                     })
-                        .thenResolve(pluginInfo);
+                        .then(_ => pluginInfo);
                 }).then(function (pluginInfo) {
                     var pkgJson;
                     var pkgJsonPath = path.join(projectRoot, 'package.json');

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -149,7 +149,7 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                 skipCopyingPlugin = false;
             }
             return P
-                .fail(function (error) {
+                .catch(function (error) {
                     var message = 'Failed to fetch plugin ' + plugin_src + ' via registry.' +
                         '\nProbably this is either a connection problem, or plugin spec is incorrect.' +
                         '\nCheck your connection and plugin name/version/URL.' +

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -358,7 +358,7 @@ function runInstall (actions, platform, project_dir, plugin_dir, plugins_dir, op
                 }).then(function (installResult) {
                     return hooksRunner.fire('after_plugin_install', hookOptions)
                         // CB-11022 Propagate install result to caller to be able to avoid unnecessary prepare
-                        .thenResolve(installResult);
+                        .then(_ => installResult);
                 });
             } else {
                 return handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, install_plugin_dir, filtered_variables, options);

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -364,7 +364,7 @@ function runInstall (actions, platform, project_dir, plugin_dir, plugins_dir, op
                 return handleInstall(actions, pluginInfo, platform, project_dir, plugins_dir, install_plugin_dir, filtered_variables, options);
             }
         }
-    ).fail(
+    ).catch(
         function (error) {
 
             if (error === 'skip') {
@@ -460,7 +460,7 @@ function tryFetchDependency (dep, install, options) {
                 var url = path.join(git_repo, dep.subdir);
                 dep.subdir = '';
                 return Q(url);
-            }).fail(function (error) { // eslint-disable-line handle-callback-err
+            }).catch(function () {
                 return Q(dep.url);
             });
 

--- a/src/util/promise-util.js
+++ b/src/util/promise-util.js
@@ -40,7 +40,7 @@ function Q_chainmap_graceful (args, func, failureCallback) {
         return args.reduce(function (soFar, arg) {
             return soFar.then(function (val) {
                 return func(arg, val);
-            }).fail(function (err) {
+            }).catch(function (err) {
                 if (failureCallback) {
                     failureCallback(err);
                 }


### PR DESCRIPTION
With this change landed, it should be safe to return native Promise instances from any modules consumed by `cordova-lib`.