### PR TITLE
Remove unnecessary spy

### DIFF
--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -21,7 +21,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const rewire = require('rewire');
 
-const { ActionStack, PluginInfo, events } = require('cordova-common');
+const { PluginInfo, events } = require('cordova-common');
 const common = require('../spec/common');
 const install = require('../src/plugman/install');
 const platforms = require('../src/platforms/platforms');
@@ -96,8 +96,6 @@ describe('plugman/uninstall', () => {
 
         beforeEach(function () {
             setupProject('uninstall.test');
-
-            spyOn(ActionStack.prototype, 'process').and.returnValue(Promise.resolve());
         });
 
         describe('success', function () {


### PR DESCRIPTION
### Motivation and Context
The stubbing is not actually needed for the tests. It actually caused problems after some refactoring I am currently working on, because the stubbing is not correct either. `ActionStack.prototype.process` actually has to return a `Q` instance when called from current `cordova-android`.


### Testing
The tests that were using this stub still pass.
