### PR TITLE
Refactor plugin_fetch.spec

### DIFF
--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -25,21 +25,6 @@ var helpers = require('../spec/helpers');
 var path = require('path');
 var events = require('cordova-common').events;
 
-var testPluginVersions = [
-    '0.0.2',
-    '0.7.0',
-    '1.0.0',
-    '1.1.0',
-    '1.1.3',
-    '1.3.0',
-    '1.7.0',
-    '1.7.1',
-    '2.0.0-rc.1',
-    '2.0.0-rc.2',
-    '2.0.0',
-    '2.3.0'
-];
-
 var cordovaVersion = '3.4.2';
 
 var tempDir = helpers.tmpDir('plugin_fetch_spec');
@@ -136,7 +121,20 @@ describe('plugin fetching version selection', function () {
             'version': '2.3.0',
             'name': 'test-plugin',
             'engines': { 'cordovaDependencies': {} },
-            'versions': testPluginVersions
+            'versions': [
+                '0.0.2',
+                '0.7.0',
+                '1.0.0',
+                '1.1.0',
+                '1.1.3',
+                '1.3.0',
+                '1.7.0',
+                '1.7.1',
+                '2.0.0-rc.1',
+                '2.0.0-rc.2',
+                '2.0.0',
+                '2.3.0'
+            ]
         };
     });
 
