### PR TITLE
Remove unused dependency properties-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "indent-string": "^3.2.0",
     "init-package-json": "^1.2.0",
     "nopt": "4.0.1",
-    "properties-parser": "0.3.1",
     "q": "^1.5.1",
     "read-chunk": "^3.0.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
Was not found earlier, since it is "used" in our test fixtures.