### PR TITLE
Ensure local dependencies are properly copied on Windows

### DIFF
--- a/integration-tests/plugman_fetch.spec.js
+++ b/integration-tests/plugman_fetch.spec.js
@@ -85,12 +85,12 @@ describe('fetch', function () {
 
         it('Test 001 : should copy locally-available plugin to plugins directory', function () {
             return fetch(test_plugin, temp).then(function () {
-                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_plugin), path.join(temp, test_plugin_id));
+                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_plugin), path.join(temp, test_plugin_id), jasmine.objectContaining({dereference: true}));
             });
         });
         it('Test 002 : should copy locally-available plugin to plugins directory when adding a plugin with searchpath argument', function () {
             return fetch(test_plugin_id, temp, { searchpath: test_plugin_searchpath }).then(function () {
-                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_plugin), path.join(temp, test_plugin_id));
+                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_plugin), path.join(temp, test_plugin_id), jasmine.objectContaining({dereference: true}));
             });
         });
         it('Test 003 : should create a symlink if used with `link` param', function () {
@@ -129,7 +129,7 @@ describe('fetch', function () {
         });
         it('Test 027 : should copy locally-available plugin to plugins directory', function () {
             return fetch(test_pkgjson_plugin, temp).then(function () {
-                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_pkgjson_plugin), path.join(temp, 'pkgjson-test-plugin'));
+                expect(fs.copySync).toHaveBeenCalledWith(path.join(test_pkgjson_plugin), path.join(temp, 'pkgjson-test-plugin'), jasmine.objectContaining({dereference: true}));
                 expect(fetchCalls).toBe(1);
             });
         });

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -289,7 +289,7 @@ function copyPlugin (pinfo, plugins_dir, link) {
         fs.symlinkSync(fixedPath, dest, 'junction');
     } else {
         events.emit('verbose', 'Copying plugin "' + plugin_dir + '" => "' + dest + '"');
-        fs.copySync(plugin_dir, dest);
+        fs.copySync(plugin_dir, dest, {dereference: true});
     }
     return dest;
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Ensures that dependencies are properly copied when the source is a symlink/junction.

### What testing has been done on this change?
E2E test suite has been run and now finally passes on Windows.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