@@ -317,31 +315,24 @@ describe('plugin fetching version selection', function () {
     });
 
     it('Test 015 : should not fail if there is no engine in the npm info', function () {
-        return pluginAdd.getFetchVersion(project, {
-            version: '2.3.0',
-            name: 'test-plugin',
-            versions: testPluginVersions
-        }, cordovaVersion)
-            .then(function (toFetch) {
-                expect(toFetch).toBe(null);
-            });
+        delete testPlugin.engines;
+
+        return getFetchVersion(testPlugin).then(version => {
+            expect(version).toBe(null);
+            expectUnmetRequirements([]);
+        });
     });
 
     it('Test 016 : should not fail if there is no cordovaDependencies in the engines', function () {
+        testPlugin.engines = {
+            'node': '>7.0.0',
+            'npm': '~2.0.0'
+        };
 
-        return pluginAdd.getFetchVersion(project, {
-            version: '2.3.0',
-            name: 'test-plugin',
-            versions: testPluginVersions,
-            engines: {
-                'node': '>7.0.0',
-                'npm': '~2.0.0'
-            }
-        }, cordovaVersion)
-            .then(function (toFetch) {
-                expect(toFetch).toBe(null);
-                expectUnmetRequirements([]);
-            });
+        return getFetchVersion(testPlugin).then(version => {
+            expect(version).toBe(null);
+            expectUnmetRequirements([]);
+        });
     });
 
     it('Test 017 : should handle extra whitespace', function () {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -152,7 +152,13 @@ function removeTestProject () {
 }
 
 describe('plugin fetching version selection', function () {
-    createTestProject();
+    beforeAll(() => {
+        createTestProject();
+    });
+    afterAll(() => {
+        removeTestProject();
+    });
+
     beforeEach(function () {
         jasmine.addMatchers({
             'toContainArray': function () {
@@ -523,9 +529,5 @@ describe('plugin fetching version selection', function () {
         ]);
 
         return testEngineWithProject(after, testEngine, '1.3.0');
-    });
-
-    it('Test 025 : clean up after plugin fetch spec', function () {
-        removeTestProject();
     });
 });

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -19,17 +19,17 @@
 
 // TODO: all of these tests should go as unit tests to src/cordova/plugin/add
 
-var fs = require('fs-extra');
-var pluginAdd = require('../src/cordova/plugin/add');
-var helpers = require('../spec/helpers');
-var path = require('path');
-var events = require('cordova-common').events;
+const fs = require('fs-extra');
+const pluginAdd = require('../src/cordova/plugin/add');
+const helpers = require('../spec/helpers');
+const path = require('path');
+const events = require('cordova-common').events;
 
-var cordovaVersion = '3.4.2';
+const cordovaVersion = '3.4.2';
 
 // Used to extract the constraint, the installed version, and the required
 // semver range from a warning message
-var UNMET_REQ_REGEX = /\s+([^\s]+)[^\d]+(\d+\.\d+\.\d+) in project, (.+) required\)/;
+const UNMET_REQ_REGEX = /\s+([^\s]+)[^\d]+(\d+\.\d+\.\d+) in project, (.+) required\)/;
 
 function unmetRequirementsCollector (warning) {
     const match = UNMET_REQ_REGEX.exec(warning);

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -166,7 +166,7 @@ describe('plugin fetching version selection', function () {
             getPlatformRequirement('6.1.1')
         ]);
         return testEngineWithProject(after, testEngine, '1.3.0');
-    }, 6000);
+    });
 
     it('Test 002 : should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function () {
         var testEngine = {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -132,31 +132,26 @@ function getWarningCheckCallback (requirements) {
         checkUnmetRequirements(requirements);
     };
 }
-var fixtures = path.join(__dirname, '..', 'spec', 'cordova', 'fixtures');
-
-function createTestProject () {
-    // Get the base project
-    fs.copySync(path.join(fixtures, 'base'), project);
-
-    // Copy a platform and a plugin to our sample project
-    fs.copySync(
-        path.join(fixtures, 'platforms', helpers.testPlatform),
-        path.join(project, 'platforms', helpers.testPlatform));
-    fs.copySync(
-        path.join(fixtures, 'plugins/android'),
-        path.join(project, 'plugins/android'));
-}
-
-function removeTestProject () {
-    fs.removeSync(tempDir);
-}
 
 describe('plugin fetching version selection', function () {
     beforeAll(() => {
-        createTestProject();
+        const fixtures = path.join(__dirname, '../spec/cordova/fixtures');
+
+        // Copy the base project as our test project
+        fs.copySync(path.join(fixtures, 'base'), project);
+
+        // Copy a platform and a plugin to our test project
+        fs.copySync(
+            path.join(fixtures, 'platforms', helpers.testPlatform),
+            path.join(project, 'platforms', helpers.testPlatform));
+        fs.copySync(
+            path.join(fixtures, 'plugins/android'),
+            path.join(project, 'plugins/android'));
     });
+
     afterAll(() => {
-        removeTestProject();
+        process.chdir(__dirname);
+        fs.removeSync(tempDir);
     });
 
     beforeEach(function () {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -89,15 +89,8 @@ function checkUnmetRequirements (requirements) {
             });
         }
     });
-    expect(reqWarnings.length).toEqual(requirements.length);
 
-    requirements.forEach(function (requirement) {
-        expect(reqWarnings).toContainArray(function (extractedWarning) {
-            return extractedWarning.dependency === requirement.dependency.trim() &&
-                    extractedWarning.installed === requirement.installed.trim() &&
-                    extractedWarning.required === requirement.required.trim();
-        });
-    });
+    expect(reqWarnings).toEqual(jasmine.arrayWithExactContents(requirements));
 }
 
 // Helper functions for creating the requirements objects taken by
@@ -155,24 +148,6 @@ describe('plugin fetching version selection', function () {
     });
 
     beforeEach(function () {
-        jasmine.addMatchers({
-            'toContainArray': function () {
-                return {
-                    compare: function (actual, expected) {
-                        var result = {};
-                        result.pass = false;
-                        for (var i = 0; i < actual.length; i++) {
-                            if (expected(actual[i])) {
-                                result.pass = true;
-                                break;
-                            }
-                        }
-                        return result;
-                    }
-                };
-            }
-        });
-
         warnings = [];
     });
 

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -27,13 +27,6 @@ var events = require('cordova-common').events;
 
 var cordovaVersion = '3.4.2';
 
