### PR TITLE
Fix crash in `cordova requirements` due to an unbound function

### DIFF
--- a/spec/cordova/requirements.spec.js
+++ b/spec/cordova/requirements.spec.js
@@ -1,0 +1,40 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var rewire = require('rewire');
+var util = require('../../src/cordova/util');
+var requirements = rewire('../../src/cordova/requirements');
+
+var project_dir = '/some/path';
+
+describe('cordova/requirements', function () {
+    beforeEach(function () {
+        spyOn(util, 'isCordova').and.returnValue(project_dir);
+    });
+
+    describe('main method', function () {
+        it('should fail if no platforms are added', function () {
+            return requirements([]).then(function () {
+            }, function (err) {
+                expect(err).toEqual(jasmine.any(Error));
+                expect(err.message).toMatch('No platforms added');
+            });
+        });
+    });
+});

--- a/src/cordova/requirements.js
+++ b/src/cordova/requirements.js
@@ -18,7 +18,7 @@
 */
 
 const { object: zipObject } = require('underscore');
-const { preProcessOptions } = require('./util');
+const cordova_util = require('./util');
 const { CordovaError } = require('cordova-common');
 const knownPlatforms = require('../platforms/platforms');
 
@@ -33,7 +33,7 @@ const knownPlatforms = require('../platforms/platforms');
  */
 module.exports = function check_reqs (platforms) {
     return Promise.resolve().then(() => {
-        const normalizedPlatforms = preProcessOptions(platforms).platforms;
+        const normalizedPlatforms = cordova_util.preProcessOptions(platforms).platforms;
 
         return Promise.all(
             normalizedPlatforms.map(getPlatformRequirementsOrError)


### PR DESCRIPTION
Fixes #740.

### Platforms affected

All of them, I think.

### What does this PR do?

Functions in utils.js expect to be called with `this` bound to the module. So this call crashed with an error

```
    this.isCordova is not a function
```

This PR fixes the call to go through the proper binding.

### What testing has been done on this change?

It fixed my build. I also added a simple fail-before, pass-after unit test.