### PR TITLE
Remove handling of legacy .fetch.json files

### DIFF
--- a/src/plugman/util/metadata.js
+++ b/src/plugman/util/metadata.js
@@ -39,17 +39,7 @@ exports.get_fetch_metadata = function (plugin_dir) {
     var pluginId = path.basename(plugin_dir);
 
     var metadataJson = getJson(pluginsDir);
-    if (metadataJson[pluginId]) {
-        return metadataJson[pluginId];
-    }
-    var legacyPath = path.join(plugin_dir, '.fetch.json');
-    if (fs.existsSync(legacyPath)) {
-        var ret = JSON.parse(fs.readFileSync(legacyPath, 'utf-8'));
-        exports.save_fetch_metadata(pluginsDir, pluginId, ret);
-        fs.unlinkSync(legacyPath);
-        return ret;
-    }
-    return {};
+    return metadataJson[pluginId] || {};
 };
 
 exports.save_fetch_metadata = function (pluginsDir, pluginId, data) {


### PR DESCRIPTION
### Motivation and Context
This PR removes stale legacy handling code for files last created by Cordova 4.3.0.

The current version of the code transformed the old files to the new format and location, so removal of the current code should not affect any reasonably recent projects.

Since this is technically a breaking change, I thought it would be nice to include this into the upcoming major release.

I came across this when reviewing #680. 

### Description
I removed code that read `plugins/<PLUGIN>/.fetch.json` and integrated it into `plugins/fetch.json`.

### Testing
I ran the existing test suite.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
