### PR TITLE
Fix 2 integration tests failures on macOS

### DIFF
--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -36,7 +36,7 @@ function getConfigPath (dir) {
 
 module.exports.tmpDir = function (suffix = 'test') {
     const dir = path.join(os.tmpdir(), `cordova-lib-${suffix}-`);
-    return fs.mkdtempSync(dir);
+    return fs.realpathSync(fs.mkdtempSync(dir));
 };
 
 /**


### PR DESCRIPTION
### What does this PR do?
`os.tmpdir()` on macOS returns `/var/folders`, but `/var` is a symlink to `/private/var`.

We dereference symlinks in a bunch of places, which was leading to tests failing when they expected something to get called with a path of `/var/folders/cordova-lib-whatever/...` and they were actually getting called with a path of `/private/var/folders/cordova-lib-whatever/...`.

This change ensures that when we create a temporary directory, we get the real path before we return it to the tests.

### What testing has been done on this change?
Ran tests of macOS and they all passed.