### PR TITLE
Breaking changes in hooks/Context

### DIFF
--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -27,6 +27,27 @@ describe('hooks/Context', () => {
         Context = rewire('../../src/hooks/Context');
     });
 
+    describe('cordova', () => {
+        let context;
+
+        beforeEach(() => {
+            spyOn(Context.prototype, 'requireCordovaModule');
+            context = new Context();
+        });
+
+        it('is only loaded when accessed', () => {
+            expect(context.requireCordovaModule).not.toHaveBeenCalled();
+        });
+
+        it('is set to require("cordova-lib").cordova', () => {
+            const cordova = Symbol('cordova');
+            context.requireCordovaModule.and.returnValue({ cordova });
+
+            expect(context.cordova).toBe(cordova);
+            expect(context.requireCordovaModule).toHaveBeenCalledWith('cordova-lib');
+        });
+    });
+
     describe('requireCordovaModule', () => {
         let requireCordovaModule;
 

--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -18,7 +18,7 @@
 */
 
 const rewire = require('rewire');
-const events = require('cordova-common').events;
+const { CordovaError } = require('cordova-common');
 
 describe('hooks/Context', () => {
     let Context;
@@ -28,16 +28,10 @@ describe('hooks/Context', () => {
     });
 
     describe('requireCordovaModule', () => {
-        let warnSpy, requireCordovaModule;
+        let requireCordovaModule;
 
         beforeEach(() => {
             requireCordovaModule = Context.prototype.requireCordovaModule;
-            warnSpy = jasmine.createSpy('warnSpy');
-            events.on('warn', warnSpy);
-        });
-
-        afterEach(() => {
-            events.removeListener('warn', warnSpy);
         });
 
         it('correctly resolves cordova-* dependencies', () => {
@@ -90,17 +84,17 @@ describe('hooks/Context', () => {
                 expect(requireSpy).toHaveBeenCalledWith('cordova-libre');
             });
 
-            it('emits a warning if non-cordova module is requested', () => {
-                requireCordovaModule('q');
+            it('throws if non-cordova module is requested', () => {
+                const expectErrorOnRequire = m =>
+                    expect(() => requireCordovaModule(m))
+                        .toThrowError(CordovaError, /non-cordova module/);
 
-                expect(requireSpy).toHaveBeenCalledWith('q');
-                expect(warnSpy).toHaveBeenCalledTimes(1);
-
-                const message = warnSpy.calls.argsFor(0)[0];
-                expect(message).toContain('requireCordovaModule');
-                expect(message).toContain('non-cordova module');
-                expect(message).toContain('deprecated');
-                expect(message).toContain('"q"');
+                expectErrorOnRequire('q');
+                expectErrorOnRequire('.');
+                expectErrorOnRequire('..');
+                expectErrorOnRequire('./asd');
+                expectErrorOnRequire('../qwe');
+                expectErrorOnRequire('/foo');
             });
         });
 

--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -67,18 +67,6 @@ describe('hooks/Context', () => {
                 Context.__set__({ require: requireSpy });
             });
 
-            it('maps some old paths to their new equivalent', () => {
-                const ConfigParser = Symbol('ConfigParser');
-                const xmlHelpers = Symbol('xmlHelpers');
-                requireSpy.and.returnValue({ ConfigParser, xmlHelpers });
-
-                expect(requireCordovaModule('cordova-lib/src/configparser/ConfigParser')).toBe(ConfigParser);
-                expect(requireCordovaModule('cordova-lib/src/util/xml-helpers')).toBe(xmlHelpers);
-                expect(requireSpy.calls.allArgs()).toEqual([
-                    ['cordova-common'], ['cordova-common']
-                ]);
-            });
-
             it('correctly handles module names that start with "cordova-lib"', () => {
                 requireCordovaModule('cordova-libre');
                 expect(requireSpy).toHaveBeenCalledWith('cordova-libre');

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -19,6 +19,7 @@
 
 var path = require('path');
 var events = require('cordova-common').events;
+var CordovaError = require('cordova-common').CordovaError;
 
 /**
  * Creates hook script context
@@ -61,9 +62,9 @@ Context.prototype.requireCordovaModule = function (modulePath) {
     const [pkg, ...pkgPath] = modulePath.split('/');
 
     if (!pkg.match(/^cordova-[^/]+/)) {
-        events.emit('warn',
+        throw new CordovaError(
             `Using "requireCordovaModule" to load non-cordova module ` +
-            `"${modulePath}" is deprecated. Instead, add this module to ` +
+            `"${modulePath}" is not supported. Instead, add this module to ` +
             `your dependencies and use regular "require" to load it.`
         );
     }

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -33,7 +33,11 @@ function Context (hook, opts) {
     // For example context.opts.plugin = Object is done, then it affects by reference
     this.opts = Object.assign({}, opts);
     this.cmdLine = process.argv.join(' ');
-    this.cordova = require('../cordova/cordova');
+
+    // Lazy-load cordova to avoid cyclical dependency
+    Object.defineProperty(this, 'cordova', {
+        get () { return this.requireCordovaModule('cordova-lib').cordova; }
+    });
 }
 
 /**

--- a/src/hooks/Context.js
+++ b/src/hooks/Context.js
@@ -17,8 +17,8 @@
  under the License.
  */
 
-var path = require('path');
-var CordovaError = require('cordova-common').CordovaError;
+const path = require('path');
+const { CordovaError } = require('cordova-common');
 
 /**
  * Creates hook script context


### PR DESCRIPTION
This includes a few changes to `hooks/Context` that necessitate a major release:
- Throw error if non-cordova module is required (Resolves #689)
- Remove outdated compatibility layer from 2015
- Lazily load `Context.cordova` to avoid cyclical dependency
- Use `const` for imports
