### PR TITLE
Increase timeout for cordova.platform e2e tests

### DIFF
--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -28,7 +28,7 @@ const fixturesDir = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
 const pluginFixturesDir = path.join(fixturesDir, 'plugins');
 
 describe('cordova/platform end-to-end', () => {
-    const TIMEOUT = 120 * 1000;
+    const TIMEOUT = 240 * 1000;
     setDefaultTimeout(TIMEOUT);
 
     let tmpDir, project, pluginsDir, platformsDir, nodeModulesDir, testPlatformDir;


### PR DESCRIPTION
Due to local test timeout of test 009. Part of #642