### PR TITLE
Remove compatibility code for plugins added by cordova@<5.4.0

### DIFF
--- a/src/cordova/prepare.js
+++ b/src/cordova/prepare.js
@@ -20,9 +20,7 @@
 var cordova_util = require('./util');
 var ConfigParser = require('cordova-common').ConfigParser;
 var PlatformJson = require('cordova-common').PlatformJson;
-var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var PlatformMunger = require('cordova-common').ConfigChanges.PlatformMunger;
-var events = require('cordova-common').events;
 var platforms = require('../platforms/platforms');
 var HooksRunner = require('../hooks/HooksRunner');
 var restore = require('./restore-util');
@@ -31,7 +29,6 @@ var config = require('./config');
 
 exports = module.exports = prepare;
 module.exports.preparePlatforms = preparePlatforms;
-module.exports.restoreMissingPluginsForPlatform = restoreMissingPluginsForPlatform;
 
 function prepare (options) {
     return Promise.resolve().then(function () {
@@ -89,85 +86,23 @@ function preparePlatforms (platformList, projectRoot, options) {
                 rootConfigXml: cordova_util.projectConfig(projectRoot)
             }
         };
-        // CB-9987 We need to reinstall the plugins for the platform it they were added by cordova@<5.4.0
-        return module.exports.restoreMissingPluginsForPlatform(platform, projectRoot, options)
+        // platformApi prepare takes care of all functionality
+        // which previously had been executed by cordova.prepare:
+        //   - reset config.xml and then merge changes from project's one,
+        //   - update www directory from project's one and merge assets from platform_www,
+        //   - reapply config changes, made by plugins,
+        //   - update platform's project
+        // Please note that plugins' changes, such as installed js files, assets and
+        // config changes is not being reinstalled on each prepare.
+        var platformApi = platforms.getPlatformApi(platform);
+        return platformApi.prepare(project, Object.assign({}, options))
             .then(function () {
-                // platformApi prepare takes care of all functionality
-                // which previously had been executed by cordova.prepare:
-                //   - reset config.xml and then merge changes from project's one,
-                //   - update www directory from project's one and merge assets from platform_www,
-                //   - reapply config changes, made by plugins,
-                //   - update platform's project
-                // Please note that plugins' changes, such as installed js files, assets and
-                // config changes is not being reinstalled on each prepare.
-                var platformApi = platforms.getPlatformApi(platform);
-                return platformApi.prepare(project, Object.assign({}, options))
-                    .then(function () {
-                        // Handle edit-config in config.xml
-                        var platformRoot = path.join(projectRoot, 'platforms', platform);
-                        var platformJson = PlatformJson.load(platformRoot, platform);
-                        var munger = new PlatformMunger(platform, platformRoot, platformJson);
-                        // the boolean argument below is "should_increment"
-                        munger.add_config_changes(project.projectConfig, true).save_all();
-                    });
+                // Handle edit-config in config.xml
+                var platformRoot = path.join(projectRoot, 'platforms', platform);
+                var platformJson = PlatformJson.load(platformRoot, platform);
+                var munger = new PlatformMunger(platform, platformRoot, platformJson);
+                // the boolean argument below is "should_increment"
+                munger.add_config_changes(project.projectConfig, true).save_all();
             });
     }));
-}
-
-/**
- * Ensures that plugins, installed with previous versions of CLI (<5.4.0) are
- *   readded to platform correctly. Also triggers regeneration of
- *   cordova_plugins.js file.
- *
- * @param   {String}  platform     Platform name to check for installed plugins
- * @param   {String}  projectRoot  A current cordova project location
- * @param   {Object}  [options]    Options that will be passed to
- *   PlatformApi.pluginAdd/Remove. This object will be extended with plugin
- *   variables, used to install the plugin initially (picked from "old"
- *   plugins/<platform>.json)
- *
- * @return  {Promise}               Promise that'll be fulfilled if all the
- *   plugins reinstalled properly.
- */
-function restoreMissingPluginsForPlatform (platform, projectRoot, options) {
-    events.emit('verbose', 'Checking for any plugins added to the project that have not been installed in ' + platform + ' platform');
-    // Flow:
-    // 1. Compare <platform>.json file in <project>/plugins ("old") and platforms/<platform> ("new")
-    // 2. If there is any differences - merge "old" one into "new"
-    // 3. Reinstall plugins that are missing and was merged on previous step
-
-    var oldPlatformJson = PlatformJson.load(path.join(projectRoot, 'plugins'), platform);
-    var platformJson = PlatformJson.load(path.join(projectRoot, 'platforms', platform), platform);
-    var missingPlugins = Object.keys(oldPlatformJson.root.installed_plugins)
-        .concat(Object.keys(oldPlatformJson.root.dependent_plugins))
-        .reduce(function (result, candidate) {
-            if (!platformJson.isPluginInstalled(candidate)) {
-                result.push({ name: candidate,
-                    // Note: isPluginInstalled is actually returns not a boolean,
-                    // but object which corresponds to this particular plugin
-                    variables: oldPlatformJson.isPluginInstalled(candidate) });
-            }
-            return result;
-        }, []);
-
-    if (missingPlugins.length === 0) {
-        events.emit('verbose', 'No differences found between plugins added to project and installed in ' +
-            platform + ' platform. Continuing...');
-        return Promise.resolve();
-    }
-    var api = platforms.getPlatformApi(platform);
-    var provider = new PluginInfoProvider();
-    return missingPlugins.reduce(function (promise, plugin) {
-        return promise.then(function () {
-            var pluginOptions = options || {};
-            pluginOptions.variables = plugin.variables;
-            pluginOptions.usePlatformWww = true;
-            events.emit('verbose', 'Reinstalling missing plugin ' + plugin.name + ' in ' + platform + ' platform');
-            var pluginInfo = provider.get(path.join(projectRoot, 'plugins', plugin.name));
-            return api.removePlugin(pluginInfo, pluginOptions)
-                .then(function () {
-                    return api.addPlugin(pluginInfo, pluginOptions);
-                });
-        });
-    }, Promise.resolve());
 }


### PR DESCRIPTION
This remove s code that is commented with:
> CB-9987 We need to reinstall the plugins for the platform it they were added by cordova@<5.4.0

I'm unsure as to the kind of release this should go in. Since we probably officially removed support for cordova@<5.4.0, this should be non-breaking. If you want to be very strict, this would be breaking. Opinions?