### PR TITLE
plugman_uninstall.spec cleanup

### DIFF
--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -20,10 +20,9 @@
 const Q = require('q');
 const fs = require('fs-extra');
 const path = require('path');
-const et = require('elementtree');
 const rewire = require('rewire');
 
-const { ActionStack, PluginInfo, events, xmlHelpers } = require('cordova-common');
+const { ActionStack, PluginInfo, events } = require('cordova-common');
 const common = require('../spec/common');
 const install = require('../src/plugman/install');
 const platforms = require('../src/platforms/platforms');
@@ -49,22 +48,6 @@ const dummy_id = 'org.test.plugins.dummyplugin';
 
 const dummyPluginInfo = new PluginInfo(plugins['org.test.plugins.dummyplugin']);
 
-const TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
-    '<widget xmlns     = "http://www.w3.org/ns/widgets"\n' +
-    '        xmlns:cdv = "http://cordova.apache.org/ns/1.0"\n' +
-    '        id        = "io.cordova.hellocordova"\n' +
-    '        version   = "0.0.1">\n' +
-    '    <name>Hello Cordova</name>\n' +
-    '    <description>\n' +
-    '        A sample Apache Cordova application that responds to the deviceready event.\n' +
-    '    </description>\n' +
-    '    <author href="http://cordova.io" email="dev@cordova.apache.org">\n' +
-    '        Apache Cordova Team\n' +
-    '    </author>\n' +
-    '    <content src="index.html" />\n' +
-    '    <access origin="*" />\n' +
-    '</widget>\n';
-
 describe('plugman/uninstall', () => {
     let uninstall, emit;
 
@@ -84,13 +67,6 @@ describe('plugman/uninstall', () => {
     });
 
     describe('start', function () {
-        beforeEach(function () {
-            const origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
-            spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function (path) {
-                if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
-                return origParseElementtreeSync(path);
-            });
-        });
 
         it('Test 001 : plugman uninstall start', function () {
             for (const p of projects) {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -17,18 +17,17 @@
     under the License.
 */
 
-var install = require('../src/plugman/install');
-var actions = require('cordova-common').ActionStack;
-var PluginInfo = require('cordova-common').PluginInfo;
-var events = require('cordova-common').events;
-var common = require('../spec/common');
-var platforms = require('../src/platforms/platforms');
-var xmlHelpers = require('cordova-common').xmlHelpers;
-var et = require('elementtree');
-var fs = require('fs-extra');
-var path = require('path');
-var Q = require('q');
-var rewire = require('rewire');
+const Q = require('q');
+const fs = require('fs-extra');
+const path = require('path');
+const et = require('elementtree');
+const rewire = require('rewire');
+
+const { ActionStack, PluginInfo, events, xmlHelpers } = require('cordova-common');
+const common = require('../spec/common');
+const install = require('../src/plugman/install');
+const platforms = require('../src/platforms/platforms');
+
 var spec = path.join(__dirname, '..', 'spec', 'plugman');
 var srcProject = path.join(spec, 'projects', 'android');
 var project = path.join(spec, 'projects', 'android_uninstall.test');
@@ -106,7 +105,7 @@ describe('plugman uninstall start', function () {
 
 describe('uninstallPlatform', function () {
     beforeEach(function () {
-        spyOn(actions.prototype, 'process').and.returnValue(Q());
+        spyOn(ActionStack.prototype, 'process').and.returnValue(Q());
         spyOn(fs, 'writeFileSync').and.returnValue(true);
         spyOn(fs, 'removeSync').and.returnValue(true);
         spyOn(fs, 'copySync').and.returnValue(true);

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -192,13 +192,11 @@ describe('uninstallPlatform', function () {
 });
 
 describe('uninstallPlugin', function () {
-    var rmstack = [];
     var emit;
 
     beforeEach(function () {
         spyOn(fs, 'writeFileSync').and.returnValue(true);
-        spyOn(fs, 'removeSync').and.callFake(function (f, p) { rmstack.push(p); return true; });
-        rmstack = [];
+        spyOn(fs, 'removeSync');
         emit = spyOn(events, 'emit');
     });
     describe('with dependencies', function () {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -66,11 +66,15 @@ const TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
     '</widget>\n';
 
 describe('plugman/uninstall', () => {
-    var uninstall;
+    let uninstall, emit;
 
     beforeEach(() => {
         uninstall = rewire('../src/plugman/uninstall');
         uninstall.__set__('npmUninstall', jasmine.createSpy());
+
+        emit = spyOn(events, 'emit');
+        spyOn(fs, 'writeFileSync').and.returnValue(true);
+        spyOn(fs, 'removeSync').and.returnValue(true);
     });
 
     afterAll(() => {
@@ -113,8 +117,6 @@ describe('plugman/uninstall', () => {
     describe('uninstallPlatform', function () {
         beforeEach(function () {
             spyOn(ActionStack.prototype, 'process').and.returnValue(Q());
-            spyOn(fs, 'writeFileSync').and.returnValue(true);
-            spyOn(fs, 'removeSync').and.returnValue(true);
             spyOn(fs, 'copySync').and.returnValue(true);
         });
         describe('success', function () {
@@ -168,7 +170,6 @@ describe('plugman/uninstall', () => {
             // FIXME this test messes up the project somehow so that 007 fails
             // Re-enable once project setup is done beforeEach test
             xit('Test 014 : should uninstall dependent plugins', function () {
-                const emit = spyOn(events, 'emit');
                 return uninstall.uninstallPlatform('android', project, 'A')
                     .then(function (result) {
                         expect(emit).toHaveBeenCalledWith('log', 'Uninstalling 2 dependent plugins.');
@@ -198,13 +199,7 @@ describe('plugman/uninstall', () => {
     });
 
     describe('uninstallPlugin', function () {
-        var emit;
 
-        beforeEach(function () {
-            spyOn(fs, 'writeFileSync').and.returnValue(true);
-            spyOn(fs, 'removeSync');
-            emit = spyOn(events, 'emit');
-        });
         describe('with dependencies', function () {
 
             it('Test 006 : should delete all dependent plugins', function () {
@@ -261,11 +256,6 @@ describe('plugman/uninstall', () => {
     });
 
     describe('uninstall', function () {
-
-        beforeEach(function () {
-            spyOn(fs, 'writeFileSync').and.returnValue(true);
-            spyOn(fs, 'removeSync').and.returnValue(true);
-        });
 
         describe('failure', function () {
             it('Test 011 : should throw if platform is unrecognized', function () {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -29,6 +29,7 @@ const platforms = require('../src/platforms/platforms');
 
 const spec = path.join(__dirname, '..', 'spec', 'plugman');
 const srcProject = path.join(spec, 'projects', 'android');
+
 const project = path.join(spec, 'projects', 'android_uninstall.test');
 const project2 = path.join(spec, 'projects', 'android_uninstall.test2');
 const project3 = path.join(spec, 'projects', 'android_uninstall.test3');
@@ -44,9 +45,6 @@ const plugins = {
     'A': path.join(plugins_dir, 'dependencies', 'A'),
     'C': path.join(plugins_dir, 'dependencies', 'C')
 };
-const dummy_id = 'org.test.plugins.dummyplugin';
-
-const dummyPluginInfo = new PluginInfo(plugins['org.test.plugins.dummyplugin']);
 
 describe('plugman/uninstall', () => {
     let uninstall, emit;
@@ -88,10 +86,13 @@ describe('plugman/uninstall', () => {
     }, 60000);
 
     describe('uninstallPlatform', function () {
+        const dummy_id = 'org.test.plugins.dummyplugin';
+
         beforeEach(function () {
             spyOn(ActionStack.prototype, 'process').and.returnValue(Q());
             spyOn(fs, 'copySync').and.returnValue(true);
         });
+
         describe('success', function () {
 
             it('Test 002 : should get PlatformApi instance for platform and invoke its\' removePlugin method', function () {
@@ -116,6 +117,7 @@ describe('plugman/uninstall', () => {
                 });
 
                 const fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
+                const dummyPluginInfo = new PluginInfo(plugins['org.test.plugins.dummyplugin']);
                 fakeProvider.get.and.returnValue(dummyPluginInfo);
 
                 function validateReturnedResultFor (values, expectedResult) {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -167,7 +167,7 @@ describe('plugman/uninstall', () => {
             it('Test 004 : should throw if platform is unrecognized', function () {
                 return uninstall.uninstallPlatform('atari', project, 'SomePlugin')
                     .then(function (result) {
-                        fail();
+                        fail('Expected promise to be rejected');
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Platform "atari" not supported.');
                     });
@@ -176,7 +176,7 @@ describe('plugman/uninstall', () => {
             it('Test 005 : should throw if plugin is missing', function () {
                 return uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
                     .then(function (result) {
-                        fail();
+                        fail('Expected promise to be rejected');
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
                     });
@@ -207,7 +207,7 @@ describe('plugman/uninstall', () => {
 
                 return uninstall.uninstallPlugin('C', plugins_install_dir)
                     .then(function (result) {
-                        fail();
+                        fail('Expected promise to be rejected');
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toEqual('Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)');
                     });
@@ -261,7 +261,7 @@ describe('plugman/uninstall', () => {
             it('Test 011 : should throw if platform is unrecognized', function () {
                 return uninstall('atari', project, 'SomePlugin')
                     .then(function (result) {
-                        fail();
+                        fail('Expected promise to be rejected');
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Platform "atari" not supported.');
                     });
@@ -270,7 +270,7 @@ describe('plugman/uninstall', () => {
             it('Test 012 : should throw if plugin is missing', function () {
                 return uninstall('android', project, 'SomePluginThatDoesntExist')
                     .then(function (result) {
-                        fail();
+                        fail('Expected promise to be rejected');
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
                     });

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -73,6 +73,12 @@ describe('plugman/uninstall', () => {
         uninstall.__set__('npmUninstall', jasmine.createSpy());
     });
 
+    afterAll(() => {
+        for (const p of projects) {
+            fs.removeSync(p);
+        }
+    });
+
     describe('start', function () {
         beforeEach(function () {
             const origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
@@ -283,13 +289,8 @@ describe('plugman/uninstall', () => {
     });
 
     describe('end', function () {
-
-        afterEach(function () {
-            for (const p of projects) {
-                fs.removeSync(p);
-            }
-        });
-
+        // TODO this was some test/teardown hybrid.
+        // We should either add more expectations or get rid of it
         it('Test 013 : end', function () {
             return uninstall('android', project, plugins['org.test.plugins.dummyplugin'])
                 .then(function () {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -28,28 +28,28 @@ const common = require('../spec/common');
 const install = require('../src/plugman/install');
 const platforms = require('../src/platforms/platforms');
 
-var spec = path.join(__dirname, '..', 'spec', 'plugman');
-var srcProject = path.join(spec, 'projects', 'android');
-var project = path.join(spec, 'projects', 'android_uninstall.test');
-var project2 = path.join(spec, 'projects', 'android_uninstall.test2');
-var project3 = path.join(spec, 'projects', 'android_uninstall.test3');
+const spec = path.join(__dirname, '..', 'spec', 'plugman');
+const srcProject = path.join(spec, 'projects', 'android');
+const project = path.join(spec, 'projects', 'android_uninstall.test');
+const project2 = path.join(spec, 'projects', 'android_uninstall.test2');
+const project3 = path.join(spec, 'projects', 'android_uninstall.test3');
 const projects = [project, project2, project3];
 
-var plugins_dir = path.join(spec, 'plugins');
-var plugins_install_dir = path.join(project, 'cordova', 'plugins');
-var plugins_install_dir2 = path.join(project2, 'cordova', 'plugins');
-var plugins_install_dir3 = path.join(project3, 'cordova', 'plugins');
+const plugins_dir = path.join(spec, 'plugins');
+const plugins_install_dir = path.join(project, 'cordova', 'plugins');
+const plugins_install_dir2 = path.join(project2, 'cordova', 'plugins');
+const plugins_install_dir3 = path.join(project3, 'cordova', 'plugins');
 
-var plugins = {
+const plugins = {
     'org.test.plugins.dummyplugin': path.join(plugins_dir, 'org.test.plugins.dummyplugin'),
     'A': path.join(plugins_dir, 'dependencies', 'A'),
     'C': path.join(plugins_dir, 'dependencies', 'C')
 };
-var dummy_id = 'org.test.plugins.dummyplugin';
+const dummy_id = 'org.test.plugins.dummyplugin';
 
-var dummyPluginInfo = new PluginInfo(plugins['org.test.plugins.dummyplugin']);
+const dummyPluginInfo = new PluginInfo(plugins['org.test.plugins.dummyplugin']);
 
-var TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+const TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
     '<widget xmlns     = "http://www.w3.org/ns/widgets"\n' +
     '        xmlns:cdv = "http://cordova.apache.org/ns/1.0"\n' +
     '        id        = "io.cordova.hellocordova"\n' +
@@ -74,7 +74,7 @@ beforeEach(() => {
 
 describe('plugman uninstall start', function () {
     beforeEach(function () {
-        var origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
+        const origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
         spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function (path) {
             if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
             return origParseElementtreeSync(path);
@@ -113,8 +113,8 @@ describe('uninstallPlatform', function () {
     describe('success', function () {
 
         it('Test 002 : should get PlatformApi instance for platform and invoke its\' removePlugin method', function () {
-            var platformApi = { removePlugin: jasmine.createSpy('removePlugin').and.returnValue(Q()) };
-            var getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
+            const platformApi = { removePlugin: jasmine.createSpy('removePlugin').and.returnValue(Q()) };
+            const getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
 
             return uninstall.uninstallPlatform('android', project, dummy_id)
                 .then(function () {
@@ -124,16 +124,16 @@ describe('uninstallPlatform', function () {
         }, 6000);
 
         it('Test 003 : should return propagate value returned by PlatformApi removePlugin method', function () {
-            var platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
+            const platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
             spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
 
-            var existsSyncOrig = fs.existsSync;
+            const existsSyncOrig = fs.existsSync;
             spyOn(fs, 'existsSync').and.callFake(function (file) {
                 if (file.indexOf(dummy_id) >= 0) return true;
                 return existsSyncOrig.call(fs, file);
             });
 
-            var fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
+            const fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
             fakeProvider.get.and.returnValue(dummyPluginInfo);
 
             function validateReturnedResultFor (values, expectedResult) {
@@ -161,7 +161,7 @@ describe('uninstallPlatform', function () {
         // FIXME this test messes up the project somehow so that 007 fails
         // Re-enable once project setup is done beforeEach test
         xit('Test 014 : should uninstall dependent plugins', function () {
-            var emit = spyOn(events, 'emit');
+            const emit = spyOn(events, 'emit');
             return uninstall.uninstallPlatform('android', project, 'A')
                 .then(function (result) {
                     expect(emit).toHaveBeenCalledWith('log', 'Uninstalling 2 dependent plugins.');
@@ -203,7 +203,7 @@ describe('uninstallPlugin', function () {
         it('Test 006 : should delete all dependent plugins', function () {
             return uninstall.uninstallPlugin('A', plugins_install_dir)
                 .then(function (result) {
-                    var del = common.spy.getDeleted(emit);
+                    const del = common.spy.getDeleted(emit);
                     expect(del).toEqual([
                         'Deleted plugin "C"',
                         'Deleted plugin "D"',
@@ -224,7 +224,7 @@ describe('uninstallPlugin', function () {
         it('Test 008 : allow forcefully removing a plugin', function () {
             return uninstall.uninstallPlugin('C', plugins_install_dir, {force: true})
                 .then(function () {
-                    var del = common.spy.getDeleted(emit);
+                    const del = common.spy.getDeleted(emit);
                     expect(del).toEqual(['Deleted plugin "C"']);
                 });
         });
@@ -232,7 +232,7 @@ describe('uninstallPlugin', function () {
         it('Test 009 : never remove top level plugins if they are a dependency', function () {
             return uninstall.uninstallPlugin('A', plugins_install_dir2)
                 .then(function () {
-                    var del = common.spy.getDeleted(emit);
+                    const del = common.spy.getDeleted(emit);
                     expect(del).toEqual([
                         'Deleted plugin "D"',
                         'Deleted plugin "A"'
@@ -243,7 +243,7 @@ describe('uninstallPlugin', function () {
         it('Test 010 : should not remove dependent plugin if it was installed after as top-level', function () {
             return uninstall.uninstallPlugin('A', plugins_install_dir3)
                 .then(function () {
-                    var del = common.spy.getDeleted(emit);
+                    const del = common.spy.getDeleted(emit);
                     expect(del).toEqual([
                         'Deleted plugin "D"',
                         'Deleted plugin "A"'

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -65,240 +65,242 @@ const TEST_XML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
     '    <access origin="*" />\n' +
     '</widget>\n';
 
-var uninstall;
+describe('plugman/uninstall', () => {
+    var uninstall;
 
-beforeEach(() => {
-    uninstall = rewire('../src/plugman/uninstall');
-    uninstall.__set__('npmUninstall', jasmine.createSpy());
-});
+    beforeEach(() => {
+        uninstall = rewire('../src/plugman/uninstall');
+        uninstall.__set__('npmUninstall', jasmine.createSpy());
+    });
 
-describe('plugman uninstall start', function () {
-    beforeEach(function () {
-        const origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
-        spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function (path) {
-            if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
-            return origParseElementtreeSync(path);
+    describe('start', function () {
+        beforeEach(function () {
+            const origParseElementtreeSync = xmlHelpers.parseElementtreeSync.bind(xmlHelpers);
+            spyOn(xmlHelpers, 'parseElementtreeSync').and.callFake(function (path) {
+                if (/config.xml$/.test(path)) return new et.ElementTree(et.XML(TEST_XML));
+                return origParseElementtreeSync(path);
+            });
         });
-    });
 
-    it('Test 001 : plugman uninstall start', function () {
-        for (const p of projects) {
-            fs.copySync(srcProject, p);
-        }
-
-        return install('android', project, plugins['org.test.plugins.dummyplugin'])
-            .then(function (result) {
-                return install('android', project, plugins['A']);
-            }).then(function () {
-                return install('android', project2, plugins['C']);
-            }).then(function () {
-                return install('android', project2, plugins['A']);
-            }).then(function () {
-                return install('android', project3, plugins['A']);
-            }).then(function () {
-                return install('android', project3, plugins['C']);
-            }).then(function (result) {
-                expect(result).toEqual(true);
-            });
-    }, 60000);
-});
-
-describe('uninstallPlatform', function () {
-    beforeEach(function () {
-        spyOn(ActionStack.prototype, 'process').and.returnValue(Q());
-        spyOn(fs, 'writeFileSync').and.returnValue(true);
-        spyOn(fs, 'removeSync').and.returnValue(true);
-        spyOn(fs, 'copySync').and.returnValue(true);
-    });
-    describe('success', function () {
-
-        it('Test 002 : should get PlatformApi instance for platform and invoke its\' removePlugin method', function () {
-            const platformApi = { removePlugin: jasmine.createSpy('removePlugin').and.returnValue(Q()) };
-            const getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
-
-            return uninstall.uninstallPlatform('android', project, dummy_id)
-                .then(function () {
-                    expect(getPlatformApi).toHaveBeenCalledWith('android', project);
-                    expect(platformApi.removePlugin).toHaveBeenCalled();
-                });
-        }, 6000);
-
-        it('Test 003 : should return propagate value returned by PlatformApi removePlugin method', function () {
-            const platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
-            spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
-
-            const existsSyncOrig = fs.existsSync;
-            spyOn(fs, 'existsSync').and.callFake(function (file) {
-                if (file.indexOf(dummy_id) >= 0) return true;
-                return existsSyncOrig.call(fs, file);
-            });
-
-            const fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
-            fakeProvider.get.and.returnValue(dummyPluginInfo);
-
-            function validateReturnedResultFor (values, expectedResult) {
-                return values.reduce(function (promise, value) {
-                    return promise
-                        .then(function () {
-                            platformApi.removePlugin.and.returnValue(Q(value));
-                            return uninstall.uninstallPlatform('android', project, dummy_id, null,
-                                { pluginInfoProvider: fakeProvider, platformVersion: '9.9.9' });
-                        })
-                        .then(function (result) {
-                            expect(!!result).toEqual(expectedResult);
-                        }, function (err) {
-                            expect(err).toBeUndefined();
-                        });
-                }, Q());
+        it('Test 001 : plugman uninstall start', function () {
+            for (const p of projects) {
+                fs.copySync(srcProject, p);
             }
 
-            return validateReturnedResultFor([ true, {}, [], 'foo', function () {} ], true)
-                .then(function () {
-                    return validateReturnedResultFor([ false, null, undefined, '' ], false);
+            return install('android', project, plugins['org.test.plugins.dummyplugin'])
+                .then(function (result) {
+                    return install('android', project, plugins['A']);
+                }).then(function () {
+                    return install('android', project2, plugins['C']);
+                }).then(function () {
+                    return install('android', project2, plugins['A']);
+                }).then(function () {
+                    return install('android', project3, plugins['A']);
+                }).then(function () {
+                    return install('android', project3, plugins['C']);
+                }).then(function (result) {
+                    expect(result).toEqual(true);
                 });
+        }, 60000);
+    });
+
+    describe('uninstallPlatform', function () {
+        beforeEach(function () {
+            spyOn(ActionStack.prototype, 'process').and.returnValue(Q());
+            spyOn(fs, 'writeFileSync').and.returnValue(true);
+            spyOn(fs, 'removeSync').and.returnValue(true);
+            spyOn(fs, 'copySync').and.returnValue(true);
         });
+        describe('success', function () {
 
-        // FIXME this test messes up the project somehow so that 007 fails
-        // Re-enable once project setup is done beforeEach test
-        xit('Test 014 : should uninstall dependent plugins', function () {
-            const emit = spyOn(events, 'emit');
-            return uninstall.uninstallPlatform('android', project, 'A')
-                .then(function (result) {
-                    expect(emit).toHaveBeenCalledWith('log', 'Uninstalling 2 dependent plugins.');
+            it('Test 002 : should get PlatformApi instance for platform and invoke its\' removePlugin method', function () {
+                const platformApi = { removePlugin: jasmine.createSpy('removePlugin').and.returnValue(Q()) };
+                const getPlatformApi = spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
+
+                return uninstall.uninstallPlatform('android', project, dummy_id)
+                    .then(function () {
+                        expect(getPlatformApi).toHaveBeenCalledWith('android', project);
+                        expect(platformApi.removePlugin).toHaveBeenCalled();
+                    });
+            }, 6000);
+
+            it('Test 003 : should return propagate value returned by PlatformApi removePlugin method', function () {
+                const platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
+                spyOn(platforms, 'getPlatformApi').and.returnValue(platformApi);
+
+                const existsSyncOrig = fs.existsSync;
+                spyOn(fs, 'existsSync').and.callFake(function (file) {
+                    if (file.indexOf(dummy_id) >= 0) return true;
+                    return existsSyncOrig.call(fs, file);
                 });
-        });
-    });
 
-    describe('failure ', function () {
-        it('Test 004 : should throw if platform is unrecognized', function () {
-            return uninstall.uninstallPlatform('atari', project, 'SomePlugin')
-                .then(function (result) {
-                    fail();
-                }, function err (errMsg) {
-                    expect(errMsg.toString()).toContain('Platform "atari" not supported.');
-                });
-        }, 6000);
+                const fakeProvider = jasmine.createSpyObj('fakeProvider', ['get']);
+                fakeProvider.get.and.returnValue(dummyPluginInfo);
 
-        it('Test 005 : should throw if plugin is missing', function () {
-            return uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
-                .then(function (result) {
-                    fail();
-                }, function err (errMsg) {
-                    expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-                });
-        }, 6000);
-    });
-});
+                function validateReturnedResultFor (values, expectedResult) {
+                    return values.reduce(function (promise, value) {
+                        return promise
+                            .then(function () {
+                                platformApi.removePlugin.and.returnValue(Q(value));
+                                return uninstall.uninstallPlatform('android', project, dummy_id, null,
+                                    { pluginInfoProvider: fakeProvider, platformVersion: '9.9.9' });
+                            })
+                            .then(function (result) {
+                                expect(!!result).toEqual(expectedResult);
+                            }, function (err) {
+                                expect(err).toBeUndefined();
+                            });
+                    }, Q());
+                }
 
-describe('uninstallPlugin', function () {
-    var emit;
-
-    beforeEach(function () {
-        spyOn(fs, 'writeFileSync').and.returnValue(true);
-        spyOn(fs, 'removeSync');
-        emit = spyOn(events, 'emit');
-    });
-    describe('with dependencies', function () {
-
-        it('Test 006 : should delete all dependent plugins', function () {
-            return uninstall.uninstallPlugin('A', plugins_install_dir)
-                .then(function (result) {
-                    const del = common.spy.getDeleted(emit);
-                    expect(del).toEqual([
-                        'Deleted plugin "C"',
-                        'Deleted plugin "D"',
-                        'Deleted plugin "A"'
-                    ]);
-                });
-        });
-
-        it('Test 007 : should fail if plugin is a required dependency', function () {
-            return uninstall.uninstallPlugin('C', plugins_install_dir)
-                .then(function (result) {
-                    fail();
-                }, function err (errMsg) {
-                    expect(errMsg.toString()).toEqual('Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)');
-                });
-        }, 6000);
-
-        it('Test 008 : allow forcefully removing a plugin', function () {
-            return uninstall.uninstallPlugin('C', plugins_install_dir, {force: true})
-                .then(function () {
-                    const del = common.spy.getDeleted(emit);
-                    expect(del).toEqual(['Deleted plugin "C"']);
-                });
-        });
-
-        it('Test 009 : never remove top level plugins if they are a dependency', function () {
-            return uninstall.uninstallPlugin('A', plugins_install_dir2)
-                .then(function () {
-                    const del = common.spy.getDeleted(emit);
-                    expect(del).toEqual([
-                        'Deleted plugin "D"',
-                        'Deleted plugin "A"'
-                    ]);
-                });
-        });
-
-        it('Test 010 : should not remove dependent plugin if it was installed after as top-level', function () {
-            return uninstall.uninstallPlugin('A', plugins_install_dir3)
-                .then(function () {
-                    const del = common.spy.getDeleted(emit);
-                    expect(del).toEqual([
-                        'Deleted plugin "D"',
-                        'Deleted plugin "A"'
-                    ]);
-                });
-        });
-    });
-});
-
-describe('uninstall', function () {
-
-    beforeEach(function () {
-        spyOn(fs, 'writeFileSync').and.returnValue(true);
-        spyOn(fs, 'removeSync').and.returnValue(true);
-    });
-
-    describe('failure', function () {
-        it('Test 011 : should throw if platform is unrecognized', function () {
-            return uninstall('atari', project, 'SomePlugin')
-                .then(function (result) {
-                    fail();
-                }, function err (errMsg) {
-                    expect(errMsg.toString()).toContain('Platform "atari" not supported.');
-                });
-        }, 6000);
-
-        it('Test 012 : should throw if plugin is missing', function () {
-            return uninstall('android', project, 'SomePluginThatDoesntExist')
-                .then(function (result) {
-                    fail();
-                }, function err (errMsg) {
-                    expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-                });
-        }, 6000);
-    });
-});
-
-describe('end', function () {
-
-    afterEach(function () {
-        for (const p of projects) {
-            fs.removeSync(p);
-        }
-    });
-
-    it('Test 013 : end', function () {
-        return uninstall('android', project, plugins['org.test.plugins.dummyplugin'])
-            .then(function () {
-                // Fails... A depends on
-                return uninstall('android', project, plugins['C']);
-            }).catch(function (err) {
-                expect(err.stack).toMatch(/The plugin 'C' is required by \(A\), skipping uninstallation./);
-            }).then(function () {
-                // dependencies on C,D ... should this only work with --recursive? prompt user..?
-                return uninstall('android', project, plugins['A']);
+                return validateReturnedResultFor([ true, {}, [], 'foo', function () {} ], true)
+                    .then(function () {
+                        return validateReturnedResultFor([ false, null, undefined, '' ], false);
+                    });
             });
+
+            // FIXME this test messes up the project somehow so that 007 fails
+            // Re-enable once project setup is done beforeEach test
+            xit('Test 014 : should uninstall dependent plugins', function () {
+                const emit = spyOn(events, 'emit');
+                return uninstall.uninstallPlatform('android', project, 'A')
+                    .then(function (result) {
+                        expect(emit).toHaveBeenCalledWith('log', 'Uninstalling 2 dependent plugins.');
+                    });
+            });
+        });
+
+        describe('failure ', function () {
+            it('Test 004 : should throw if platform is unrecognized', function () {
+                return uninstall.uninstallPlatform('atari', project, 'SomePlugin')
+                    .then(function (result) {
+                        fail();
+                    }, function err (errMsg) {
+                        expect(errMsg.toString()).toContain('Platform "atari" not supported.');
+                    });
+            }, 6000);
+
+            it('Test 005 : should throw if plugin is missing', function () {
+                return uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
+                    .then(function (result) {
+                        fail();
+                    }, function err (errMsg) {
+                        expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
+                    });
+            }, 6000);
+        });
+    });
+
+    describe('uninstallPlugin', function () {
+        var emit;
+
+        beforeEach(function () {
+            spyOn(fs, 'writeFileSync').and.returnValue(true);
+            spyOn(fs, 'removeSync');
+            emit = spyOn(events, 'emit');
+        });
+        describe('with dependencies', function () {
+
+            it('Test 006 : should delete all dependent plugins', function () {
+                return uninstall.uninstallPlugin('A', plugins_install_dir)
+                    .then(function (result) {
+                        const del = common.spy.getDeleted(emit);
+                        expect(del).toEqual([
+                            'Deleted plugin "C"',
+                            'Deleted plugin "D"',
+                            'Deleted plugin "A"'
+                        ]);
+                    });
+            });
+
+            it('Test 007 : should fail if plugin is a required dependency', function () {
+                return uninstall.uninstallPlugin('C', plugins_install_dir)
+                    .then(function (result) {
+                        fail();
+                    }, function err (errMsg) {
+                        expect(errMsg.toString()).toEqual('Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)');
+                    });
+            }, 6000);
+
+            it('Test 008 : allow forcefully removing a plugin', function () {
+                return uninstall.uninstallPlugin('C', plugins_install_dir, {force: true})
+                    .then(function () {
+                        const del = common.spy.getDeleted(emit);
+                        expect(del).toEqual(['Deleted plugin "C"']);
+                    });
+            });
+
+            it('Test 009 : never remove top level plugins if they are a dependency', function () {
+                return uninstall.uninstallPlugin('A', plugins_install_dir2)
+                    .then(function () {
+                        const del = common.spy.getDeleted(emit);
+                        expect(del).toEqual([
+                            'Deleted plugin "D"',
+                            'Deleted plugin "A"'
+                        ]);
+                    });
+            });
+
+            it('Test 010 : should not remove dependent plugin if it was installed after as top-level', function () {
+                return uninstall.uninstallPlugin('A', plugins_install_dir3)
+                    .then(function () {
+                        const del = common.spy.getDeleted(emit);
+                        expect(del).toEqual([
+                            'Deleted plugin "D"',
+                            'Deleted plugin "A"'
+                        ]);
+                    });
+            });
+        });
+    });
+
+    describe('uninstall', function () {
+
+        beforeEach(function () {
+            spyOn(fs, 'writeFileSync').and.returnValue(true);
+            spyOn(fs, 'removeSync').and.returnValue(true);
+        });
+
+        describe('failure', function () {
+            it('Test 011 : should throw if platform is unrecognized', function () {
+                return uninstall('atari', project, 'SomePlugin')
+                    .then(function (result) {
+                        fail();
+                    }, function err (errMsg) {
+                        expect(errMsg.toString()).toContain('Platform "atari" not supported.');
+                    });
+            }, 6000);
+
+            it('Test 012 : should throw if plugin is missing', function () {
+                return uninstall('android', project, 'SomePluginThatDoesntExist')
+                    .then(function (result) {
+                        fail();
+                    }, function err (errMsg) {
+                        expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
+                    });
+            }, 6000);
+        });
+    });
+
+    describe('end', function () {
+
+        afterEach(function () {
+            for (const p of projects) {
+                fs.removeSync(p);
+            }
+        });
+
+        it('Test 013 : end', function () {
+            return uninstall('android', project, plugins['org.test.plugins.dummyplugin'])
+                .then(function () {
+                    // Fails... A depends on
+                    return uninstall('android', project, plugins['C']);
+                }).catch(function (err) {
+                    expect(err.stack).toMatch(/The plugin 'C' is required by \(A\), skipping uninstallation./);
+                }).then(function () {
+                    // dependencies on C,D ... should this only work with --recursive? prompt user..?
+                    return uninstall('android', project, plugins['A']);
+                });
+        });
     });
 });

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -66,29 +66,26 @@ describe('plugman/uninstall', () => {
         }
     });
 
-    describe('start', function () {
+    beforeAll(() => {
+        for (const p of projects) {
+            fs.copySync(srcProject, p);
+        }
 
-        it('Test 001 : plugman uninstall start', function () {
-            for (const p of projects) {
-                fs.copySync(srcProject, p);
-            }
-
-            return install('android', project, plugins['org.test.plugins.dummyplugin'])
-                .then(function (result) {
-                    return install('android', project, plugins['A']);
-                }).then(function () {
-                    return install('android', project2, plugins['C']);
-                }).then(function () {
-                    return install('android', project2, plugins['A']);
-                }).then(function () {
-                    return install('android', project3, plugins['A']);
-                }).then(function () {
-                    return install('android', project3, plugins['C']);
-                }).then(function (result) {
-                    expect(result).toEqual(true);
-                });
-        }, 60000);
-    });
+        return install('android', project, plugins['org.test.plugins.dummyplugin'])
+            .then(function (result) {
+                return install('android', project, plugins['A']);
+            }).then(function () {
+                return install('android', project2, plugins['C']);
+            }).then(function () {
+                return install('android', project2, plugins['A']);
+            }).then(function () {
+                return install('android', project3, plugins['A']);
+            }).then(function () {
+                return install('android', project3, plugins['C']);
+            }).then(function (result) {
+                expect(result).toEqual(true);
+            });
+    }, 60000);
 
     describe('uninstallPlatform', function () {
         beforeEach(function () {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -76,7 +76,7 @@ describe('plugman/uninstall', () => {
             }).then(function (result) {
                 expect(result).toEqual(true);
             });
-    }, 60000);
+    });
 
     beforeEach(() => {
         uninstall = rewire('../src/plugman/uninstall');
@@ -117,7 +117,7 @@ describe('plugman/uninstall', () => {
                         expect(getPlatformApi).toHaveBeenCalledWith('android', project);
                         expect(platformApi.removePlugin).toHaveBeenCalled();
                     });
-            }, 6000);
+            });
 
             it('Test 003 : should return propagate value returned by PlatformApi removePlugin method', function () {
                 const platformApi = { removePlugin: jasmine.createSpy('removePlugin') };
@@ -171,7 +171,7 @@ describe('plugman/uninstall', () => {
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Platform "atari" not supported.');
                     });
-            }, 6000);
+            });
 
             it('Test 005 : should throw if plugin is missing', function () {
                 return uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
@@ -180,7 +180,7 @@ describe('plugman/uninstall', () => {
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
                     });
-            }, 6000);
+            });
         });
     });
 
@@ -211,7 +211,7 @@ describe('plugman/uninstall', () => {
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toEqual('Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)');
                     });
-            }, 6000);
+            });
 
             it('Test 008 : allow forcefully removing a plugin', function () {
                 setupProject('uninstall.test');
@@ -265,7 +265,7 @@ describe('plugman/uninstall', () => {
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Platform "atari" not supported.');
                     });
-            }, 6000);
+            });
 
             it('Test 012 : should throw if plugin is missing', function () {
                 return uninstall('android', project, 'SomePluginThatDoesntExist')
@@ -274,7 +274,7 @@ describe('plugman/uninstall', () => {
                     }, function err (errMsg) {
                         expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
                     });
-            }, 6000);
+            });
         });
     });
 


### PR DESCRIPTION
Apart from a much-needed general cleanup of `plugman_uninstall.spec`, this fixes one of the tests disabled in e878ecb0b8860c36c59af18d158c89f48528fc9c as part of #613.