### PR TITLE
[WIP] 8.1.x TEST WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "cordova-lib",
   "license": "Apache-2.0",
   "description": "Apache Cordova tools core lib and API",
-  "version": "8.0.0",
+  "version": "8.1.0-dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/apache/cordova-lib"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "plist": "2.0.1",
     "properties-parser": "0.3.1",
     "q": "1.0.1",
-    "request": "2.79.0",
     "semver": "^5.3.0",
     "shelljs": "0.3.0",
     "tar": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "xcode": "^1.0.0"
   },
   "devDependencies": {
-    "codecov": "^2.1.0",
+    "codecov": "^3.1.0",
     "eslint": "^4.2.0",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -313,7 +313,7 @@ describe('util module', function () {
         describe('getPlatformApiFunction', function () {
             it('Test 027 : should throw error informing user to update platform', function () {
                 expect(function () { util.getPlatformApiFunction('some/path', 'android'); }).toThrowError(
-                    /(Uncaught, unspecified|Unhandled) "error" event. \( Using this version of Cordova with older version of cordova-android is deprecated\. Upgrade to cordova-android@5\.0\.0 or newer.\)/
+                    /\( Using this version of Cordova with older version of cordova-android is deprecated\. Upgrade to cordova-android@5\.0\.0 or newer.\)/
                 );
             });
 

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -29,7 +29,7 @@
     "windows": {
         "hostos": ["win32"],
         "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-windows.git",
-        "version": "~5.0.0",
+        "version": "~6.0.0",
         "apiCompatibleSince": "4.3.0",
         "deprecated": false
     },


### PR DESCRIPTION
I am working on minor version 8.1.0, to be in new 8.1.x branch based on 8.0.x to accomplish the following:
- resolve npm audit issues
- use cordova-windows@6.0.x by default (GH-691)

This PR is currently expected to fail Travis CI/AppVeyor CI due to some issues with HooksRunner tests that were solved in master branch (GH-623).