### PR TITLE
Simpler and better cordova/util.getPlatformApiFunction

### DIFF
--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -62,7 +62,7 @@ describe('platforms/platforms', () => {
             expect(platformApi).toBeDefined();
             expect(platformApi.platform).toEqual('windows');
             expect(events.emit.calls.count()).toEqual(1);
-            expect(events.emit.calls.argsFor(0)[1]).toMatch('PlatformApi successfully found');
+            expect(events.emit.calls.argsFor(0)[1]).toMatch('Platform API successfully found in:');
             expect(util.convertToRealPathSafe.calls.count()).toEqual(1);
             expect(util.isCordova.calls.count()).toEqual(0);
             expect(util.requireNoCache.calls.count()).toEqual(1);

--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -62,7 +62,7 @@ describe('platforms/platforms', () => {
             expect(platformApi).toBeDefined();
             expect(platformApi.platform).toEqual('windows');
             expect(events.emit.calls.count()).toEqual(1);
-            expect(events.emit.calls.argsFor(0)[1]).toEqual('PlatformApi successfully found for platform windows');
+            expect(events.emit.calls.argsFor(0)[1]).toMatch('PlatformApi successfully found');
             expect(util.convertToRealPathSafe.calls.count()).toEqual(1);
             expect(util.isCordova.calls.count()).toEqual(0);
             expect(util.requireNoCache.calls.count()).toEqual(1);

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -220,7 +220,7 @@ describe('util module', function () {
                 var specPlugDir = __dirname.replace('spec-cordova', 'spec-plugman');
                 util.getPlatformApiFunction((path.join(specPlugDir, 'fixtures', 'projects', 'platformApi', 'platforms', 'windows', 'cordova', 'Api.js')), 'windows');
                 expect(events.emit.calls.count()).toBe(1);
-                expect(events.emit.calls.argsFor(0)[1]).toMatch('PlatformApi successfully found');
+                expect(events.emit.calls.argsFor(0)[1]).toMatch('Platform API successfully found in:');
             });
         });
     });

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -220,7 +220,7 @@ describe('util module', function () {
                 var specPlugDir = __dirname.replace('spec-cordova', 'spec-plugman');
                 util.getPlatformApiFunction((path.join(specPlugDir, 'fixtures', 'projects', 'platformApi', 'platforms', 'windows', 'cordova', 'Api.js')), 'windows');
                 expect(events.emit.calls.count()).toBe(1);
-                expect(events.emit.calls.argsFor(0)[1]).toBe('PlatformApi successfully found for platform windows');
+                expect(events.emit.calls.argsFor(0)[1]).toMatch('PlatformApi successfully found');
             });
         });
     });

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -359,15 +359,15 @@ function getPlatformApiFunction (dir) {
         PlatformApi = exports.requireNoCache(dir);
     } catch (err) {
         // Module not found or threw error during loading
-        err.message = `Unable to load Platform API from ${dir}:\n` + err.message;
+        err.message = `Unable to load Platform API from ${dir}:\n${err.message}`;
         throw err;
     }
 
     // Module doesn't implement the expected interface
     if (!PlatformApi || !PlatformApi.createPlatform) {
-        throw new Error(`The package at ${dir} does not appear to implement the Cordova Platform API.`);
+        throw new Error(`The package at "${dir}" does not appear to implement the Cordova Platform API.`);
     }
 
-    events.emit('verbose', 'PlatformApi successfully found in ' + dir);
+    events.emit('verbose', 'Platform API successfully found in: ' + dir);
     return PlatformApi;
 }

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -351,43 +351,23 @@ function isSymbolicLink (dir) {
     }
 }
 
-// Takes a libDir (root of platform where pkgJson is expected) & a platform name.
-// Platform is used if things go wrong, so we can use polyfill.
-// Potential errors : path doesn't exist, module isn't found or can't load.
-// Message prints if file not named Api.js or falls back to pollyfill.
-function getPlatformApiFunction (libDir, platform) {
-    var PlatformApi;
+// Returns the API of the platform contained in `dir`.
+// Potential errors : module isn't found, can't load or doesn't implement the expected interface.
+function getPlatformApiFunction (dir) {
+    let PlatformApi;
     try {
-        // First we need to find whether platform exposes its' API via js module
-        // If it does, then we require and instantiate it.
-        // This will throw if package.json does not exist, or specify 'main'.
-        var apiEntryPoint = require.resolve(libDir);
-        if (apiEntryPoint) {
-            if (path.basename(apiEntryPoint) !== 'Api.js') {
-                events.emit('verbose', 'File name should be called Api.js.');
-                // Not an error, still load it ...
-            }
-            PlatformApi = exports.requireNoCache(apiEntryPoint);
-            if (!PlatformApi.createPlatform) {
-                PlatformApi = null;
-                events.emit('error', 'Does not appear to implement platform Api.');
-            } else {
-                events.emit('verbose', 'PlatformApi successfully found for platform ' + platform);
-            }
-        } else {
-            events.emit('verbose', 'No Api.js entry point found.');
-        }
+        PlatformApi = exports.requireNoCache(dir);
     } catch (err) {
-        // Emit the err, someone might care ...
-        events.emit('warn', 'Unable to load PlatformApi from platform. ' + err);
-        if (!platforms[platform]) {
-            events.emit('error', 'The platform "' + platform + '" does not appear to be a valid cordova platform. It is missing API.js. ' + platform + ' not supported.');
-        }
+        // Module not found or threw error during loading
+        err.message = `Unable to load Platform API from ${dir}:\n` + err.message;
+        throw err;
     }
 
-    if (!PlatformApi) {
-        throw new Error('Your ' + platform + ' platform does not have Api.js');
+    // Module doesn't implement the expected interface
+    if (!PlatformApi || !PlatformApi.createPlatform) {
+        throw new Error(`The package at ${dir} does not appear to implement the Cordova Platform API.`);
     }
 
+    events.emit('verbose', 'PlatformApi successfully found in ' + dir);
     return PlatformApi;
 }


### PR DESCRIPTION
### Motivation and Context
The logic in `cordova/util.getPlatformApiFunction` was a tad to complex and had a few problems because of that.

During testing I frequently had the situation that an error occurred during loading of a platform API module, mostly because of a missing dependency. This function caught these errors and insted threw an error claiming `'Your ' + platform + ' platform does not have Api.js'` which was plainly wrong and confusing.

On top of that came a dead code branch and IMHO unnecessary checks. Enough reason for a rewrite

AFAICT this method is not publicly exposed, so this should be a minor change at most.

### Description
- The happy path is unchanged as are the situations in which errors are thrown
- The second argument is now unused and could be removed at the call sites in a following or this PR
- The other notable changes all pertain to logged messages:
  - No more warning that file should be called `Api.js`
  - No more special error message if platform is a custom one (`!platforms[platform]`)
  - Improved error message if module doesn't implement the expected interface


### Testing
The existing tests pass.
