### PR TITLE
Pass project config.xml path to platform's prepare

### DIFF
--- a/src/cordova/prepare.js
+++ b/src/cordova/prepare.js
@@ -86,7 +86,8 @@ function preparePlatforms (platformList, projectRoot, options) {
             projectConfig: new ConfigParser(cordova_util.projectConfig(projectRoot)),
             locations: {
                 plugins: path.join(projectRoot, 'plugins'),
-                www: cordova_util.projectWww(projectRoot)
+                www: cordova_util.projectWww(projectRoot),
+                rootConfigXml: cordova_util.projectConfig(projectRoot)
             }
         };
         // CB-9987 We need to reinstall the plugins for the platform it they were added by cordova@<5.4.0


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently we're passing in an already-constructed ConfigParser instance as part of the fake projectInfo object, but the problem is that it's constructed with the version of cordova-common depended on by *cordova-lib* as opposed to the version of cordova-common depended on by the *platform*.

See https://github.com/apache/cordova-ios/issues/535 and https://github.com/apache/cordova-android/issues/690

### Description
<!-- Describe your changes in detail -->
Pass the path to the root config.xml in, so that we can construct the ConfigParser at the Platform API level, using the correct version.

In the meantime, for compatibility reasons, we have to keep passing in a ConfigParser instance, and the Platform API needs to handle the case where rootConfigXml is undefined and it needs to fetch the path out of the existing ConfigParser instance and then overwrite it with a newly constructed ConfigParser.

We should at some point look into making this "root project info" object a class in cordova-common so that we can document what it's expected to contain and rely on that both here and in the platforms.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Unit tests pass.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
