### PR TITLE
Add Electron Platform

### DIFF
--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -38,7 +38,7 @@ describe('platforms/platforms', () => {
 
     it('should have all and only the supported platforms', function () {
         expect(Object.keys(platforms)).toEqual(jasmine.arrayWithExactContents([
-            'android', 'browser', 'ios', 'osx', 'windows'
+            'android', 'browser', 'ios', 'osx', 'windows', 'electron'
         ]));
     });
 

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -33,5 +33,11 @@
         "version": "~5.0.1",
         "apiCompatibleSince": "5.0.0",
         "deprecated": false
+    },
+    "electron": {
+        "url": "https://github.com/apache/cordova-electron.git",
+        "version": "~1.0.0",
+        "apiCompatibleSince": "5.0.0",
+        "deprecated": false
     }
 }

--- a/src/plugman/util/default-engines.js
+++ b/src/plugman/util/default-engines.js
@@ -35,6 +35,8 @@ module.exports = function (project_dir) {
             { 'platform': 'windows', 'scriptSrc': path.join(project_dir, 'cordova', 'version') },
         'cordova-browser':
             { 'platform': 'browser', 'scriptSrc': path.join(project_dir, 'cordova', 'version') },
+        'cordova-electron':
+            { 'platform': 'electron', 'scriptSrc': path.join(project_dir, 'cordova', 'version') },
         'apple-xcode':
             { 'platform': 'ios', 'scriptSrc': path.join(project_dir, 'cordova', 'apple_xcode_version') },
         'apple-ios':


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
- Add Electron platform config and plugman default engine.
- Updated platform test spec to include Electron

### What testing has been done on this change?
- `npm t`