### PR TITLE
Only upload coverage when tests succeed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,6 @@ install:
 
 script:
   - npm run cover
+
+after_success:
   - npm run report-coverage


### PR DESCRIPTION
Purely cosmetic. Codecov seems to ignore coverage from failing builds anyway.