### PR TITLE
platform.spec cleanup

### DIFF
--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -41,6 +41,8 @@ describe('cordova/platform', () => {
         nodeModulesDir = path.join(project, 'node_modules');
         testPlatformDir = path.join(platformsDir, testPlatform);
         process.chdir(tmpDir);
+        return cordova.create(path.basename(project))
+            .then(() => process.chdir(project));
     });
 
     afterEach(() => {
@@ -55,11 +57,11 @@ describe('cordova/platform', () => {
     describe('platform end-to-end', () => {
 
         it('Test 001 : should successfully run', () => {
-            return cordova.create(path.basename(project))
+            // Check there are no platforms yet.
+            expect(installedPlatforms()).toEqual([]);
+
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
-                    // Check there are no platforms yet.
-                    expect(installedPlatforms()).toEqual([]);
                     // Add the testing platform.
                     return cordova.platform('add', [testPlatform]);
                 })
@@ -92,9 +94,8 @@ describe('cordova/platform', () => {
         });
 
         it('Test 002 : should install plugins correctly while adding platform', () => {
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     return cordova.plugin('add', path.join(pluginFixturesDir, 'test'));
                 })
                 .then(() => {
@@ -121,9 +122,8 @@ describe('cordova/platform', () => {
             addHelper.__set__({ require: requireFake });
             platform.__set__({ addHelper });
 
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     return cordova.plugin('add', path.join(pluginFixturesDir, 'test'));
                 })
                 .then(() => {
@@ -139,9 +139,8 @@ describe('cordova/platform', () => {
     describe('platform add plugin rm end-to-end', () => {
 
         it('Test 006 : should remove dependency when removing parent plugin', () => {
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     return cordova.platform('add', 'browser@latest');
                 })
                 .then(() => {
@@ -167,10 +166,8 @@ describe('cordova/platform', () => {
     describe('platform add and remove --fetch', () => {
 
         it('Test 007 : should add and remove platform from node_modules directory', () => {
-
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     return cordova.platform('add', 'browser', {'save': true});
                 })
                 .then(() => {
@@ -198,10 +195,8 @@ describe('cordova/platform', () => {
     describe('plugin add and rm end-to-end --fetch', () => {
 
         it('Test 008 : should remove dependency when removing parent plugin', () => {
-
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     return cordova.platform('add', 'browser');
                 })
                 .then(() => {
@@ -233,9 +228,8 @@ describe('cordova/platform', () => {
     describe('non-core platform add and rm end-to-end --fetch', () => {
 
         it('Test 009 : should add and remove 3rd party platforms', () => {
-            return cordova.create(path.basename(project))
+            return Promise.resolve()
                 .then(() => {
-                    process.chdir(project);
                     // add cordova-android instead of android
                     return cordova.platform('add', 'cordova-android');
                 })

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -128,33 +128,6 @@ describe('cordova/platform', () => {
         });
     });
 
-    describe('platform add plugin rm end-to-end', () => {
-
-        it('Test 006 : should remove dependency when removing parent plugin', () => {
-            return Promise.resolve()
-                .then(() => {
-                    return cordova.platform('add', 'ios');
-                })
-                .then(() => {
-                    return cordova.plugin('add', 'cordova-plugin-media');
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    return cordova.platform('add', 'android');
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    return cordova.plugin('rm', 'cordova-plugin-media');
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
-                });
-        });
-    });
-
     describe('platform add and remove --fetch', () => {
 
         it('Test 007 : should add and remove platform from node_modules directory', () => {

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -32,14 +32,14 @@ var pluginsDir = path.join(fixturesDir, 'plugins');
 
 describe('cordova/platform', () => {
 
-    describe('platform end-to-end', function () {
+    describe('platform end-to-end', () => {
 
         var tmpDir = helpers.tmpDir('platform_test');
         var project = path.join(tmpDir, 'project');
 
         var results;
 
-        beforeEach(function () {
+        beforeEach(() => {
             fs.removeSync(tmpDir);
 
             fs.copySync(path.join(fixturesDir, 'base'), project);
@@ -53,7 +53,7 @@ describe('cordova/platform', () => {
 
             // The config.json in the fixture project points at fake "local" paths.
             // Since it's not a URL, the lazy-loader will just return the junk path.
-            spyOn(superspawn, 'spawn').and.callFake(function (cmd, args) {
+            spyOn(superspawn, 'spawn').and.callFake(cmd => {
                 if (cmd.match(/create\b/)) {
                     // This is a call to the bin/create script, so do the copy ourselves.
                     fs.copySync(path.join(fixturesDir, 'platforms/android'), path.join(project, 'platforms/android'));
@@ -65,24 +65,24 @@ describe('cordova/platform', () => {
                 return Q();
             });
 
-            events.on('results', function (res) { results = res; });
+            events.on('results', res => { results = res; });
         });
 
-        afterEach(function () {
+        afterEach(() => {
             process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
             fs.removeSync(tmpDir);
         });
 
         // Factoring out some repeated checks.
         function emptyPlatformList () {
-            return cordova.platform('list').then(function () {
+            return cordova.platform('list').then(() => {
                 var installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
                 expect(installed[1].indexOf(helpers.testPlatform)).toBe(-1);
             });
         }
         function fullPlatformList () {
-            return cordova.platform('list').then(function () {
+            return cordova.platform('list').then(() => {
                 var installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
                 expect(installed[1].indexOf(helpers.testPlatform)).toBeGreaterThan(-1);
@@ -96,34 +96,34 @@ describe('cordova/platform', () => {
         //
         // This test was designed to use a older version of android before API.js
         // It is not valid anymore.
-        xit('Test 001 : should successfully run', function () {
+        xit('Test 001 : should successfully run', () => {
 
             // Check there are no platforms yet.
             return emptyPlatformList()
-                .then(function () {
+                .then(() => {
                     // Add the testing platform.
                     return cordova.platform('add', [helpers.testPlatform]);
                 })
-                .then(function () {
+                .then(() => {
                     // Check the platform add was successful.
                     expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
                     expect(path.join(project, 'platforms', helpers.testPlatform, 'cordova')).toExist();
                 })
                 .then(fullPlatformList) // Check for it in platform ls.
-                .then(function () {
+                .then(() => {
                     // Try to update the platform.
                     return cordova.platform('update', [helpers.testPlatform]);
                 })
-                .then(function () {
+                .then(() => {
                     // Our fake update script in the exec mock above creates this dummy file.
                     expect(path.join(project, 'platforms', helpers.testPlatform, 'updated')).toExist();
                 })
                 .then(fullPlatformList) // Platform should still be in platform ls.
-                .then(function () {
+                .then(() => {
                     // And now remove it.
                     return cordova.platform('rm', [helpers.testPlatform]);
                 })
-                .then(function () {
+                .then(() => {
                     // It should be gone.
                     expect(path.join(project, 'platforms', helpers.testPlatform)).not.toExist();
                 })
@@ -131,12 +131,12 @@ describe('cordova/platform', () => {
 
         });
 
-        xit('Test 002 : should install plugins correctly while adding platform', function () {
+        xit('Test 002 : should install plugins correctly while adding platform', () => {
             return cordova.plugin('add', path.join(pluginsDir, 'test'))
-                .then(function () {
+                .then(() => {
                     return cordova.platform('add', [helpers.testPlatform]);
                 })
-                .then(function () {
+                .then(() => {
                     // Check the platform add was successful.
                     expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
                     // Check that plugin files exists in www dir
@@ -144,149 +144,149 @@ describe('cordova/platform', () => {
                 });
         }, 60000);
 
-        xit('Test 003 : should call prepare after plugins were installed into platform', function () {
+        xit('Test 003 : should call prepare after plugins were installed into platform', () => {
             var order = '';
-            spyOn(plugman, 'install').and.callFake(function () { order += 'I'; });
+            spyOn(plugman, 'install').and.callFake(() => { order += 'I'; });
             // below line won't work since prepare is inline require in addHelper, not global
-            var x = addHelper.__set__('prepare', function () { order += 'P'; }); // eslint-disable-line no-unused-vars
+            var x = addHelper.__set__('prepare', () => { order += 'P'; }); // eslint-disable-line no-unused-vars
             // spyOn(prepare).and.callFake(function() { console.log('prepare'); order += 'P'; });
             return cordova.plugin('add', path.join(pluginsDir, 'test'))
-                .then(function () {
+                .then(() => {
                     return platform('add', [helpers.testPlatform]);
                 })
-                .then(function () {
+                .then(() => {
                     expect(order).toBe('IP'); // Install first, then prepare
                 });
         });
     });
 
-    describe('platform add plugin rm end-to-end', function () {
+    describe('platform add plugin rm end-to-end', () => {
 
         var tmpDir = helpers.tmpDir('plugin_rm_test');
         var project = path.join(tmpDir, 'hello');
         var pluginsDir = path.join(project, 'plugins');
 
-        beforeEach(function () {
+        beforeEach(() => {
             process.chdir(tmpDir);
         });
 
-        afterEach(function () {
+        afterEach(() => {
             process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
             fs.removeSync(tmpDir);
         });
 
-        it('Test 006 : should remove dependency when removing parent plugin', function () {
+        it('Test 006 : should remove dependency when removing parent plugin', () => {
 
             return cordova.create('hello')
-                .then(function () {
+                .then(() => {
                     process.chdir(project);
                     return cordova.platform('add', 'browser@latest');
                 })
-                .then(function () {
+                .then(() => {
                     return cordova.plugin('add', 'cordova-plugin-media');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                     return cordova.platform('add', 'android');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                     return cordova.plugin('rm', 'cordova-plugin-media');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
                 });
         }, 100000);
     });
 
-    describe('platform add and remove --fetch', function () {
+    describe('platform add and remove --fetch', () => {
 
         var tmpDir = helpers.tmpDir('plat_add_remove_fetch_test');
         var project = path.join(tmpDir, 'helloFetch');
         var platformsDir = path.join(project, 'platforms');
         var nodeModulesDir = path.join(project, 'node_modules');
 
-        beforeEach(function () {
+        beforeEach(() => {
             process.chdir(tmpDir);
         });
 
-        afterEach(function () {
+        afterEach(() => {
             process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
             fs.removeSync(tmpDir);
         });
 
-        it('Test 007 : should add and remove platform from node_modules directory', function () {
+        it('Test 007 : should add and remove platform from node_modules directory', () => {
 
             return cordova.create('helloFetch')
-                .then(function () {
+                .then(() => {
                     process.chdir(project);
                     return cordova.platform('add', 'browser', {'save': true});
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
                     expect(path.join(platformsDir, 'browser')).toExist();
                     return cordova.platform('add', 'android');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
                     expect(path.join(platformsDir, 'android')).toExist();
                     // Tests finish before this command finishes resolving
                     // return cordova.platform('rm', 'ios');
                 })
-                .then(function () {
+                .then(() => {
                     // expect(path.join(nodeModulesDir, 'cordova-ios')).not.toExist();
                     // expect(path.join(platformsDir, 'ios')).not.toExist();
                     // Tests finish before this command finishes resolving
                     // return cordova.platform('rm', 'android');
                 })
-                .then(function () {
+                .then(() => {
                     // expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
                     // expect(path.join(platformsDir, 'android')).not.toExist();
                 });
         }, 100000);
     });
 
-    describe('plugin add and rm end-to-end --fetch', function () {
+    describe('plugin add and rm end-to-end --fetch', () => {
 
         var tmpDir = helpers.tmpDir('plugin_rm_fetch_test');
         var project = path.join(tmpDir, 'hello3');
         var pluginsDir = path.join(project, 'plugins');
 
-        beforeEach(function () {
+        beforeEach(() => {
             process.chdir(tmpDir);
         });
 
-        afterEach(function () {
+        afterEach(() => {
             process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
             fs.removeSync(tmpDir);
         });
 
-        it('Test 008 : should remove dependency when removing parent plugin', function () {
+        it('Test 008 : should remove dependency when removing parent plugin', () => {
 
             return cordova.create('hello3')
-                .then(function () {
+                .then(() => {
                     process.chdir(project);
                     return cordova.platform('add', 'browser');
                 })
-                .then(function () {
+                .then(() => {
                     return cordova.plugin('add', 'cordova-plugin-media', {'save': true});
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                     expect(path.join(project, 'node_modules', 'cordova-plugin-media')).toExist();
                     expect(path.join(project, 'node_modules', 'cordova-plugin-file')).toExist();
                     return cordova.platform('add', 'android');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                     return cordova.plugin('rm', 'cordova-plugin-media');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
                     // These don't work yet due to the tests finishing before the promise resolves.
@@ -297,40 +297,40 @@ describe('cordova/platform', () => {
         }, 60000);
     });
 
-    describe('non-core platform add and rm end-to-end --fetch', function () {
+    describe('non-core platform add and rm end-to-end --fetch', () => {
 
         var tmpDir = helpers.tmpDir('non-core-platform-test');
         var project = path.join(tmpDir, 'hello');
         var results;
 
-        beforeEach(function () {
+        beforeEach(() => {
             process.chdir(tmpDir);
-            events.on('results', function (res) { results = res; });
+            events.on('results', res => { results = res; });
         });
 
-        afterEach(function () {
+        afterEach(() => {
             process.chdir(path.join(__dirname, '..')); // Needed to rm the dir on Windows.
             fs.removeSync(tmpDir);
         });
 
-        it('Test 009 : should add and remove 3rd party platforms', function () {
+        it('Test 009 : should add and remove 3rd party platforms', () => {
             var installed;
             return cordova.create('hello')
-                .then(function () {
+                .then(() => {
                     process.chdir(project);
                     // add cordova-android instead of android
                     return cordova.platform('add', 'cordova-android');
                 })
-                .then(function () {
+                .then(() => {
                     // 3rd party platform from npm
                     return cordova.platform('add', 'cordova-platform-test');
                 })
-                .then(function () {
+                .then(() => {
                     expect(path.join(project, 'platforms', 'android')).toExist();
                     expect(path.join(project, 'platforms', 'cordova-platform-test')).toExist();
                     return cordova.platform('ls');
                 })
-                .then(function () {
+                .then(() => {
                     // use regex to grab installed platforms
                     installed = results.match(/Installed platforms:\n {2}(.*)\n {2}(.*)/);
                     expect(installed).toBeDefined();

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -141,7 +141,7 @@ describe('cordova/platform', () => {
         it('Test 006 : should remove dependency when removing parent plugin', () => {
             return Promise.resolve()
                 .then(() => {
-                    return cordova.platform('add', 'browser@latest');
+                    return cordova.platform('add', 'ios');
                 })
                 .then(() => {
                     return cordova.plugin('add', 'cordova-plugin-media');
@@ -197,7 +197,7 @@ describe('cordova/platform', () => {
         it('Test 008 : should remove dependency when removing parent plugin', () => {
             return Promise.resolve()
                 .then(() => {
-                    return cordova.platform('add', 'browser');
+                    return cordova.platform('add', 'ios');
                 })
                 .then(() => {
                     return cordova.plugin('add', 'cordova-plugin-media', {'save': true});

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -181,18 +181,16 @@ describe('cordova/platform', () => {
                 .then(() => {
                     expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
                     expect(path.join(platformsDir, 'android')).toExist();
-                    // Tests finish before this command finishes resolving
-                    // return cordova.platform('rm', 'ios');
+                    return cordova.platform('rm', 'browser');
                 })
                 .then(() => {
-                    // expect(path.join(nodeModulesDir, 'cordova-ios')).not.toExist();
-                    // expect(path.join(platformsDir, 'ios')).not.toExist();
-                    // Tests finish before this command finishes resolving
-                    // return cordova.platform('rm', 'android');
+                    expect(path.join(nodeModulesDir, 'cordova-browser')).not.toExist();
+                    expect(path.join(platformsDir, 'browser')).not.toExist();
+                    return cordova.platform('rm', 'android');
                 })
                 .then(() => {
-                    // expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
-                    // expect(path.join(platformsDir, 'android')).not.toExist();
+                    expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
+                    expect(path.join(platformsDir, 'android')).not.toExist();
                 });
         });
     });

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -31,7 +31,7 @@ describe('cordova/platform', () => {
     const TIMEOUT = 120 * 1000;
     setDefaultTimeout(TIMEOUT);
 
-    let tmpDir, project, pluginsDir, platformsDir, nodeModulesDir;
+    let tmpDir, project, pluginsDir, platformsDir, nodeModulesDir, testPlatformDir;
 
     beforeEach(() => {
         tmpDir = getTmpDir('cordova-platform-e2e-test');
@@ -39,6 +39,7 @@ describe('cordova/platform', () => {
         pluginsDir = path.join(project, 'plugins');
         platformsDir = path.join(project, 'platforms');
         nodeModulesDir = path.join(project, 'node_modules');
+        testPlatformDir = path.join(platformsDir, testPlatform);
         process.chdir(tmpDir);
     });
 
@@ -64,8 +65,8 @@ describe('cordova/platform', () => {
                 })
                 .then(() => {
                     // Check the platform add was successful.
-                    expect(path.join(project, 'platforms', testPlatform)).toExist();
-                    expect(path.join(project, 'platforms', testPlatform, 'cordova')).toExist();
+                    expect(testPlatformDir).toExist();
+                    expect(path.join(testPlatformDir, 'cordova')).toExist();
                     expect(installedPlatforms()).toEqual([testPlatform]);
                 })
                 // .then(() => {
@@ -74,7 +75,7 @@ describe('cordova/platform', () => {
                 // })
                 // .then(() => {
                 //     // Our fake update script in the exec mock above creates this dummy file.
-                //     expect(path.join(project, 'platforms', testPlatform, 'updated')).toExist();
+                //     expect(path.join(testPlatformDir, 'updated')).toExist();
                 //     // Platform should still be in platform ls.
                 //     expect(installedPlatforms()).toEqual([testPlatform]);
                 // })
@@ -84,7 +85,7 @@ describe('cordova/platform', () => {
                 })
                 .then(() => {
                     // It should be gone.
-                    expect(path.join(project, 'platforms', testPlatform)).not.toExist();
+                    expect(testPlatformDir).not.toExist();
                     expect(installedPlatforms()).toEqual([]);
                 });
 
@@ -101,9 +102,9 @@ describe('cordova/platform', () => {
                 })
                 .then(() => {
                     // Check the platform add was successful.
-                    expect(path.join(project, 'platforms', testPlatform)).toExist();
+                    expect(testPlatformDir).toExist();
                     // Check that plugin files exists in www dir
-                    expect(path.join(project, 'platforms', testPlatform, 'platform_www/test.js')).toExist();
+                    expect(path.join(testPlatformDir, 'platform_www/test.js')).toExist();
                 });
         });
 
@@ -211,8 +212,8 @@ describe('cordova/platform', () => {
                 .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    expect(path.join(project, 'node_modules', 'cordova-plugin-media')).toExist();
-                    expect(path.join(project, 'node_modules', 'cordova-plugin-file')).toExist();
+                    expect(path.join(nodeModulesDir, 'cordova-plugin-media')).toExist();
+                    expect(path.join(nodeModulesDir, 'cordova-plugin-file')).toExist();
                     return cordova.platform('add', 'android');
                 })
                 .then(() => {
@@ -224,9 +225,9 @@ describe('cordova/platform', () => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
                     // These don't work yet due to the tests finishing before the promise resolves.
-                    // expect(path.join(project, 'node_modules', 'cordova-plugin-media')).not.toExist();
-                    // expect(path.join(project, 'node_modules', 'cordova-plugin-file')).not.toExist();
-                    // expect(path.join(project, 'node_modules', 'cordova-plugin-compat')).not.toExist();
+                    // expect(path.join(nodeModulesDir, 'cordova-plugin-media')).not.toExist();
+                    // expect(path.join(nodeModulesDir, 'cordova-plugin-file')).not.toExist();
+                    // expect(path.join(nodeModulesDir, 'cordova-plugin-compat')).not.toExist();
                 });
         });
     });
@@ -245,8 +246,8 @@ describe('cordova/platform', () => {
                     return cordova.platform('add', 'cordova-platform-test');
                 })
                 .then(() => {
-                    expect(path.join(project, 'platforms', 'android')).toExist();
-                    expect(path.join(project, 'platforms', 'cordova-platform-test')).toExist();
+                    expect(path.join(platformsDir, 'android')).toExist();
+                    expect(path.join(platformsDir, 'cordova-platform-test')).toExist();
                     expect(installedPlatforms()).toEqual(jasmine.arrayWithExactContents([
                         'android', 'cordova-platform-test'
                     ]));

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -40,9 +40,9 @@ describe('cordova/platform', () => {
         platformsDir = path.join(project, 'platforms');
         nodeModulesDir = path.join(project, 'node_modules');
         testPlatformDir = path.join(platformsDir, testPlatform);
-        process.chdir(tmpDir);
-        return cordova.create(path.basename(project))
-            .then(() => process.chdir(project));
+
+        fs.copySync(path.join(fixturesDir, 'basePkgJson'), project);
+        process.chdir(project);
     });
 
     afterEach(() => {

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -71,16 +71,19 @@ describe('cordova/platform', () => {
                     expect(path.join(testPlatformDir, 'cordova')).toExist();
                     expect(installedPlatforms()).toEqual([testPlatform]);
                 })
-                // .then(() => {
-                //     // Try to update the platform.
-                //     return cordova.platform('update', [testPlatform]);
-                // })
-                // .then(() => {
-                //     // Our fake update script in the exec mock above creates this dummy file.
-                //     expect(path.join(testPlatformDir, 'updated')).toExist();
-                //     // Platform should still be in platform ls.
-                //     expect(installedPlatforms()).toEqual([testPlatform]);
-                // })
+                .then(() => {
+                    // Spy on Api.updatePlatform since it always rejects otherwise
+                    const Api = require(path.join(nodeModulesDir, 'cordova-android'));
+                    spyOn(Api, 'updatePlatform').and.returnValue(Promise.resolve());
+                    spyOn(require('../src/cordova/util'), 'getPlatformApiFunction').and.returnValue(Api);
+
+                    return cordova.platform('update', [testPlatform]).then(_ => Api);
+                })
+                .then(Api => {
+                    expect(Api.updatePlatform).toHaveBeenCalled();
+                    // Platform should still be in platform ls.
+                    expect(installedPlatforms()).toEqual([testPlatform]);
+                })
                 .then(() => {
                     // And now remove it.
                     return cordova.platform('rm', [testPlatform]);

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -15,29 +15,29 @@
     under the License.
 */
 
-var helpers = require('../spec/helpers');
-var path = require('path');
-var fs = require('fs-extra');
-var superspawn = require('cordova-common').superspawn;
-var config = require('../src/cordova/config');
-var Q = require('q');
-var events = require('cordova-common').events;
-var cordova = require('../src/cordova/cordova');
-var rewire = require('rewire');
-var plugman = require('../src/plugman/plugman');
-var platform = rewire('../src/cordova/platform');
-var addHelper = rewire('../src/cordova/platform/addHelper');
-var fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
-var pluginsDir = path.join(fixturesDir, 'plugins');
+const helpers = require('../spec/helpers');
+const path = require('path');
+const fs = require('fs-extra');
+const superspawn = require('cordova-common').superspawn;
+const config = require('../src/cordova/config');
+const Q = require('q');
+const events = require('cordova-common').events;
+const cordova = require('../src/cordova/cordova');
+const rewire = require('rewire');
+const plugman = require('../src/plugman/plugman');
+const platform = rewire('../src/cordova/platform');
+const addHelper = rewire('../src/cordova/platform/addHelper');
+const fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
+const pluginsDir = path.join(fixturesDir, 'plugins');
 
 describe('cordova/platform', () => {
 
     describe('platform end-to-end', () => {
 
-        var tmpDir = helpers.tmpDir('platform_test');
-        var project = path.join(tmpDir, 'project');
+        const tmpDir = helpers.tmpDir('platform_test');
+        const project = path.join(tmpDir, 'project');
 
-        var results;
+        let results;
 
         beforeEach(() => {
             fs.removeSync(tmpDir);
@@ -47,7 +47,7 @@ describe('cordova/platform', () => {
 
             // Now we load the config.json in the newly created project and edit the target platform's lib entry
             // to point at the fixture version. This is necessary so that cordova.prepare can find cordova.js there.
-            var c = config.read(project);
+            const c = config.read(project);
             c.lib[helpers.testPlatform].url = path.join(fixturesDir, 'platforms', helpers.testPlatform + '-lib');
             config.write(project, c);
 
@@ -76,14 +76,14 @@ describe('cordova/platform', () => {
         // Factoring out some repeated checks.
         function emptyPlatformList () {
             return cordova.platform('list').then(() => {
-                var installed = results.match(/Installed platforms:\n {2}(.*)/);
+                const installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
                 expect(installed[1].indexOf(helpers.testPlatform)).toBe(-1);
             });
         }
         function fullPlatformList () {
             return cordova.platform('list').then(() => {
-                var installed = results.match(/Installed platforms:\n {2}(.*)/);
+                const installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
                 expect(installed[1].indexOf(helpers.testPlatform)).toBeGreaterThan(-1);
             });
@@ -145,10 +145,10 @@ describe('cordova/platform', () => {
         }, 60000);
 
         xit('Test 003 : should call prepare after plugins were installed into platform', () => {
-            var order = '';
+            let order = '';
             spyOn(plugman, 'install').and.callFake(() => { order += 'I'; });
             // below line won't work since prepare is inline require in addHelper, not global
-            var x = addHelper.__set__('prepare', () => { order += 'P'; }); // eslint-disable-line no-unused-vars
+            const x = addHelper.__set__('prepare', () => { order += 'P'; }); // eslint-disable-line no-unused-vars
             // spyOn(prepare).and.callFake(function() { console.log('prepare'); order += 'P'; });
             return cordova.plugin('add', path.join(pluginsDir, 'test'))
                 .then(() => {
@@ -162,9 +162,9 @@ describe('cordova/platform', () => {
 
     describe('platform add plugin rm end-to-end', () => {
 
-        var tmpDir = helpers.tmpDir('plugin_rm_test');
-        var project = path.join(tmpDir, 'hello');
-        var pluginsDir = path.join(project, 'plugins');
+        const tmpDir = helpers.tmpDir('plugin_rm_test');
+        const project = path.join(tmpDir, 'hello');
+        const pluginsDir = path.join(project, 'plugins');
 
         beforeEach(() => {
             process.chdir(tmpDir);
@@ -204,10 +204,10 @@ describe('cordova/platform', () => {
 
     describe('platform add and remove --fetch', () => {
 
-        var tmpDir = helpers.tmpDir('plat_add_remove_fetch_test');
-        var project = path.join(tmpDir, 'helloFetch');
-        var platformsDir = path.join(project, 'platforms');
-        var nodeModulesDir = path.join(project, 'node_modules');
+        const tmpDir = helpers.tmpDir('plat_add_remove_fetch_test');
+        const project = path.join(tmpDir, 'helloFetch');
+        const platformsDir = path.join(project, 'platforms');
+        const nodeModulesDir = path.join(project, 'node_modules');
 
         beforeEach(() => {
             process.chdir(tmpDir);
@@ -251,9 +251,9 @@ describe('cordova/platform', () => {
 
     describe('plugin add and rm end-to-end --fetch', () => {
 
-        var tmpDir = helpers.tmpDir('plugin_rm_fetch_test');
-        var project = path.join(tmpDir, 'hello3');
-        var pluginsDir = path.join(project, 'plugins');
+        const tmpDir = helpers.tmpDir('plugin_rm_fetch_test');
+        const project = path.join(tmpDir, 'hello3');
+        const pluginsDir = path.join(project, 'plugins');
 
         beforeEach(() => {
             process.chdir(tmpDir);
@@ -299,9 +299,9 @@ describe('cordova/platform', () => {
 
     describe('non-core platform add and rm end-to-end --fetch', () => {
 
-        var tmpDir = helpers.tmpDir('non-core-platform-test');
-        var project = path.join(tmpDir, 'hello');
-        var results;
+        const tmpDir = helpers.tmpDir('non-core-platform-test');
+        const project = path.join(tmpDir, 'hello');
+        let results;
 
         beforeEach(() => {
             process.chdir(tmpDir);
@@ -314,7 +314,7 @@ describe('cordova/platform', () => {
         });
 
         it('Test 009 : should add and remove 3rd party platforms', () => {
-            var installed;
+            let installed;
             return cordova.create('hello')
                 .then(() => {
                     process.chdir(project);

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -15,18 +15,19 @@
     under the License.
 */
 
-const helpers = require('../spec/helpers');
+const Q = require('q');
 const path = require('path');
 const fs = require('fs-extra');
-const superspawn = require('cordova-common').superspawn;
-const config = require('../src/cordova/config');
-const Q = require('q');
-const events = require('cordova-common').events;
-const cordova = require('../src/cordova/cordova');
 const rewire = require('rewire');
+
+const { events, superspawn } = require('cordova-common');
+const helpers = require('../spec/helpers');
+const config = require('../src/cordova/config');
+const cordova = require('../src/cordova/cordova');
 const plugman = require('../src/plugman/plugman');
 const platform = rewire('../src/cordova/platform');
 const addHelper = rewire('../src/cordova/platform/addHelper');
+
 const fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
 const pluginsDir = path.join(fixturesDir, 'plugins');
 

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -27,7 +27,7 @@ const plugman = require('../src/plugman/plugman');
 const fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
 const pluginFixturesDir = path.join(fixturesDir, 'plugins');
 
-describe('cordova/platform', () => {
+describe('cordova/platform end-to-end', () => {
     const TIMEOUT = 120 * 1000;
     setDefaultTimeout(TIMEOUT);
 
@@ -54,159 +54,147 @@ describe('cordova/platform', () => {
         return listPlatforms(project);
     }
 
-    describe('platform end-to-end', () => {
+    it('Test 001 : should successfully run', () => {
+        // Check there are no platforms yet.
+        expect(installedPlatforms()).toEqual([]);
 
-        it('Test 001 : should successfully run', () => {
-            // Check there are no platforms yet.
-            expect(installedPlatforms()).toEqual([]);
+        return Promise.resolve()
+            .then(() => {
+                // Add the testing platform.
+                return cordova.platform('add', [testPlatform]);
+            })
+            .then(() => {
+                // Check the platform add was successful.
+                expect(testPlatformDir).toExist();
+                expect(path.join(testPlatformDir, 'cordova')).toExist();
+                expect(installedPlatforms()).toEqual([testPlatform]);
+            })
+            .then(() => {
+                // Spy on Api.updatePlatform since it always rejects otherwise
+                const Api = require(path.join(nodeModulesDir, 'cordova-android'));
+                spyOn(Api, 'updatePlatform').and.returnValue(Promise.resolve());
+                spyOn(require('../src/cordova/util'), 'getPlatformApiFunction').and.returnValue(Api);
 
-            return Promise.resolve()
-                .then(() => {
-                    // Add the testing platform.
-                    return cordova.platform('add', [testPlatform]);
-                })
-                .then(() => {
-                    // Check the platform add was successful.
-                    expect(testPlatformDir).toExist();
-                    expect(path.join(testPlatformDir, 'cordova')).toExist();
-                    expect(installedPlatforms()).toEqual([testPlatform]);
-                })
-                .then(() => {
-                    // Spy on Api.updatePlatform since it always rejects otherwise
-                    const Api = require(path.join(nodeModulesDir, 'cordova-android'));
-                    spyOn(Api, 'updatePlatform').and.returnValue(Promise.resolve());
-                    spyOn(require('../src/cordova/util'), 'getPlatformApiFunction').and.returnValue(Api);
+                return cordova.platform('update', [testPlatform]).then(_ => Api);
+            })
+            .then(Api => {
+                expect(Api.updatePlatform).toHaveBeenCalled();
+                // Platform should still be in platform ls.
+                expect(installedPlatforms()).toEqual([testPlatform]);
+            })
+            .then(() => {
+                // And now remove it.
+                return cordova.platform('rm', [testPlatform]);
+            })
+            .then(() => {
+                // It should be gone.
+                expect(testPlatformDir).not.toExist();
+                expect(installedPlatforms()).toEqual([]);
+            });
 
-                    return cordova.platform('update', [testPlatform]).then(_ => Api);
-                })
-                .then(Api => {
-                    expect(Api.updatePlatform).toHaveBeenCalled();
-                    // Platform should still be in platform ls.
-                    expect(installedPlatforms()).toEqual([testPlatform]);
-                })
-                .then(() => {
-                    // And now remove it.
-                    return cordova.platform('rm', [testPlatform]);
-                })
-                .then(() => {
-                    // It should be gone.
-                    expect(testPlatformDir).not.toExist();
-                    expect(installedPlatforms()).toEqual([]);
-                });
-
-        });
-
-        it('Test 002 : should install plugins correctly while adding platform', () => {
-            spyOn(plugman, 'install').and.callThrough();
-            const prepare = require('../src/cordova/prepare');
-            const prepareSpy = jasmine.createSpy('prepare', prepare).and.callThrough();
-            Object.assign(prepareSpy, prepare);
-
-            // This is all just to get the prepareSpy to be used by `platform.add`
-            const platform = rewire('../src/cordova/platform');
-            const addHelper = rewire('../src/cordova/platform/addHelper');
-            const requireFake = jasmine.createSpy('require', addHelper.__get__('require')).and.callThrough();
-            requireFake.withArgs('../prepare').and.returnValue(prepareSpy);
-            addHelper.__set__({ require: requireFake });
-            platform.__set__({ addHelper });
-
-            return Promise.resolve()
-                .then(() => {
-                    return cordova.plugin('add', path.join(pluginFixturesDir, 'test'));
-                })
-                .then(() => {
-                    return platform('add', [testPlatform]);
-                })
-                .then(() => {
-                    // Check the platform add was successful.
-                    expect(testPlatformDir).toExist();
-                    // Check that plugin files exists in www dir
-                    expect(path.join(testPlatformDir, 'platform_www/test.js')).toExist();
-                    // should call prepare after plugins were installed into platform
-                    expect(plugman.install).toHaveBeenCalledBefore(prepareSpy);
-                });
-        });
     });
 
-    describe('platform add and remove --fetch', () => {
+    it('Test 002 : should install plugins correctly while adding platform', () => {
+        spyOn(plugman, 'install').and.callThrough();
+        const prepare = require('../src/cordova/prepare');
+        const prepareSpy = jasmine.createSpy('prepare', prepare).and.callThrough();
+        Object.assign(prepareSpy, prepare);
 
-        it('Test 007 : should add and remove platform from node_modules directory', () => {
-            return Promise.resolve()
-                .then(() => {
-                    return cordova.platform('add', 'browser', {'save': true});
-                })
-                .then(() => {
-                    expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
-                    expect(path.join(platformsDir, 'browser')).toExist();
-                    return cordova.platform('add', 'android');
-                })
-                .then(() => {
-                    expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
-                    expect(path.join(platformsDir, 'android')).toExist();
-                    return cordova.platform('rm', 'browser');
-                })
-                .then(() => {
-                    expect(path.join(nodeModulesDir, 'cordova-browser')).not.toExist();
-                    expect(path.join(platformsDir, 'browser')).not.toExist();
-                    return cordova.platform('rm', 'android');
-                })
-                .then(() => {
-                    expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
-                    expect(path.join(platformsDir, 'android')).not.toExist();
-                });
-        });
+        // This is all just to get the prepareSpy to be used by `platform.add`
+        const platform = rewire('../src/cordova/platform');
+        const addHelper = rewire('../src/cordova/platform/addHelper');
+        const requireFake = jasmine.createSpy('require', addHelper.__get__('require')).and.callThrough();
+        requireFake.withArgs('../prepare').and.returnValue(prepareSpy);
+        addHelper.__set__({ require: requireFake });
+        platform.__set__({ addHelper });
+
+        return Promise.resolve()
+            .then(() => {
+                return cordova.plugin('add', path.join(pluginFixturesDir, 'test'));
+            })
+            .then(() => {
+                return platform('add', [testPlatform]);
+            })
+            .then(() => {
+                // Check the platform add was successful.
+                expect(testPlatformDir).toExist();
+                // Check that plugin files exists in www dir
+                expect(path.join(testPlatformDir, 'platform_www/test.js')).toExist();
+                // should call prepare after plugins were installed into platform
+                expect(plugman.install).toHaveBeenCalledBefore(prepareSpy);
+            });
     });
 
-    describe('plugin add and rm end-to-end --fetch', () => {
-
-        it('Test 008 : should remove dependency when removing parent plugin', () => {
-            return Promise.resolve()
-                .then(() => {
-                    return cordova.platform('add', 'ios');
-                })
-                .then(() => {
-                    return cordova.plugin('add', 'cordova-plugin-media', {save: true});
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    expect(path.join(nodeModulesDir, 'cordova-plugin-media')).toExist();
-                    expect(path.join(nodeModulesDir, 'cordova-plugin-file')).toExist();
-                    return cordova.platform('add', 'android');
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    return cordova.plugin('rm', 'cordova-plugin-media', {save: true});
-                })
-                .then(() => {
-                    expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
-                    expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
-                    expect(path.join(nodeModulesDir, 'cordova-plugin-media')).not.toExist();
-                    expect(path.join(nodeModulesDir, 'cordova-plugin-file')).not.toExist();
-                });
-        });
+    it('Test 007 : should add and remove platform from node_modules directory', () => {
+        return Promise.resolve()
+            .then(() => {
+                return cordova.platform('add', 'browser', {'save': true});
+            })
+            .then(() => {
+                expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
+                expect(path.join(platformsDir, 'browser')).toExist();
+                return cordova.platform('add', 'android');
+            })
+            .then(() => {
+                expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
+                expect(path.join(platformsDir, 'android')).toExist();
+                return cordova.platform('rm', 'browser');
+            })
+            .then(() => {
+                expect(path.join(nodeModulesDir, 'cordova-browser')).not.toExist();
+                expect(path.join(platformsDir, 'browser')).not.toExist();
+                return cordova.platform('rm', 'android');
+            })
+            .then(() => {
+                expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
+                expect(path.join(platformsDir, 'android')).not.toExist();
+            });
     });
 
-    describe('non-core platform add and rm end-to-end --fetch', () => {
+    it('Test 008 : should remove dependency when removing parent plugin', () => {
+        return Promise.resolve()
+            .then(() => {
+                return cordova.platform('add', 'ios');
+            })
+            .then(() => {
+                return cordova.plugin('add', 'cordova-plugin-media', {save: true});
+            })
+            .then(() => {
+                expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
+                expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
+                expect(path.join(nodeModulesDir, 'cordova-plugin-media')).toExist();
+                expect(path.join(nodeModulesDir, 'cordova-plugin-file')).toExist();
+                return cordova.platform('add', 'android');
+            })
+            .then(() => {
+                expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
+                expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
+                return cordova.plugin('rm', 'cordova-plugin-media', {save: true});
+            })
+            .then(() => {
+                expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
+                expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
+                expect(path.join(nodeModulesDir, 'cordova-plugin-media')).not.toExist();
+                expect(path.join(nodeModulesDir, 'cordova-plugin-file')).not.toExist();
+            });
+    });
 
-        it('Test 009 : should add and remove 3rd party platforms', () => {
-            return Promise.resolve()
-                .then(() => {
-                    // add cordova-android instead of android
-                    return cordova.platform('add', 'cordova-android');
-                })
-                .then(() => {
-                    // 3rd party platform from npm
-                    return cordova.platform('add', 'cordova-platform-test');
-                })
-                .then(() => {
-                    expect(path.join(platformsDir, 'android')).toExist();
-                    expect(path.join(platformsDir, 'cordova-platform-test')).toExist();
-                    expect(installedPlatforms()).toEqual(jasmine.arrayWithExactContents([
-                        'android', 'cordova-platform-test'
-                    ]));
-                });
-        });
+    it('Test 009 : should add and remove 3rd party platforms', () => {
+        return Promise.resolve()
+            .then(() => {
+                // add cordova-android instead of android
+                return cordova.platform('add', 'cordova-android');
+            })
+            .then(() => {
+                // 3rd party platform from npm
+                return cordova.platform('add', 'cordova-platform-test');
+            })
+            .then(() => {
+                expect(path.join(platformsDir, 'android')).toExist();
+                expect(path.join(platformsDir, 'cordova-platform-test')).toExist();
+                expect(installedPlatforms()).toEqual(jasmine.arrayWithExactContents([
+                    'android', 'cordova-platform-test'
+                ]));
+            });
     });
 });

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -21,7 +21,7 @@ const fs = require('fs-extra');
 const rewire = require('rewire');
 
 const { events, superspawn } = require('cordova-common');
-const helpers = require('../spec/helpers');
+const { tmpDir: getTmpDir, testPlatform } = require('../spec/helpers');
 const config = require('../src/cordova/config');
 const cordova = require('../src/cordova/cordova');
 const plugman = require('../src/plugman/plugman');
@@ -35,7 +35,7 @@ describe('cordova/platform', () => {
 
     describe('platform end-to-end', () => {
 
-        const tmpDir = helpers.tmpDir('platform_test');
+        const tmpDir = getTmpDir('platform_test');
         const project = path.join(tmpDir, 'project');
 
         let results;
@@ -49,7 +49,7 @@ describe('cordova/platform', () => {
             // Now we load the config.json in the newly created project and edit the target platform's lib entry
             // to point at the fixture version. This is necessary so that cordova.prepare can find cordova.js there.
             const c = config.read(project);
-            c.lib[helpers.testPlatform].url = path.join(fixturesDir, 'platforms', helpers.testPlatform + '-lib');
+            c.lib[testPlatform].url = path.join(fixturesDir, 'platforms', testPlatform + '-lib');
             config.write(project, c);
 
             // The config.json in the fixture project points at fake "local" paths.
@@ -61,7 +61,7 @@ describe('cordova/platform', () => {
                 } else if (cmd.match(/version\b/)) {
                     return Q('3.3.0');
                 } else if (cmd.match(/update\b/)) {
-                    fs.writeFileSync(path.join(project, 'platforms', helpers.testPlatform, 'updated'), 'I was updated!', 'utf-8');
+                    fs.writeFileSync(path.join(project, 'platforms', testPlatform, 'updated'), 'I was updated!', 'utf-8');
                 }
                 return Q();
             });
@@ -79,14 +79,14 @@ describe('cordova/platform', () => {
             return cordova.platform('list').then(() => {
                 const installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
-                expect(installed[1].indexOf(helpers.testPlatform)).toBe(-1);
+                expect(installed[1].indexOf(testPlatform)).toBe(-1);
             });
         }
         function fullPlatformList () {
             return cordova.platform('list').then(() => {
                 const installed = results.match(/Installed platforms:\n {2}(.*)/);
                 expect(installed).toBeDefined();
-                expect(installed[1].indexOf(helpers.testPlatform)).toBeGreaterThan(-1);
+                expect(installed[1].indexOf(testPlatform)).toBeGreaterThan(-1);
             });
         }
 
@@ -103,30 +103,30 @@ describe('cordova/platform', () => {
             return emptyPlatformList()
                 .then(() => {
                     // Add the testing platform.
-                    return cordova.platform('add', [helpers.testPlatform]);
+                    return cordova.platform('add', [testPlatform]);
                 })
                 .then(() => {
                     // Check the platform add was successful.
-                    expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
-                    expect(path.join(project, 'platforms', helpers.testPlatform, 'cordova')).toExist();
+                    expect(path.join(project, 'platforms', testPlatform)).toExist();
+                    expect(path.join(project, 'platforms', testPlatform, 'cordova')).toExist();
                 })
                 .then(fullPlatformList) // Check for it in platform ls.
                 .then(() => {
                     // Try to update the platform.
-                    return cordova.platform('update', [helpers.testPlatform]);
+                    return cordova.platform('update', [testPlatform]);
                 })
                 .then(() => {
                     // Our fake update script in the exec mock above creates this dummy file.
-                    expect(path.join(project, 'platforms', helpers.testPlatform, 'updated')).toExist();
+                    expect(path.join(project, 'platforms', testPlatform, 'updated')).toExist();
                 })
                 .then(fullPlatformList) // Platform should still be in platform ls.
                 .then(() => {
                     // And now remove it.
-                    return cordova.platform('rm', [helpers.testPlatform]);
+                    return cordova.platform('rm', [testPlatform]);
                 })
                 .then(() => {
                     // It should be gone.
-                    expect(path.join(project, 'platforms', helpers.testPlatform)).not.toExist();
+                    expect(path.join(project, 'platforms', testPlatform)).not.toExist();
                 })
                 .then(emptyPlatformList); // platform ls should be empty too.;
 
@@ -135,13 +135,13 @@ describe('cordova/platform', () => {
         xit('Test 002 : should install plugins correctly while adding platform', () => {
             return cordova.plugin('add', path.join(pluginsDir, 'test'))
                 .then(() => {
-                    return cordova.platform('add', [helpers.testPlatform]);
+                    return cordova.platform('add', [testPlatform]);
                 })
                 .then(() => {
                     // Check the platform add was successful.
-                    expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
+                    expect(path.join(project, 'platforms', testPlatform)).toExist();
                     // Check that plugin files exists in www dir
-                    expect(path.join(project, 'platforms', helpers.testPlatform, 'assets/www/test.js')).toExist();
+                    expect(path.join(project, 'platforms', testPlatform, 'assets/www/test.js')).toExist();
                 });
         }, 60000);
 
@@ -153,7 +153,7 @@ describe('cordova/platform', () => {
             // spyOn(prepare).and.callFake(function() { console.log('prepare'); order += 'P'; });
             return cordova.plugin('add', path.join(pluginsDir, 'test'))
                 .then(() => {
-                    return platform('add', [helpers.testPlatform]);
+                    return platform('add', [testPlatform]);
                 })
                 .then(() => {
                     expect(order).toBe('IP'); // Install first, then prepare
@@ -163,7 +163,7 @@ describe('cordova/platform', () => {
 
     describe('platform add plugin rm end-to-end', () => {
 
-        const tmpDir = helpers.tmpDir('plugin_rm_test');
+        const tmpDir = getTmpDir('plugin_rm_test');
         const project = path.join(tmpDir, 'hello');
         const pluginsDir = path.join(project, 'plugins');
 
@@ -205,7 +205,7 @@ describe('cordova/platform', () => {
 
     describe('platform add and remove --fetch', () => {
 
-        const tmpDir = helpers.tmpDir('plat_add_remove_fetch_test');
+        const tmpDir = getTmpDir('plat_add_remove_fetch_test');
         const project = path.join(tmpDir, 'helloFetch');
         const platformsDir = path.join(project, 'platforms');
         const nodeModulesDir = path.join(project, 'node_modules');
@@ -252,7 +252,7 @@ describe('cordova/platform', () => {
 
     describe('plugin add and rm end-to-end --fetch', () => {
 
-        const tmpDir = helpers.tmpDir('plugin_rm_fetch_test');
+        const tmpDir = getTmpDir('plugin_rm_fetch_test');
         const project = path.join(tmpDir, 'hello3');
         const pluginsDir = path.join(project, 'plugins');
 
@@ -300,7 +300,7 @@ describe('cordova/platform', () => {
 
     describe('non-core platform add and rm end-to-end --fetch', () => {
 
-        const tmpDir = helpers.tmpDir('non-core-platform-test');
+        const tmpDir = getTmpDir('non-core-platform-test');
         const project = path.join(tmpDir, 'hello');
         let results;
 

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -21,7 +21,7 @@ const fs = require('fs-extra');
 const rewire = require('rewire');
 
 const { superspawn } = require('cordova-common');
-const { tmpDir: getTmpDir, testPlatform } = require('../spec/helpers');
+const { tmpDir: getTmpDir, testPlatform, setDefaultTimeout } = require('../spec/helpers');
 const { listPlatforms } = require('../src/cordova/util');
 const config = require('../src/cordova/config');
 const cordova = require('../src/cordova/cordova');
@@ -33,6 +33,9 @@ const fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
 const pluginFixturesDir = path.join(fixturesDir, 'plugins');
 
 describe('cordova/platform', () => {
+    const TIMEOUT = 120 * 1000;
+    setDefaultTimeout(TIMEOUT);
+
     let tmpDir, project, pluginsDir, platformsDir, nodeModulesDir;
 
     beforeEach(() => {
@@ -136,7 +139,7 @@ describe('cordova/platform', () => {
                     // Check that plugin files exists in www dir
                     expect(path.join(project, 'platforms', testPlatform, 'assets/www/test.js')).toExist();
                 });
-        }, 60000);
+        });
 
         xit('Test 003 : should call prepare after plugins were installed into platform', () => {
             let order = '';
@@ -179,7 +182,7 @@ describe('cordova/platform', () => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
                 });
-        }, 100000);
+        });
     });
 
     describe('platform add and remove --fetch', () => {
@@ -212,7 +215,7 @@ describe('cordova/platform', () => {
                     // expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
                     // expect(path.join(platformsDir, 'android')).not.toExist();
                 });
-        }, 100000);
+        });
     });
 
     describe('plugin add and rm end-to-end --fetch', () => {
@@ -247,7 +250,7 @@ describe('cordova/platform', () => {
                     // expect(path.join(project, 'node_modules', 'cordova-plugin-file')).not.toExist();
                     // expect(path.join(project, 'node_modules', 'cordova-plugin-compat')).not.toExist();
                 });
-        }, 60000);
+        });
     });
 
     describe('non-core platform add and rm end-to-end --fetch', () => {
@@ -270,6 +273,6 @@ describe('cordova/platform', () => {
                         'android', 'cordova-platform-test'
                     ]));
                 });
-        }, 90000);
+        });
     });
 });

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -94,25 +94,10 @@ describe('cordova/platform', () => {
         });
 
         it('Test 002 : should install plugins correctly while adding platform', () => {
-            return Promise.resolve()
-                .then(() => {
-                    return cordova.plugin('add', path.join(pluginFixturesDir, 'test'));
-                })
-                .then(() => {
-                    return cordova.platform('add', [testPlatform]);
-                })
-                .then(() => {
-                    // Check the platform add was successful.
-                    expect(testPlatformDir).toExist();
-                    // Check that plugin files exists in www dir
-                    expect(path.join(testPlatformDir, 'platform_www/test.js')).toExist();
-                });
-        });
-
-        it('Test 003 : should call prepare after plugins were installed into platform', () => {
-            spyOn(plugman, 'install').and.returnValue(Promise.resolve());
-            const prepareSpy = jasmine.createSpy('prepare').and.returnValue(Promise.resolve());
-            prepareSpy.preparePlatforms = jasmine.createSpy('preparePlatforms').and.returnValue(Promise.resolve());
+            spyOn(plugman, 'install').and.callThrough();
+            const prepare = require('../src/cordova/prepare');
+            const prepareSpy = jasmine.createSpy('prepare', prepare).and.callThrough();
+            Object.assign(prepareSpy, prepare);
 
             // This is all just to get the prepareSpy to be used by `platform.add`
             const platform = rewire('../src/cordova/platform');
@@ -130,7 +115,11 @@ describe('cordova/platform', () => {
                     return platform('add', [testPlatform]);
                 })
                 .then(() => {
-                    // Install first, then prepare
+                    // Check the platform add was successful.
+                    expect(testPlatformDir).toExist();
+                    // Check that plugin files exists in www dir
+                    expect(path.join(testPlatformDir, 'platform_www/test.js')).toExist();
+                    // should call prepare after plugins were installed into platform
                     expect(plugman.install).toHaveBeenCalledBefore(prepareSpy);
                 });
         });

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -192,7 +192,7 @@ describe('cordova/platform', () => {
                     return cordova.platform('add', 'ios');
                 })
                 .then(() => {
-                    return cordova.plugin('add', 'cordova-plugin-media', {'save': true});
+                    return cordova.plugin('add', 'cordova-plugin-media', {save: true});
                 })
                 .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
@@ -204,15 +204,13 @@ describe('cordova/platform', () => {
                 .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
-                    return cordova.plugin('rm', 'cordova-plugin-media');
+                    return cordova.plugin('rm', 'cordova-plugin-media', {save: true});
                 })
                 .then(() => {
                     expect(path.join(pluginsDir, 'cordova-plugin-media')).not.toExist();
                     expect(path.join(pluginsDir, 'cordova-plugin-file')).not.toExist();
-                    // These don't work yet due to the tests finishing before the promise resolves.
-                    // expect(path.join(nodeModulesDir, 'cordova-plugin-media')).not.toExist();
-                    // expect(path.join(nodeModulesDir, 'cordova-plugin-file')).not.toExist();
-                    // expect(path.join(nodeModulesDir, 'cordova-plugin-compat')).not.toExist();
+                    expect(path.join(nodeModulesDir, 'cordova-plugin-media')).not.toExist();
+                    expect(path.join(nodeModulesDir, 'cordova-plugin-file')).not.toExist();
                 });
         });
     });

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -154,7 +154,7 @@ describe('cordova/platform end-to-end', () => {
     it('Test 008 : should remove dependency when removing parent plugin', () => {
         return Promise.resolve()
             .then(() => {
-                return cordova.platform('add', 'ios');
+                return cordova.platform('add', testPlatform);
             })
             .then(() => {
                 return cordova.plugin('add', 'cordova-plugin-media', {save: true});
@@ -164,11 +164,6 @@ describe('cordova/platform end-to-end', () => {
                 expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                 expect(path.join(nodeModulesDir, 'cordova-plugin-media')).toExist();
                 expect(path.join(nodeModulesDir, 'cordova-plugin-file')).toExist();
-                return cordova.platform('add', 'android');
-            })
-            .then(() => {
-                expect(path.join(pluginsDir, 'cordova-plugin-media')).toExist();
-                expect(path.join(pluginsDir, 'cordova-plugin-file')).toExist();
                 return cordova.plugin('rm', 'cordova-plugin-media', {save: true});
             })
             .then(() => {

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -99,28 +99,36 @@ describe('cordova/platform', () => {
         xit('Test 001 : should successfully run', function () {
 
             // Check there are no platforms yet.
-            return emptyPlatformList().then(function () {
-                // Add the testing platform.
-                return cordova.platform('add', [helpers.testPlatform]);
-            }).then(function () {
-                // Check the platform add was successful.
-                expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
-                expect(path.join(project, 'platforms', helpers.testPlatform, 'cordova')).toExist();
-            }).then(fullPlatformList) // Check for it in platform ls.
+            return emptyPlatformList()
+                .then(function () {
+                    // Add the testing platform.
+                    return cordova.platform('add', [helpers.testPlatform]);
+                })
+                .then(function () {
+                    // Check the platform add was successful.
+                    expect(path.join(project, 'platforms', helpers.testPlatform)).toExist();
+                    expect(path.join(project, 'platforms', helpers.testPlatform, 'cordova')).toExist();
+                })
+                .then(fullPlatformList) // Check for it in platform ls.
                 .then(function () {
                     // Try to update the platform.
                     return cordova.platform('update', [helpers.testPlatform]);
-                }).then(function () {
+                })
+                .then(function () {
                     // Our fake update script in the exec mock above creates this dummy file.
                     expect(path.join(project, 'platforms', helpers.testPlatform, 'updated')).toExist();
-                }).then(fullPlatformList) // Platform should still be in platform ls.
+                })
+                .then(fullPlatformList) // Platform should still be in platform ls.
                 .then(function () {
                     // And now remove it.
                     return cordova.platform('rm', [helpers.testPlatform]);
-                }).then(function () {
+                })
+                .then(function () {
                     // It should be gone.
                     expect(path.join(project, 'platforms', helpers.testPlatform)).not.toExist();
-                }).then(emptyPlatformList); // platform ls should be empty too.;
+                })
+                .then(emptyPlatformList); // platform ls should be empty too.;
+
         });
 
         xit('Test 002 : should install plugins correctly while adding platform', function () {
@@ -312,10 +320,12 @@ describe('cordova/platform', () => {
                     process.chdir(project);
                     // add cordova-android instead of android
                     return cordova.platform('add', 'cordova-android');
-                }).then(function () {
+                })
+                .then(function () {
                     // 3rd party platform from npm
                     return cordova.platform('add', 'cordova-platform-test');
-                }).then(function () {
+                })
+                .then(function () {
                     expect(path.join(project, 'platforms', 'android')).toExist();
                     expect(path.join(project, 'platforms', 'cordova-platform-test')).toExist();
                     return cordova.platform('ls');


### PR DESCRIPTION
Another episode in the series Spec Cleanup.

### Highlights
- Re-enable some tests
- Remove some tests for being duplicates after recent refactors
- Slightly reduced overall runtime
- Uniform, increased timeouts to address CI-3 of #642