### PR TITLE
CB-14166 distinguish npm.cmd and npm.exe in win32, to check if escape is necessary (workaround solution)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "read-chunk": "^3.0.0",
     "semver": "^5.3.0",
     "shebang-command": "^1.2.0",
-    "underscore": "^1.9.0"
+    "underscore": "^1.9.0",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "codecov": "^3.0.1",

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -18,6 +18,7 @@
 */
 
 var fs = require('fs-extra');
+var which = require('which');
 var url = require('url');
 var underscore = require('underscore');
 var semver = require('semver');
@@ -136,10 +137,13 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                 }
 
                 if (process.platform === 'win32' && parsedSpec.version) {
-                    var windowsShellSpecialCharacters = ['&', '\\', '<', '>', '^', '|'];
-                    specContainsSpecialCharacters = windowsShellSpecialCharacters.some(function (character) {
-                        return parsedSpec.version.indexOf(character);
-                    });
+                    var npmExtension = path.extname(which.sync('npm'));
+                    if (npmExtension && npmExtension.toUpperCase() !== '.EXE') {
+                        var windowsShellSpecialCharacters = ['&', '\\', '<', '>', '^', '|'];
+                        specContainsSpecialCharacters = windowsShellSpecialCharacters.some(function (character) {
+                            return parsedSpec.version.indexOf(character) >= 0;
+                        });
+                    }
                 }
 
                 var fetchPluginSrc = specContainsSpecialCharacters ?


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all platforms in windows. 
(Especially the nodist is used as managing node versions.)

### What does this PR do?
This PR is based on the PR https://github.com/apache/cordova-lib/pull/622 .

When cordova executes npm command in windows, escaping arguments should be necessary.
However, this necessity depends on the type of npm command according to windows feature.
i.e.
npm.cmd   => escaping is necessary
npm.exe     => escaping is not necessary (escaping brings an error)

As discussions in https://issues.apache.org/jira/projects/CB/issues/CB-14166,
nvm-windows => only npm.cmd is installed and cordova uses npm.cmd
nodist => both npm.cmd and npm.exe are installed and cordova uses npm.exe

Therefore this PR adding function which checks the extension of npm command and skip escaping function if the extension is '.exe'.

And I improved escaping function itself from
```
parsedSpec.version.indexOf(character);
```
to
```
parsedSpec.version.indexOf(character) >= 0;
```
because the former return -1 (logically true) even if the `version` does not contain `character`.
The latter return true if and only if the `version` contains `character`;

### What testing has been done on this change?
In my windows 10, cordova 8.0.0 and Nodist environment (where npm.cmd and npm.exe are installed, cordova uses npm.exe automatically in superspawn.js), I checked by following commands,
```
> cordova create CB-14116-8
> cd CB-14116-8
> codova platform add windows@5.0.0
```
and confirm it works.
Before this PR, the above commands brings following error in Nodist environment.

```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name ""1"": Tags may not have any characters that encodeURIComponent encodes.
```


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
