### PR TITLE
Fix restoring plugins from package.json

### DIFF
--- a/spec/cordova/restore-util.spec.js
+++ b/spec/cordova/restore-util.spec.js
@@ -129,7 +129,8 @@ describe('cordova/restore-util', () => {
             return o;
         }, {});
         if (Object.keys(specs).length > 0) {
-            expect(pkgJson.dependencies).toEqual(jasmine.objectContaining(specs));
+            let specs = Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies);
+            expect(specs).toEqual(jasmine.objectContaining(specs));
         }
     }
 
@@ -295,36 +296,6 @@ describe('cordova/restore-util', () => {
             });
         });
 
-        /**
-        *   When config.xml and pkg.json share a common plugin but pkg.json defines no variables for it,
-        *   prepare will update pkg.json to match config.xml's plugins/variables.
-        */
-        it('Test#012 : update pkg.json to include plugin and variable found in config.xml', () => {
-            getCfg()
-                .addPlugin({
-                    name: 'cordova-plugin-camera',
-                    variables: { variable_1: 'value_1' }
-                })
-                .write();
-            setPkgJson('cordova.plugins', {
-                'cordova-plugin-camera': {}
-            });
-
-            return restore.installPluginsFromConfigXML({ save: true }).then(() => {
-                expectConsistentPlugins([
-                    jasmine.objectContaining({
-                        name: 'cordova-plugin-camera',
-                        variables: { variable_1: 'value_1' }
-                    })
-                ]);
-            });
-        });
-
-        /**
-        *   For plugins that are the same, it will merge their variables together for the final list.
-        *   Plugins that are unique to that file, will be copied over to the file that is missing it.
-        *   Config.xml and pkg.json will have identical plugins and variables after cordova prepare.
-        */
         it('Test#013 : update pkg.json AND config.xml to include all plugins and merge unique variables', () => {
             getCfg()
                 .addPlugin({
@@ -346,7 +317,7 @@ describe('cordova/restore-util', () => {
                 expectPluginsInPkgJson([
                     jasmine.objectContaining({
                         name: 'cordova-plugin-camera',
-                        variables: { variable_1: ' ', variable_2: ' ', variable_3: 'value_3' }
+                        variables: { variable_1: ' ', variable_2: ' ' }
                     }),
                     jasmine.objectContaining({
                         name: 'cordova-plugin-splashscreen',
@@ -360,12 +331,7 @@ describe('cordova/restore-util', () => {
             });
         });
 
-        /**
-        *   If either file is missing a plugin, it will be added with the correct variables.
-        *   If there is a matching plugin name, the variables will be merged and then added
-        *   to config and pkg.json.
-        */
-        it('Test#014 : update pkg.json AND config.xml to include all plugins and merge variables (no dupes)', () => {
+        it('Test#014 : update pkg.json AND config.xml to include all plugins and use package.json variables', () => {
             getCfg()
                 .addPlugin({
                     name: 'cordova-plugin-camera',
@@ -390,7 +356,7 @@ describe('cordova/restore-util', () => {
                 expectPluginsInPkgJson([{
                     name: 'cordova-plugin-camera',
                     spec: '^2.3.0',
-                    variables: { variable_1: 'value_1', variable_2: 'value_2', variable_3: 'value_3' }
+                    variables: { variable_1: 'value_1', variable_3: 'value_3' }
                 }, {
                     name: 'cordova-plugin-device',
                     spec: '~1.0.0',

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -268,9 +268,11 @@ function installPluginsFromConfigXML (args) {
 
     let specs = Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies);
 
-    let plugins = pluginIDs.map(plID => {
-        return { name: plID, spec: specs[plID], variables: pkgJson.cordova.plugins[plID] || {} };
-    });
+    let plugins = pluginIDs.map(plID => ({
+        name: plID,
+        spec: specs[plID],
+        variables: pkgJson.cordova.plugins[plID] || {}
+    }));
 
     let pluginName = '';
 

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -234,6 +234,7 @@ function installPluginsFromConfigXML (args) {
     pkgJson.cordova.plugins = pkgJson.cordova.plugins || {};
 
     const pkgPluginIDs = Object.keys(pkgJson.cordova.plugins);
+    const pkgSpecs = Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies);
 
     // Check for plugins listed in config.xml
     const cfg = new ConfigParser(confXmlPath);
@@ -247,7 +248,9 @@ function installPluginsFromConfigXML (args) {
 
             const cfgPlugin = cfg.getPlugin(plID);
 
-            if (cfgPlugin.spec) {
+            // If config.xml has a spec for the plugin and package.json has not,
+            // add the spec to devDependencies of package.json
+            if (cfgPlugin.spec && !(plID in pkgSpecs)) {
                 pkgJson.devDependencies[plID] = cfgPlugin.spec;
             }
 

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -281,13 +281,13 @@ function installPluginsFromConfigXML (args) {
     // before installing the next root plugin otherwise we can have common
     // plugin dependencies installed twice which throws a nasty error.
     return promiseutil.Q_chainmap_graceful(plugins, function (pluginConfig) {
-        const pluginPath = path.join(pluginsRoot, pluginConfig.name);
+        pluginName = pluginConfig.name;
+
+        const pluginPath = path.join(pluginsRoot, pluginName);
         if (fs.existsSync(pluginPath)) {
             // Plugin already exists
             return Promise.resolve();
         }
-
-        pluginName = pluginConfig.name;
 
         events.emit('log', `Discovered saved plugin "${pluginName}". Adding it to the project`);
 

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -220,23 +220,18 @@ function installPluginsFromConfigXML (args) {
     const pkgJsonPath = path.join(projectRoot, 'package.json');
     const confXmlPath = cordova_util.projectConfig(projectRoot);
 
-    let pkgJson = {
-        devDependencies: {},
-        cordova: {
-            plugins: {}
-        }
-    };
+    let pkgJson = {};
     let indent = '  ';
 
     if (fs.existsSync(pkgJsonPath)) {
         let fileData = fs.readFileSync(pkgJsonPath, 'utf8');
         indent = detectIndent(fileData).indent;
-
         pkgJson = JSON.parse(fileData);
-        pkgJson.devDependencies = pkgJson.devDependencies || {};
-        pkgJson.cordova = pkgJson.cordova || {};
-        pkgJson.cordova.plugins = pkgJson.cordova.plugins || {};
     }
+
+    pkgJson.devDependencies = pkgJson.devDependencies || {};
+    pkgJson.cordova = pkgJson.cordova || {};
+    pkgJson.cordova.plugins = pkgJson.cordova.plugins || {};
 
     let pkgPluginIDs = Object.keys(pkgJson.cordova.plugins);
 

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -224,7 +224,7 @@ function installPluginsFromConfigXML (args) {
     let indent = '  ';
 
     if (fs.existsSync(pkgJsonPath)) {
-        let fileData = fs.readFileSync(pkgJsonPath, 'utf8');
+        const fileData = fs.readFileSync(pkgJsonPath, 'utf8');
         indent = detectIndent(fileData).indent;
         pkgJson = JSON.parse(fileData);
     }
@@ -233,7 +233,7 @@ function installPluginsFromConfigXML (args) {
     pkgJson.cordova = pkgJson.cordova || {};
     pkgJson.cordova.plugins = pkgJson.cordova.plugins || {};
 
-    let pkgPluginIDs = Object.keys(pkgJson.cordova.plugins);
+    const pkgPluginIDs = Object.keys(pkgJson.cordova.plugins);
 
     // Check for plugins listed in config.xml
     const cfg = new ConfigParser(confXmlPath);
@@ -245,7 +245,7 @@ function installPluginsFromConfigXML (args) {
         if (!pkgPluginIDs.includes(plID)) {
             events.emit('info', `Plugin '${plID}' found in config.xml... Migrating it to package.json`);
 
-            let cfgPlugin = cfg.getPlugin(plID);
+            const cfgPlugin = cfg.getPlugin(plID);
 
             if (cfgPlugin.spec) {
                 pkgJson.devDependencies[plID] = cfgPlugin.spec;
@@ -256,7 +256,7 @@ function installPluginsFromConfigXML (args) {
     });
 
     // Now that plugins have been updated, re-fetch them from package.json
-    let pluginIDs = Object.keys(pkgJson.cordova.plugins);
+    const pluginIDs = Object.keys(pkgJson.cordova.plugins);
 
     if (pluginIDs.length !== pkgPluginIDs.length) {
         // We've modified package.json and need to save it
@@ -266,9 +266,9 @@ function installPluginsFromConfigXML (args) {
         });
     }
 
-    let specs = Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies);
+    const specs = Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies);
 
-    let plugins = pluginIDs.map(plID => ({
+    const plugins = pluginIDs.map(plID => ({
         name: plID,
         spec: specs[plID],
         variables: pkgJson.cordova.plugins[plID] || {}

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -280,7 +280,7 @@ function installPluginsFromConfigXML (args) {
     // We need to wait for the plugin and its dependencies to be installed
     // before installing the next root plugin otherwise we can have common
     // plugin dependencies installed twice which throws a nasty error.
-    return promiseutil.Q_chainmap(plugins, function (pluginConfig) {
+    return promiseutil.Q_chainmap_graceful(plugins, function (pluginConfig) {
         const pluginPath = path.join(pluginsRoot, pluginConfig.name);
         if (fs.existsSync(pluginPath)) {
             // Plugin already exists

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -50,6 +50,7 @@ Object.defineProperty(exports, 'libDirectory', {
 });
 
 exports.isCordova = isCordova;
+exports.getProjectRoot = getProjectRoot;
 exports.cdProjectRoot = cdProjectRoot;
 exports.deleteSvnFolders = deleteSvnFolders;
 exports.listPlatforms = listPlatforms;
@@ -151,12 +152,24 @@ function isCordova (dir) {
     return false;
 }
 
-// Cd to project root dir and return its path. Throw CordovaError if not in a Corodva project.
-function cdProjectRoot () {
-    var projectRoot = convertToRealPathSafe(this.isCordova());
+/**
+ * Returns the project root directory path.
+ *
+ * Throws a CordovaError if not in a Cordova project.
+ */
+function getProjectRoot () {
+    const projectRoot = convertToRealPathSafe(this.isCordova());
+
     if (!projectRoot) {
         throw new CordovaError('Current working directory is not a Cordova-based project.');
     }
+
+    return projectRoot;
+}
+
+// Cd to project root dir and return its path. Throw CordovaError if not in a Corodva project.
+function cdProjectRoot () {
+    const projectRoot = this.getProjectRoot();
     if (!origCwd) {
         origCwd = process.env.PWD || process.cwd();
     }


### PR DESCRIPTION
 <!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some of the code removed in GH-750 had side effects on the rest of the plugin restoration procedure. Namely, despite wanting to migrate to package.json, we actually relied on config.xml for retrieving the plugin spec and variables. When we stopped syncing changes back to config.xml, those plugins stopped getting restored.


### Description
<!-- Describe your changes in detail -->
I've refactored this significantly to reduce complexity and make it easier to read and understand.

We look at package.json for plugins.
Then we look at config.xml. If a plugin exists in config.xml but not in package.json, we copy it to package.json.
Then we build up a list of the name/version/variables for each plugin, and pass them to the plugin installer in series.

### Testing
<!-- Please describe in detail how you tested your changes. -->
All tests pass.
It appears to work properly, having been tested in several of my own apps now, but I don't trust that the unit/e2e tests actually validate it, so I encourage further testing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change