### PR TITLE
Fix faulty Promise handling in plugman.uninstall

### DIFF
--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -42,11 +42,9 @@ const plugins = {
     'C': path.join(plugins_dir, 'dependencies', 'C')
 };
 
-// Grab a reference to the original, before someone stubs it
-const { copySync } = fs;
 function setupProject (name) {
     const projectPath = path.join(projectsPath, name);
-    copySync(projectPath, project);
+    fs.copySync(projectPath, project);
 }
 
 describe('plugman/uninstall', () => {
@@ -82,8 +80,6 @@ describe('plugman/uninstall', () => {
         uninstall.__set__('npmUninstall', jasmine.createSpy().and.returnValue(Promise.resolve()));
 
         emit = spyOn(events, 'emit');
-        spyOn(fs, 'writeFileSync');
-        spyOn(fs, 'removeSync');
     });
 
     afterEach(() => {
@@ -102,7 +98,6 @@ describe('plugman/uninstall', () => {
             setupProject('uninstall.test');
 
             spyOn(ActionStack.prototype, 'process').and.returnValue(Promise.resolve());
-            spyOn(fs, 'copySync');
         });
 
         describe('success', function () {

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -79,7 +79,7 @@ describe('plugman/uninstall', () => {
 
     beforeEach(() => {
         uninstall = rewire('../src/plugman/uninstall');
-        uninstall.__set__('npmUninstall', jasmine.createSpy());
+        uninstall.__set__('npmUninstall', jasmine.createSpy().and.returnValue(Promise.resolve()));
 
         emit = spyOn(events, 'emit');
         spyOn(fs, 'writeFileSync');


### PR DESCRIPTION
In the old code, when `projectRoot` was falsy, `promise` was never waited upon.

The bug this fixes probably does not bite anyone in the wild, but it's a bug nonetheless (and it causes tests to be flaky). Maybe we can get it into the next patch release @dpogue?