### PR TITLE
Prevent masking of errors during testing

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -16,9 +16,16 @@
     specific language governing permissions and limitations
     under the License.
 */
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
-const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+const { events } = require('cordova-common');
+const { SpecReporter } = require('jasmine-spec-reporter');
+
+// Node.js throws an Error if the `error` event is emitted on a EventEmitter
+// instance that has no handlers attached for it. This often masks the actual
+// error that was causing the issue. So we attach a listener here.
+events.on('error', console.error);
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(new SpecReporter({


### PR DESCRIPTION
### Motivation and Context
Node.js throws an `Error` if the `error` event is emitted on a `EventEmitter` instance that has no handlers attached for it. This is usually the case during testing and often masks the actual error that is causing the issue.

### Description
We attach a listener to just log error events to console. During passing tests runs, no additional output is generated.



