### PR TITLE
[WIP] Update cordova-common & export common object - under discussion

### DIFF
--- a/cordova-lib.js
+++ b/cordova-lib.js
@@ -26,6 +26,7 @@ exports = module.exports = {
     get binname () {
         return this.cordova.binname;
     },
+    common: common,
     events: common.events,
     configparser: common.ConfigParser,
     PluginInfo: common.PluginInfo,

--- a/cordova-lib.js
+++ b/cordova-lib.js
@@ -20,6 +20,12 @@
 var common = require('cordova-common');
 
 exports = module.exports = {
+    set binname (name) {
+        this.cordova.binname = name;
+    },
+    get binname () {
+        return this.cordova.binname;
+    },
     common: common,
     events: common.events,
     configparser: common.ConfigParser,

--- a/cordova-lib.js
+++ b/cordova-lib.js
@@ -20,12 +20,6 @@
 var common = require('cordova-common');
 
 exports = module.exports = {
-    set binname (name) {
-        this.cordova.binname = name;
-    },
-    get binname () {
-        return this.cordova.binname;
-    },
     common: common,
     events: common.events,
     configparser: common.ConfigParser,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "cordova-common": "^2.2.0",
+    "cordova-common": "^3.0.0",
     "cordova-create": "^1.1.0",
     "cordova-fetch": "^1.3.0",
     "cordova-serve": "^2.0.0",

--- a/spec/cordova/create.spec.js
+++ b/spec/cordova/create.spec.js
@@ -18,9 +18,13 @@
 */
 
 var fs = require('fs-extra');
+
 var helpers = require('../helpers');
+
 var path = require('path');
-var events = require('cordova-common').events;
+
+const events = require('../../cordova-lib').events;
+
 var cordova = require('../../src/cordova/cordova');
 
 var tmpDir = helpers.tmpDir('create_test');

--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -17,8 +17,11 @@
 
 var path = require('path');
 var fs = require('fs-extra');
-var events = require('cordova-common').events;
+
+const { events } = require('../../../cordova-lib');
+
 var rewire = require('rewire');
+
 var platform_module = require('../../../src/cordova/platform');
 var cordova_util = require('../../../src/cordova/util');
 var cordova_config = require('../../../src/cordova/config');

--- a/spec/cordova/platform/check.spec.js
+++ b/spec/cordova/platform/check.spec.js
@@ -16,10 +16,14 @@ http://www.apache.org/licenses/LICENSE-2.0
 */
 
 var fs = require('fs-extra');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
+
 var superspawn = require('cordova-common').superspawn;
+
 var rewire = require('rewire');
 var platform_check = rewire('../../../src/cordova/platform/check');
+
 var platform = require('../../../src/cordova/platform');
 var cordova_util = require('../../../src/cordova/util');
 

--- a/spec/cordova/platform/getPlatformDetailsFromDir.spec.js
+++ b/spec/cordova/platform/getPlatformDetailsFromDir.spec.js
@@ -17,10 +17,14 @@
 
 var path = require('path');
 var fs = require('fs-extra');
+
 var rewire = require('rewire');
+
 var cordova_util = require('../../../src/cordova/util');
+
+const events = require('../../../cordova-lib').events;
+
 var platform_getPlatformDetails = rewire('../../../src/cordova/platform/getPlatformDetailsFromDir');
-var events = require('cordova-common').events;
 
 describe('cordova/platform/getPlatformDetailsFromDir', function () {
     var package_json_mock;

--- a/spec/cordova/platform/list.spec.js
+++ b/spec/cordova/platform/list.spec.js
@@ -15,7 +15,8 @@
     under the License.
 */
 
-var events = require('cordova-common').events;
+const events = require('../../../cordova-lib').events;
+
 var platform_list = require('../../../src/cordova/platform/list');
 var cordova_util = require('../../../src/cordova/util');
 

--- a/spec/cordova/platform/remove.spec.js
+++ b/spec/cordova/platform/remove.spec.js
@@ -17,8 +17,11 @@
 
 var path = require('path');
 var fs = require('fs-extra');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
+
 var rewire = require('rewire');
+
 var cordova_util = require('../../../src/cordova/util');
 var promiseutil = require('../../../src/util/promise-util');
 

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -23,7 +23,7 @@ var fs = require('fs-extra');
 
 var rewire = require('rewire');
 
-const { events } = require('../../../cordova-lib');
+const { events } = require('../../../cordova-lib').common;
 
 var util = require('../../../src/cordova/util');
 

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -20,10 +20,13 @@
 var os = require('os');
 var path = require('path');
 var fs = require('fs-extra');
+
 var rewire = require('rewire');
-var events = require('cordova-common').events;
+
+const { events } = require('../../../cordova-lib');
 
 var util = require('../../../src/cordova/util');
+
 var platforms = rewire('../../../src/platforms/platforms');
 
 var CORDOVA_ROOT = path.join(__dirname, '../fixtures/projects/platformApi');

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -19,12 +19,17 @@
 
 var rewire = require('rewire');
 var add = rewire('../../../src/cordova/plugin/add');
+
 var plugman = require('../../../src/plugman/plugman');
 var cordova_util = require('../../../src/cordova/util');
+
 var path = require('path');
 var fs = require('fs-extra');
+
 var config = require('../../../src/cordova/config');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
+
 var plugin_util = require('../../../src/cordova/plugin/util');
 
 describe('cordova/plugin/add', function () {

--- a/spec/cordova/plugin/list.spec.js
+++ b/spec/cordova/plugin/list.spec.js
@@ -19,7 +19,9 @@
 
 var list = require('../../../src/cordova/plugin/list');
 var plugin_util = require('../../../src/cordova/plugin/util');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
+
 var semver = require('semver');
 
 describe('cordova/plugin/list', function () {

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -19,11 +19,16 @@
 
 var rewire = require('rewire');
 var remove = rewire('../../../src/cordova/plugin/remove');
+
 var cordova_util = require('../../../src/cordova/util');
 var metadata = require('../../../src/plugman/util/metadata');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
+
 var plugman = require('../../../src/plugman/plugman');
+
 var fs = require('fs-extra');
+
 var prepare = require('../../../src/cordova/prepare');
 var plugin_util = require('../../../src/cordova/plugin/util');
 var config = require('../../../src/cordova/config');

--- a/spec/cordova/plugin/util.spec.js
+++ b/spec/cordova/plugin/util.spec.js
@@ -19,8 +19,10 @@
 
 var rewire = require('rewire');
 var plugin_util = rewire('../../../src/cordova/plugin/util');
+
 var fs = require('fs-extra');
-var events = require('cordova-common').events;
+
+const events = require('../../../cordova-lib').events;
 
 describe('cordova/plugin/util', function () {
     var plugin_info_mock = function () {};

--- a/spec/cordova/restore-util.spec.js
+++ b/spec/cordova/restore-util.spec.js
@@ -17,8 +17,11 @@
 
 const path = require('path');
 const fs = require('fs-extra');
+
 const rewire = require('rewire');
-const { ConfigParser } = require('cordova-common');
+
+const ConfigParser = require('../../../cordova-lib').configparser;
+
 const { tmpDir: getTmpDir, testPlatform } = require('../helpers');
 
 /**

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -20,7 +20,8 @@
 var path = require('path');
 var fs = require('fs-extra');
 var os = require('os');
-var ConfigParser = require('cordova-common').ConfigParser;
+
+const ConfigParser = require('../cordova-lib').configparser;
 
 // Just use Android everywhere; we're mocking out any calls to the `android` binary.
 module.exports.testPlatform = 'android';

--- a/spec/hooks/Context.spec.js
+++ b/spec/hooks/Context.spec.js
@@ -18,7 +18,8 @@
 */
 
 const rewire = require('rewire');
-const events = require('cordova-common').events;
+
+const events = require('../../cordova-lib').events;
 
 describe('hooks/Context', () => {
     let Context;

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -22,7 +22,10 @@ const os = require('os');
 const path = require('path');
 const semver = require('semver');
 
-const { events, PlatformJson, superspawn } = require('cordova-common');
+const { events } = require('../../cordova-lib');
+
+const { PlatformJson, superspawn } = require('cordova-common');
+
 const { spy: emitSpyHelper } = require('../common');
 const install = require('../../src/plugman/install');
 const knownPlatforms = require('../../src/platforms/platforms');


### PR DESCRIPTION
* update unit tests to use objects from `cordova-lib.js` instead of `require('cordova-common')` whenever possible
* export common object from cordova-common, with quick unit-test verification that it works
* do not export `binname` attribute
* cordova-common@3 update

This means that tools like Cordova CLI would use the exported `common` object instead of explicitly requiring the `cordova-common` dependency. I think this would lead to both easier maintenance and reduced likelihood of violating the [cordova-common singleton rule](https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md#cordova-common-singleton-rule).

If this proposal is accepted, I think we should deprecate use of individual `common` member objects from the exports (`events`, `configparser`, `PluginInfo`, and `CordovaError`) and remove them someday in the future.

If this proposal is not accepted for any reason, an alternative solution would be to add an export of the `CordovaLogger` object. Then Cordova CLI could drop the explicit cordova-common dependency.