-var tempDir = helpers.tmpDir('plugin_fetch_spec');
-var project = path.join(tempDir, 'project');
-
-function getFetchVersion (plugin) {
-    return pluginAdd.getFetchVersion(project, plugin, cordovaVersion);
-}
-
 // Used to extract the constraint, the installed version, and the required
 // semver range from a warning message
 var UNMET_REQ_REGEX = /\s+([^\s]+)[^\d]+(\d+\.\d+\.\d+) in project, (.+) required\)/;
@@ -84,8 +77,13 @@ function getPluginRequirement (requirement) {
 }
 
 describe('plugin fetching version selection', function () {
+    let tempDir, project, testPlugin;
+
     beforeAll(() => {
         const fixtures = path.join(__dirname, '../spec/cordova/fixtures');
+
+        tempDir = helpers.tmpDir('plugin_fetch_spec');
+        project = path.join(tempDir, 'project');
 
         // Copy the base project as our test project
         fs.copySync(path.join(fixtures, 'base'), project);
@@ -104,7 +102,6 @@ describe('plugin fetching version selection', function () {
         fs.removeSync(tempDir);
     });
 
-    let testPlugin;
     beforeEach(function () {
         unmetRequirementsCollector.store = [];
 
@@ -136,6 +133,10 @@ describe('plugin fetching version selection', function () {
     afterEach(() => {
         events.removeListener('warn', unmetRequirementsCollector);
     });
+
+    function getFetchVersion (plugin) {
+        return pluginAdd.getFetchVersion(project, plugin, cordovaVersion);
+    }
 
     it('Test 001 : should handle a mix of upper bounds and single versions', function () {
         testPlugin.engines.cordovaDependencies = {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -20,7 +20,7 @@
 // TODO: all of these tests should go as unit tests to src/cordova/plugin/add
 
 var fs = require('fs-extra');
-var plugin = require('../src/cordova/plugin/add');
+var pluginAdd = require('../src/cordova/plugin/add');
 var helpers = require('../spec/helpers');
 var path = require('path');
 var events = require('cordova-common').events;
@@ -60,7 +60,7 @@ events.on('warn', function (warning) {
 // Tests a sample engine against the installed platforms/plugins in our test
 // project
 function testEngineWithProject (done, testEngine, testResult) {
-    return plugin.getFetchVersion(project,
+    return pluginAdd.getFetchVersion(project,
         {
             'version': '2.3.0',
             'name': 'test-plugin',
@@ -343,7 +343,7 @@ describe('plugin fetching version selection', function () {
     });
 
     it('Test 015 : should not fail if there is no engine in the npm info', function () {
-        return plugin.getFetchVersion(project, {
+        return pluginAdd.getFetchVersion(project, {
             version: '2.3.0',
             name: 'test-plugin',
             versions: testPluginVersions
@@ -356,7 +356,7 @@ describe('plugin fetching version selection', function () {
     it('Test 016 : should not fail if there is no cordovaDependencies in the engines', function () {
         var after = getWarningCheckCallback([]);
 
-        return plugin.getFetchVersion(project, {
+        return pluginAdd.getFetchVersion(project, {
             version: '2.3.0',
             name: 'test-plugin',
             versions: testPluginVersions,

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -76,7 +76,7 @@ function getPluginRequirement (requirement) {
     };
 }
 
-describe('plugin fetching version selection', function () {
+describe('plugin fetching version selection', () => {
     let tempDir, project, testPlugin;
 
     beforeAll(() => {
@@ -102,7 +102,7 @@ describe('plugin fetching version selection', function () {
         fs.removeSync(tempDir);
     });
 
-    beforeEach(function () {
+    beforeEach(() => {
         unmetRequirementsCollector.store = [];
 
         // We generate warnings when we don't fetch latest. Collect them to make sure we
@@ -138,7 +138,7 @@ describe('plugin fetching version selection', function () {
         return pluginAdd.getFetchVersion(project, plugin, cordovaVersion);
     }
 
-    it('Test 001 : should handle a mix of upper bounds and single versions', function () {
+    it('Test 001 : should handle a mix of upper bounds and single versions', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': { 'cordova-android': '1.0.0' },
             '0.0.2': { 'cordova-android': '>1.0.0' },
@@ -155,7 +155,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 002 : should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', function () {
+    it('Test 002 : should apply upper bound engine constraints when there are no unspecified constraints above the upper bound', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.0.0': { 'cordova-android': '>2.0.0' },
             '1.7.0': { 'cordova-android': '>4.0.0' },
@@ -172,7 +172,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 003 : should apply upper bound engine constraints when there are unspecified constraints above the upper bound', function () {
+    it('Test 003 : should apply upper bound engine constraints when there are unspecified constraints above the upper bound', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': {},
             '2.0.0': { 'cordova-android': '~5.0.0' },
@@ -185,7 +185,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 004 : should handle the case where there are no constraints for earliest releases', function () {
+    it('Test 004 : should handle the case where there are no constraints for earliest releases', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.0.0': { 'cordova-android': '~5.0.0' }
         };
@@ -196,7 +196,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 005 : should handle the case where the lowest version is unsatisfied', function () {
+    it('Test 005 : should handle the case where the lowest version is unsatisfied', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.2': { 'cordova-android': '~5.0.0' }
         };
@@ -207,7 +207,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 006 : should handle upperbounds if no single version constraints are given', function () {
+    it('Test 006 : should handle upperbounds if no single version constraints are given', () => {
         testPlugin.engines.cordovaDependencies = {
             '<1.0.0': { 'cordova-android': '<2.0.0' }
         };
@@ -218,7 +218,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 007 : should apply upper bounds greater than highest version', function () {
+    it('Test 007 : should apply upper bounds greater than highest version', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': {},
             '<5.0.0': { 'cordova-android': '<2.0.0' }
@@ -230,7 +230,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 008 : should treat empty constraints as satisfied', function () {
+    it('Test 008 : should treat empty constraints as satisfied', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.0.0': {},
             '1.1.0': { 'cordova-android': '>5.0.0' }
@@ -242,7 +242,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 009 : should ignore an empty cordovaDependencies entry', function () {
+    it('Test 009 : should ignore an empty cordovaDependencies entry', () => {
         testPlugin.engines.cordovaDependencies = {};
 
         return getFetchVersion(testPlugin).then(version => {
@@ -251,7 +251,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 010 : should ignore a badly formatted semver range', function () {
+    it('Test 010 : should ignore a badly formatted semver range', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.1.3': { 'cordova-android': 'badSemverRange' }
         };
@@ -262,7 +262,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 011 : should respect unreleased versions in constraints', function () {
+    it('Test 011 : should respect unreleased versions in constraints', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.0.0': { 'cordova-android': '3.1.0' },
             '1.1.2': { 'cordova-android': '6.1.1' },
@@ -275,7 +275,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 012 : should respect plugin constraints', function () {
+    it('Test 012 : should respect plugin constraints', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': { 'ca.filmaj.AndroidPlugin': '1.2.0' },
             '1.1.3': { 'ca.filmaj.AndroidPlugin': '<5.0.0 || >2.3.0' },
@@ -288,7 +288,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 013 : should respect cordova constraints', function () {
+    it('Test 013 : should respect cordova constraints', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': { 'cordova': '>1.0.0' },
             '1.1.3': { 'cordova': '<3.0.0 || >4.0.0' },
@@ -301,7 +301,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 014 : should not include pre-release versions', function () {
+    it('Test 014 : should not include pre-release versions', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': {},
             '2.0.0': { 'cordova-android': '>5.0.0' }
@@ -314,7 +314,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 015 : should not fail if there is no engine in the npm info', function () {
+    it('Test 015 : should not fail if there is no engine in the npm info', () => {
         delete testPlugin.engines;
 
         return getFetchVersion(testPlugin).then(version => {
@@ -323,7 +323,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 016 : should not fail if there is no cordovaDependencies in the engines', function () {
+    it('Test 016 : should not fail if there is no cordovaDependencies in the engines', () => {
         testPlugin.engines = {
             'node': '>7.0.0',
             'npm': '~2.0.0'
@@ -335,7 +335,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 017 : should handle extra whitespace', function () {
+    it('Test 017 : should handle extra whitespace', () => {
         testPlugin.engines.cordovaDependencies = {
             '  1.0.0    ': {},
             '2.0.0   ': { ' cordova-android': '~5.0.0   ' },
@@ -348,7 +348,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 018 : should ignore badly typed version requirement entries', function () {
+    it('Test 018 : should ignore badly typed version requirement entries', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.1.0': ['cordova', '5.0.0'],
             '1.3.0': undefined,
@@ -361,7 +361,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 019 : should ignore badly typed constraint entries', function () {
+    it('Test 019 : should ignore badly typed constraint entries', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.2': { 'cordova': 1 },
             '0.7.0': { 'cordova': {} },
@@ -377,7 +377,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 020 : should ignore bad semver versions', function () {
+    it('Test 020 : should ignore bad semver versions', () => {
         testPlugin.engines.cordovaDependencies = {
             '0.0.0': { 'cordova-android': '5.0.0' },
             'notAVersion': { 'cordova-android': '3.1.0' },
@@ -393,7 +393,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 021 : should not fail if there are bad semver versions', function () {
+    it('Test 021 : should not fail if there are bad semver versions', () => {
         testPlugin.engines.cordovaDependencies = {
             'notAVersion': { 'cordova-android': '3.1.0' },
             '^1.1.2': { 'cordova-android': '3.1.0' },
@@ -410,7 +410,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 022 : should properly warn about multiple unmet requirements', function () {
+    it('Test 022 : should properly warn about multiple unmet requirements', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.7.0': {
                 'cordova-android': '>5.1.0',
@@ -428,7 +428,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 023 : should properly warn about both unmet latest and upper bound requirements', function () {
+    it('Test 023 : should properly warn about both unmet latest and upper bound requirements', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.7.0': { 'cordova-android': '>5.1.0' },
             '<5.0.0': {
@@ -446,7 +446,7 @@ describe('plugin fetching version selection', function () {
         });
     });
 
-    it('Test 024 : should not warn about versions past latest', function () {
+    it('Test 024 : should not warn about versions past latest', () => {
         testPlugin.engines.cordovaDependencies = {
             '1.7.0': { 'cordova-android': '>5.1.0' },
             '7.0.0': {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -20,10 +20,10 @@
 // TODO: all of these tests should go as unit tests to src/cordova/plugin/add
 
 const fs = require('fs-extra');
-const pluginAdd = require('../src/cordova/plugin/add');
-const helpers = require('../spec/helpers');
 const path = require('path');
-const events = require('cordova-common').events;
+const { events } = require('cordova-common');
+const helpers = require('../spec/helpers');
+const pluginAdd = require('../src/cordova/plugin/add');
 
 const cordovaVersion = '3.4.2';
 

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -19,10 +19,9 @@
 
 // TODO: all of these tests should go as unit tests to src/cordova/plugin/add
 
-const fs = require('fs-extra');
-const path = require('path');
 const { events } = require('cordova-common');
-const helpers = require('../spec/helpers');
+const cordovaUtil = require('../src/cordova/util');
+const pluginUtil = require('../src/cordova/plugin/util');
 const pluginAdd = require('../src/cordova/plugin/add');
 
 const cordovaVersion = '3.4.2';
@@ -77,30 +76,7 @@ function getPluginRequirement (requirement) {
 }
 
 describe('plugin fetching version selection', () => {
-    let tempDir, project, testPlugin;
-
-    beforeAll(() => {
-        const fixtures = path.join(__dirname, '../spec/cordova/fixtures');
-
-        tempDir = helpers.tmpDir('plugin_fetch_spec');
-        project = path.join(tempDir, 'project');
-
-        // Copy the base project as our test project
-        fs.copySync(path.join(fixtures, 'base'), project);
-
-        // Copy a platform and a plugin to our test project
-        fs.copySync(
-            path.join(fixtures, 'platforms', helpers.testPlatform),
-            path.join(project, 'platforms', helpers.testPlatform));
-        fs.copySync(
-            path.join(fixtures, 'plugins/android'),
-            path.join(project, 'plugins/android'));
-    });
-
-    afterAll(() => {
-        process.chdir(__dirname);
-        fs.removeSync(tempDir);
-    });
+    let project, testPlugin;
 
     beforeEach(() => {
         unmetRequirementsCollector.store = [];
@@ -128,6 +104,13 @@ describe('plugin fetching version selection', () => {
                 '2.3.0'
             ]
         };
+
+        spyOn(pluginUtil, 'getInstalledPlugins').and.returnValue([
+            { id: 'ca.filmaj.AndroidPlugin', version: '4.2.0' }
+        ]);
+        spyOn(cordovaUtil, 'getInstalledPlatformsWithVersions').and.returnValue(
+            Promise.resolve({ android: '3.1.0' })
+        );
     });
 
     afterEach(() => {

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -96,7 +96,7 @@ function checkUnmetRequirements (requirements) {
             return extractedWarning.dependency === requirement.dependency.trim() &&
                     extractedWarning.installed === requirement.installed.trim() &&
                     extractedWarning.required === requirement.required.trim();
-        }, requirement);
+        });
     });
 }
 

--- a/integration-tests/plugin_fetch.spec.js
+++ b/integration-tests/plugin_fetch.spec.js
@@ -64,7 +64,7 @@ events.on('warn', function (warning) {
 // Checks the warnings that were printed by the CLI to ensure that the code is
 // listing the correct reasons for failure. Checks against the global warnings
 // object which is reset before each test
-function checkUnmetRequirements (requirements) {
+function expectUnmetRequirements (requirements) {
     var reqWarnings = [];
 
     warnings.forEach(function (warning) {
@@ -82,7 +82,7 @@ function checkUnmetRequirements (requirements) {
 }
 
 // Helper functions for creating the requirements objects taken by
-// checkUnmetRequirements()
+// expectUnmetRequirements()
 function getPlatformRequirement (requirement) {
     return {
         dependency: 'cordova-android',
@@ -153,7 +153,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.3.0');
-            checkUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
+            expectUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
         });
     });
 
@@ -170,7 +170,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
+            expectUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
         });
     });
 
@@ -183,7 +183,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.7.1');
-            checkUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
         });
     });
 
@@ -194,7 +194,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('0.7.0');
-            checkUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
         });
     });
 
@@ -205,7 +205,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
         });
     });
 
@@ -216,7 +216,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('2.3.0');
-            checkUnmetRequirements([]);
+            expectUnmetRequirements([]);
         });
     });
 
@@ -228,7 +228,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([ getPlatformRequirement('<2.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('<2.0.0') ]);
         });
     });
 
@@ -240,7 +240,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.0.0');
-            checkUnmetRequirements([ getPlatformRequirement('>5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('>5.0.0') ]);
         });
     });
 
@@ -249,7 +249,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([]);
+            expectUnmetRequirements([]);
         });
     });
 
@@ -260,7 +260,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('2.3.0');
-            checkUnmetRequirements([]);
+            expectUnmetRequirements([]);
         });
     });
 
@@ -273,7 +273,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.1.0');
-            checkUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
+            expectUnmetRequirements([ getPlatformRequirement('6.1.1') ]);
         });
     });
 
@@ -286,7 +286,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('2.0.0');
-            checkUnmetRequirements([ getPluginRequirement('6.1.1') ]);
+            expectUnmetRequirements([ getPluginRequirement('6.1.1') ]);
         });
     });
 
@@ -299,7 +299,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.1.0');
-            checkUnmetRequirements([ getCordovaRequirement('6.1.1') ]);
+            expectUnmetRequirements([ getCordovaRequirement('6.1.1') ]);
         });
     });
 
@@ -312,7 +312,7 @@ describe('plugin fetching version selection', function () {
         // Should not return 2.0.0-rc.2
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.7.1');
-            checkUnmetRequirements([ getPlatformRequirement('>5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('>5.0.0') ]);
         });
     });
 
@@ -340,7 +340,7 @@ describe('plugin fetching version selection', function () {
         }, cordovaVersion)
             .then(function (toFetch) {
                 expect(toFetch).toBe(null);
-                checkUnmetRequirements([]);
+                expectUnmetRequirements([]);
             });
     });
 
@@ -353,7 +353,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.7.1');
-            checkUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('~5.0.0') ]);
         });
     });
 
@@ -366,7 +366,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('2.3.0');
-            checkUnmetRequirements([]);
+            expectUnmetRequirements([]);
         });
     });
 
@@ -382,7 +382,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('2.3.0');
-            checkUnmetRequirements([]);
+            expectUnmetRequirements([]);
         });
     });
 
@@ -398,7 +398,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([ getPlatformRequirement('5.0.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('5.0.0') ]);
         });
     });
 
@@ -415,7 +415,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.7.1');
-            checkUnmetRequirements([ getPlatformRequirement('5.1.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('5.1.0') ]);
         });
     });
 
@@ -430,7 +430,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.3.0');
-            checkUnmetRequirements([
+            expectUnmetRequirements([
                 getPlatformRequirement('>5.1.0'),
                 getPluginRequirement('3.1.0')
             ]);
@@ -448,7 +448,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe(null);
-            checkUnmetRequirements([
+            expectUnmetRequirements([
                 getPlatformRequirement('>5.1.0 AND >7.1.0'),
                 getPluginRequirement('3.1.0')
             ]);
@@ -466,7 +466,7 @@ describe('plugin fetching version selection', function () {
 
         return getFetchVersion(testPlugin).then(version => {
             expect(version).toBe('1.3.0');
-            checkUnmetRequirements([ getPlatformRequirement('>5.1.0') ]);
+            expectUnmetRequirements([ getPlatformRequirement('>5.1.0') ]);
         });
     });
 });

--- a/spec/cordova/plugin/add.getFetchVersion.spec.js
+++ b/spec/cordova/plugin/add.getFetchVersion.spec.js
@@ -17,12 +17,10 @@
     under the License.
 */
 
-// TODO: all of these tests should go as unit tests to src/cordova/plugin/add
-
 const { events } = require('cordova-common');
-const cordovaUtil = require('../src/cordova/util');
-const pluginUtil = require('../src/cordova/plugin/util');
-const pluginAdd = require('../src/cordova/plugin/add');
+const cordovaUtil = require('../../../src/cordova/util');
+const pluginUtil = require('../../../src/cordova/plugin/util');
+const pluginAdd = require('../../../src/cordova/plugin/add');
 
 const cordovaVersion = '3.4.2';
 

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -363,8 +363,8 @@ describe('cordova/plugin/add', function () {
     });
 
     // TODO: reorganize these tests once the logic here is understood! -filmaj
-    // TODO: rewrite the tests from integration-tests/plugin_fetch.spec.js to here.
     describe('unit tests to replace integration-tests/plugin_fetch.spec.js', function () {
+        // See also the tests in spec/cordova/plugin/add.getFetchVersion.spec.js
         describe('getFetchVersion helper method', function () {
             var pluginInfo;
 


### PR DESCRIPTION
### Motivation and Context
The logic in this test file was not very transparent and it relied on outdated fixtures.


### Description
I refactored the test to be more readable, robust and self contained. Finally I removed the reliance on the outdated fixtures and moved it to `spec` since it is actually a unit test.


### Testing
`npm t`

