### PR TITLE
CB-14166 distinguish npm.cmd and npm.exe in win32, to check if escape is necessary (workaround solution in 8.1.x only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "shebang-command": "^1.2.0",
     "shelljs": "0.3.0",
     "tar": "^4.4.1",
-    "underscore": "^1.9.0"
+    "underscore": "^1.9.0",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "codecov": "^3.0.1",

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -19,6 +19,7 @@
 
 var shell = require('shelljs');
 var fs = require('fs');
+var which = require('which');
 var url = require('url');
 var underscore = require('underscore');
 var semver = require('semver');
@@ -137,10 +138,13 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                 }
 
                 if (process.platform === 'win32' && parsedSpec.version) {
-                    var windowsShellSpecialCharacters = ['&', '\\', '<', '>', '^', '|'];
-                    specContainsSpecialCharacters = windowsShellSpecialCharacters.some(function (character) {
-                        return parsedSpec.version.indexOf(character);
-                    });
+                    var npmExtension = path.extname(which.sync('npm'));
+                    if (npmExtension && npmExtension.toUpperCase() !== '.EXE') {
+                        var windowsShellSpecialCharacters = ['&', '\\', '<', '>', '^', '|'];
+                        specContainsSpecialCharacters = windowsShellSpecialCharacters.some(function (character) {
+                            return parsedSpec.version.indexOf(character) >= 0;
+                        });
+                    }
                 }
 
                 var fetchPluginSrc = specContainsSpecialCharacters ?


### PR DESCRIPTION
Cherry-pick of #688 for 8.1.0 as discussed _and agreed_ in [[1]](https://lists.apache.org/thread.html/23b1a44a35b0bf58792ab2820230dac4236bdcab90573127bf7e91c6@%3Cdev.cordova.apache.org%3E)

[1] <https://lists.apache.org/thread.html/23b1a44a35b0bf58792ab2820230dac4236bdcab90573127bf7e91c6@%3Cdev.cordova.apache.org%3E>