### PR TITLE
GH-706 dependency patch fix for 8.x only

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "shelljs": "0.3.0",
     "tar": "^4.4.1",
     "underscore": "^1.9.0",
-    "which": "^1.3.1"
+    "which": "^1.3.1",
+    "xcode": "^1.0.0"
   },
   "devDependencies": {
     "codecov": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "properties-parser": "0.3.1",
     "q": "^1.5.1",
     "read-chunk": "^2.1.0",
+    "request": "^2.88.0",
     "semver": "^5.3.0",
     "shebang-command": "^1.2.0",
     "shelljs": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cordova-js": "^4.2.2",
     "cordova-serve": "^2.0.0",
     "dep-graph": "1.1.0",
+    "dependency-ls": "^1.1.1",
     "detect-indent": "^5.0.0",
     "elementtree": "^0.1.7",
     "glob": "^7.1.2",
@@ -40,6 +41,8 @@
     "shelljs": "0.3.0",
     "tar": "^4.4.1",
     "underscore": "^1.9.0",
+    "unorm": "^1.4.1",
+    "valid-identifier": "0.0.1",
     "which": "^1.3.1",
     "xcode": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "semver": "^5.3.0",
     "shebang-command": "^1.2.0",
     "shelljs": "0.3.0",
-    "tar": "^4.4.1",
+    "tar": "^2.2.1",
     "underscore": "^1.9.0",
     "unorm": "^1.4.1",
     "valid-identifier": "0.0.1",

--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -17,6 +17,8 @@
     under the License.
 */
 
+'use strict';
+
 const rewire = require('rewire');
 const events = require('cordova-common').events;
 

--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -1,0 +1,95 @@
+/*!
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const rewire = require('rewire');
+const events = require('cordova-common').events;
+
+describe('hooks/Context', () => {
+    let Context;
+
+    beforeEach(() => {
+        Context = rewire('../../src/hooks/Context');
+    });
+
+    describe('requireCordovaModule', () => {
+        let warnSpy, requireCordovaModule;
+
+        beforeEach(() => {
+            requireCordovaModule = Context.prototype.requireCordovaModule;
+            warnSpy = jasmine.createSpy('warnSpy');
+            events.on('warn', warnSpy);
+        });
+
+        afterEach(() => {
+            events.removeListener('warn', warnSpy);
+        });
+
+        it('correctly resolves cordova-* dependencies', () => {
+            const cordovaCommon = require('cordova-common');
+            expect(requireCordovaModule('cordova-common')).toBe(cordovaCommon);
+        });
+
+        it('correctly resolves inner modules of cordova-* dependencies', () => {
+            const MODULE = 'cordova-common/src/events';
+            expect(requireCordovaModule(MODULE)).toBe(require(MODULE));
+        });
+
+        it('correctly resolves cordova-lib', () => {
+            const cordovaLib = require('../..');
+            expect(requireCordovaModule('cordova-lib')).toBe(cordovaLib);
+        });
+
+        it('correctly resolves inner modules of cordova-lib', () => {
+            const platforms = require('../../src/platforms/platforms');
+            expect(requireCordovaModule('cordova-lib/src/platforms/platforms')).toBe(platforms);
+        });
+
+        it('correctly resolves inner modules of cordova-lib', () => {
+            const platforms = require('../../src/platforms/platforms');
+            expect(requireCordovaModule('cordova-lib/src/platforms/platforms')).toBe(platforms);
+        });
+
+        describe('with stubbed require', () => {
+            let requireSpy;
+
+            beforeEach(() => {
+                requireSpy = jasmine.createSpy('require');
+                Context.__set__({ require: requireSpy });
+            });
+
+            it('maps some old paths to their new equivalent', () => {
+                const ConfigParser = Symbol('ConfigParser');
+                const xmlHelpers = Symbol('xmlHelpers');
+                requireSpy.and.returnValue({ ConfigParser, xmlHelpers });
+
+                expect(requireCordovaModule('cordova-lib/src/configparser/ConfigParser')).toBe(ConfigParser);
+                expect(requireCordovaModule('cordova-lib/src/util/xml-helpers')).toBe(xmlHelpers);
+                expect(requireSpy.calls.allArgs()).toEqual([
+                    ['cordova-common'], ['cordova-common']
+                ]);
+            });
+
+            it('correctly handles module names that start with "cordova-lib"', () => {
+                requireCordovaModule('cordova-libre');
+                expect(requireSpy).toHaveBeenCalledWith('cordova-libre');
+            });
+        });
+
+    });
+});

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -17,6 +17,8 @@
  under the License.
  */
 
+'use strict';
+
 var path = require('path');
 var events = require('cordova-common').events;
 

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -54,19 +54,24 @@ var compatMap = {
 };
 
 /**
- * Returns a required module
- * @param {String} modulePath Module path
- * @returns {Object} */
+ * Requires the specified Cordova module.
+ *
+ * This method should only be used to require packages named `cordova-*`.
+ * Public modules of such a Cordova module can be required by giving their
+ * full package path: `cordova-foo/bar` for example.
+ *
+ * @param {String} modulePath   Module path as specified above
+ * @returns {*}                 The required Cordova module
+ */
 Context.prototype.requireCordovaModule = function (modulePath) {
     const pkg = modulePath.split('/')[0];
 
     if (pkg !== 'cordova-lib') return require(modulePath);
 
-    // There is a very common mistake, when hook requires some cordova functionality
-    // using 'cordova-lib/...' path.
-    // This path will be resolved only when running cordova from 'normal' installation
-    // (without symlinked modules). If cordova-lib linked to cordova-cli this path is
-    // never resolved, so hook fails with 'Error: Cannot find module 'cordova-lib''
+    // We can only resolve `cordova-lib` by name if this module is installed as
+    // a dependency of the current main module (e.g. when running `cordova`).
+    // To handle `cordova-lib` paths correctly in all other cases too, we
+    // resolve them to real paths before requiring them.
     var resolvedPath = path.resolve(__dirname, modulePath.replace(/^cordova-lib/, '../../../cordova-lib'));
     var relativePath = path.relative(__dirname, resolvedPath).replace(/\\/g, '/');
     events.emit('verbose', 'Resolving module name for ' + modulePath + ' => ' + relativePath);

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -58,6 +58,10 @@ var compatMap = {
  * @param {String} modulePath Module path
  * @returns {Object} */
 Context.prototype.requireCordovaModule = function (modulePath) {
+    const pkg = modulePath.split('/')[0];
+
+    if (pkg !== 'cordova-lib') return require(modulePath);
+
     // There is a very common mistake, when hook requires some cordova functionality
     // using 'cordova-lib/...' path.
     // This path will be resolved only when running cordova from 'normal' installation


### PR DESCRIPTION
UPDATED:
- reintroduce `xcode` as needed in 8.1.x to avoid breaking plugins such as `branch-cordova-sdk` before next major release, to resolve GH-706 (bug #706)
- ~~emit a message in case someone uses `requireCordovaModule('xcode')` that it is now deprecated, will be removed in the near future, along with the recommended solution~~
- reintroduce some other dependencies to better ensure that any other plugins or applications using `requireCordovaModule` would not be broken by a minor release upgrade
- emit a deprecation warning message in case a plugin or application uses `requireCordovaModule` with a non-Cordova module
- some other updates from PR #707

This fix is NOT WANTED in `master` branch. I think we do not want to support `requireCordovaModule('xcode')` in the next major release.

This fix was tested as follows:
* pushed this change to `bug-706-xcode-hotfix-test` on my fork
* made `bug-706-xcode-hotfix-test` branch on my fork of `cordova-cli` that uses cordova-lib from `git+https://github.com/brodybits/cordova-lib.git#bug-706-xcode-hotfix-test` as dependency
* In <https://github.com/brodybits/cordova-xcode-error> (fork of <https://github.com/Tallyb/cordova-xcode-error> with `config.xml` fix):
  - I used cross-platform `nvs` tool (<https://github.com/jasongin/nvs>) to switch to Node.js 10.10 and do `npm i -g https://github.com/brodybits/cordova-cli#bug-706-xcode-hotfix-test`
  - `cordova platform add ios` outputs the deprecation message, does not fail with the `xcode` error

Resolves #706 