### PR TITLE
Fix sporadic timeout of HooksRunner test 012

### DIFF
--- a/integration-tests/HooksRunner.spec.js
+++ b/integration-tests/HooksRunner.spec.js
@@ -245,7 +245,7 @@ describe('HooksRunner', function () {
                                 expect(context).toEqual(expectedContext);
                             });
                     });
-            });
+            }, 20 * 1000);
         });
 
         describe('plugin hooks', function () {


### PR DESCRIPTION
Test 012 sporadically takes slightly longer than the current default
timeout of 10s, so this increases the timeout for this test to 20s.