### PR TITLE
Script path must not be wrapped in quotes

### DIFF
--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -165,7 +165,7 @@ function callEngineScripts (engines, project_dir) {
     return Promise.all(
         engines.map(function (engine) {
             // CB-5192; on Windows scriptSrc doesn't have file extension so we shouldn't check whether the script exists
-            var scriptPath = engine.scriptSrc ? '"' + engine.scriptSrc + '"' : null;
+            var scriptPath = engine.scriptSrc || null;
             if (scriptPath && (isWindows || fs.existsSync(engine.scriptSrc))) {
 
                 if (!isWindows) { // not required on Windows


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
Fixes #754
Fixes apache/cordova#52


### Description
Paths must not be wrapped in quotes before passing them to `fs`. When invoking commands on the shell, escaping should be handled by the shell library.

### Testing
<!-- Please describe in detail how you tested your changes. -->
None. Opening PR here for CI.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
