### PR TITLE
Remove saving platforms/plugins to config.xml

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -217,14 +217,6 @@ describe('cordova/platform/addHelper', function () {
                 });
             });
 
-            it('should write out the version of platform just added/updated to config.xml if the save option is provided', function () {
-                return platform_addHelper('add', hooks_mock, projectRoot, ['ios'], { save: true, restoring: true }).then(function (result) {
-                    expect(cfg_parser_mock.prototype.removeEngine).toHaveBeenCalled();
-                    expect(cfg_parser_mock.prototype.addEngine).toHaveBeenCalled();
-                    expect(cfg_parser_mock.prototype.write).toHaveBeenCalled();
-                });
-            });
-
             describe('if the project contains a package.json', function () {
                 it('should write out the platform just added/updated to the cordova.platforms property of package.json', function () {
                     fs.readFileSync.and.returnValue('file');

--- a/spec/cordova/platform/remove.spec.js
+++ b/spec/cordova/platform/remove.spec.js
@@ -36,7 +36,7 @@ describe('cordova/platform/remove', function () {
     beforeEach(function () {
         hooks_mock = jasmine.createSpyObj('hooksRunner mock', ['fire']);
         hooks_mock.fire.and.returnValue(Promise.resolve());
-        cfg_parser_mock.prototype = jasmine.createSpyObj('config parser mock', ['write', 'removeEngine']);
+        cfg_parser_mock.prototype = jasmine.createSpyObj('config parser mock', ['write', 'getEngines', 'removeEngine']);
 
         platform_remove = rewire('../../../src/cordova/platform/remove');
         platform_remove.__set__({
@@ -50,6 +50,7 @@ describe('cordova/platform/remove', function () {
         spyOn(cordova_util, 'removePlatformPluginsJson');
         spyOn(events, 'emit');
         spyOn(cordova_util, 'requireNoCache').and.returnValue({});
+        cfg_parser_mock.prototype.getEngines.and.returnValue([{ name: 'atari', spec: '^0.0.1' }]);
     });
 
     describe('error/warning conditions', function () {

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -40,7 +40,7 @@ describe('cordova/plugin/add', function () {
     beforeEach(function () {
         hook_mock = jasmine.createSpyObj('hooks runner mock', ['fire']);
         hook_mock.fire.and.returnValue(Promise.resolve());
-        Cfg_parser_mock.prototype = jasmine.createSpyObj('config parser prototype mock', ['getPlugin', 'removePlugin', 'addPlugin', 'write']);
+        Cfg_parser_mock.prototype = jasmine.createSpyObj('config parser prototype mock', ['getPlugin']);
         cfg_parser_revert_mock = add.__set__('ConfigParser', Cfg_parser_mock);
         plugin_info = jasmine.createSpyObj('pluginInfo', ['getPreferences']);
         plugin_info.getPreferences.and.returnValue({});
@@ -164,9 +164,6 @@ describe('cordova/plugin/add', function () {
                     expect(add.determinePluginTarget).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), jasmine.anything(), jasmine.objectContaining({ 'variables': cli_plugin_variables }));
                     // check that the plugin variables from config.xml got added to cli_variables
                     expect(plugman.install).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), jasmine.anything(), jasmine.anything(), jasmine.objectContaining({ 'cli_variables': cli_plugin_variables }));
-                    expect(Cfg_parser_mock.prototype.removePlugin).toHaveBeenCalledWith('cordova-plugin-device');
-                    expect(Cfg_parser_mock.prototype.addPlugin).toHaveBeenCalledWith(jasmine.any(Object), cli_plugin_variables);
-                    expect(Cfg_parser_mock.prototype.write).toHaveBeenCalled();
                 });
             });
             // can't test the following due to inline require of preparePlatforms

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -52,7 +52,7 @@ describe('cordova/plugin/remove', function () {
         hook_mock = jasmine.createSpyObj('hooks runner mock', ['fire']);
         spyOn(prepare, 'preparePlatforms').and.returnValue(true);
         hook_mock.fire.and.returnValue(Promise.resolve());
-        cfg_parser_mock.prototype = jasmine.createSpyObj('config parser mock', ['write', 'removeEngine', 'addEngine', 'getHookScripts', 'removePlugin']);
+        cfg_parser_mock.prototype = jasmine.createSpyObj('config parser mock', ['write', 'getPlugin', 'removePlugin']);
         cfg_parser_revert_mock = remove.__set__('ConfigParser', cfg_parser_mock);
         plugin_info_provider_mock.prototype = jasmine.createSpyObj('plugin info provider mock', ['get', 'getPreferences']);
         plugin_info_provider_mock.prototype.get = function (directory) {
@@ -159,6 +159,7 @@ describe('cordova/plugin/remove', function () {
                 fs.existsSync.and.returnValue(true);
                 remove.validatePluginId.and.returnValue('cordova-plugin-splashscreen');
                 var opts = { important: 'options', plugins: ['cordova-plugin-splashscreen'] };
+                cfg_parser_mock.prototype.getPlugin.and.returnValue({});
                 return remove(projectRoot, 'cordova-plugin-splashscreen', hook_mock, opts).then(function () {
                     expect(cfg_parser_mock.prototype.removePlugin).toHaveBeenCalled();
                     expect(cfg_parser_mock.prototype.write).toHaveBeenCalled();

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -220,13 +220,6 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                                 // was installed. However, we save it with the "~" attribute (this allows for patch updates).
                                 spec = saveVersion ? '~' + platDetails.version : spec;
 
-                                // Save target into config.xml, overriding already existing settings.
-                                events.emit('log', '--save flag or autosave detected');
-                                events.emit('log', 'Saving ' + platform + '@' + spec + ' into config.xml file ...');
-                                cfg.removeEngine(platform);
-                                cfg.addEngine(platform, spec);
-                                cfg.write();
-
                                 // Save to add to pacakge.json's cordova.platforms array in the next then.
                                 platformsToSave.push(platform);
                             }

--- a/src/cordova/platform/remove.js
+++ b/src/cordova/platform/remove.js
@@ -54,9 +54,11 @@ function remove (hooksRunner, projectRoot, targets, opts) {
                     var platformName = target.split('@')[0];
                     var xml = cordova_util.projectConfig(projectRoot);
                     var cfg = new ConfigParser(xml);
-                    events.emit('log', 'Removing platform ' + target + ' from config.xml file...');
-                    cfg.removeEngine(platformName);
-                    cfg.write();
+                    if (cfg.getEngines && cfg.getEngines().some(function (e) { return e.name === platformName; })) {
+                        events.emit('log', 'Removing platform ' + target + ' from config.xml file...');
+                        cfg.removeEngine(platformName);
+                        cfg.write();
+                    }
                     // If package.json exists and contains a specified platform in cordova.platforms, it will be removed.
                     if (pkgJson !== undefined && pkgJson.cordova !== undefined && pkgJson.cordova.platforms !== undefined) {
                         var index = pkgJson.cordova.platforms.indexOf(platformName);

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -183,13 +183,6 @@ function add (projectRoot, hooksRunner, opts) {
                                 }
                             }
                         }
-                        xml = cordova_util.projectConfig(projectRoot);
-                        cfg = new ConfigParser(xml);
-                        cfg.removePlugin(pluginInfo.id);
-                        cfg.addPlugin(attributes, opts.cli_variables);
-                        cfg.write();
-
-                        events.emit('results', 'Saved plugin info for "' + pluginInfo.id + '" to config.xml');
                     }
                 });
             }, Promise.resolve());

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -115,12 +115,15 @@ function remove (projectRoot, targets, hooksRunner, opts) {
     }
 
     function persistRemovalToCfg (target) {
-        events.emit('log', 'Removing plugin ' + target + ' from config.xml file...');
         var configPath = cordova_util.projectConfig(projectRoot);
         if (fs.existsSync(configPath)) { // should not happen with real life but needed for tests
             var configXml = new ConfigParser(configPath);
-            configXml.removePlugin(target);
-            configXml.write();
+
+            if (configXml.getPlugin(target)) {
+                events.emit('log', 'Removing plugin ' + target + ' from config.xml file...');
+                configXml.removePlugin(target);
+                configXml.write();
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All (via tooling)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We've had one major version of cordova-lib that attempted to ensure both config.xml and package.json were kept in sync, and now it's time to push people more strongly towards using package.json.


### Description
<!-- Describe your changes in detail -->
We will still attempt to read values from config.xml and update them in package.json, but we will no longer reflect changes back to config.xml.
Whatever's saved in package.json should always have priority over what is read from config.xml.

The next phase will be to [improve the handling of package.json updates](https://github.com/apache/cordova-common/pull/34), and then in the next major to completely remove the code that looks at config.xml for platforms/plugins.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Updated spec and E2E tests.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
