### PR TITLE
Replace underscore with modern JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "md5-file": "^4.0.0",
     "read-chunk": "^3.1.0",
     "semver": "^5.6.0",
-    "shebang-command": "^1.2.0",
-    "underscore": "^1.9.1"
+    "shebang-command": "^1.2.0"
   },
   "devDependencies": {
     "codecov": "^3.2.0",

--- a/spec/plugman/variable-merge.spec.js
+++ b/spec/plugman/variable-merge.spec.js
@@ -18,7 +18,6 @@
 */
 var rewire = require('rewire');
 var variable_merge = rewire('../../src/plugman/variable-merge');
-var underscore = require('underscore');
 
 describe('mergeVariables', function () {
     var plugin_info_provider_mock = function () {};
@@ -51,8 +50,7 @@ describe('mergeVariables', function () {
         expect(variable_merge.mergeVariables('some/path', 'android', opts)).toEqual({});
     });
     it('should throw error if variables are missing', function () {
-        plugin_info.getPreferences.and.returnValue({});
-        spyOn(underscore, 'difference').and.returnValue(['missing variable']);
+        plugin_info.getPreferences.and.returnValue({ foo: '' });
         var opts = { cli_variables: {} };
         expect(function () { variable_merge.mergeVariables('some/path', 'android', opts); }).toThrow();
     });

--- a/src/cordova/compile.js
+++ b/src/cordova/compile.js
@@ -21,7 +21,6 @@ var cordova_util = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
 var promiseUtil = require('../util/promise-util');
 var platform_lib = require('../platforms/platforms');
-var _ = require('underscore');
 
 // Returns a promise.
 module.exports = function compile (options) {
@@ -36,7 +35,7 @@ module.exports = function compile (options) {
                     return promiseUtil.Q_chainmap(options.platforms, function (platform) {
                         return platform_lib
                             .getPlatformApi(platform)
-                            .build(_.clone(options.options));
+                            .build(Object.assign({}, options.options));
                     });
                 }).then(function () {
                     return hooksRunner.fire('after_compile', options);

--- a/src/cordova/emulate.js
+++ b/src/cordova/emulate.js
@@ -20,7 +20,6 @@
 var cordova_util = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
 var platform_lib = require('../platforms/platforms');
-var _ = require('underscore');
 
 // Returns a promise.
 module.exports = function emulate (options) {
@@ -30,7 +29,7 @@ module.exports = function emulate (options) {
         options.options.device = false;
         options.options.emulator = true;
 
-        var optsClone = _.clone(options.options);
+        var optsClone = Object.assign({}, options.options);
         // This is needed as .build modifies opts
         optsClone.nobuild = true;
 

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -19,7 +19,6 @@ var path = require('path');
 var fs = require('fs-extra');
 var semver = require('semver');
 var fetch = require('cordova-fetch');
-var _ = require('underscore');
 var CordovaError = require('cordova-common').CordovaError;
 var ConfigParser = require('cordova-common').ConfigParser;
 var PlatformJson = require('cordova-common').PlatformJson;
@@ -265,7 +264,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
 
 function getVersionFromConfigFile (platform, cfg) {
     // Get appropriate version from config.xml
-    var engine = _.find(cfg.getEngines(), function (eng) {
+    const engine = cfg.getEngines().find(eng => {
         return eng.name.toLowerCase() === platform.toLowerCase();
     });
 

--- a/src/cordova/prepare.js
+++ b/src/cordova/prepare.js
@@ -28,7 +28,6 @@ var HooksRunner = require('../hooks/HooksRunner');
 var restore = require('./restore-util');
 var path = require('path');
 var config = require('./config');
-var _ = require('underscore');
 
 exports = module.exports = prepare;
 module.exports.preparePlatforms = preparePlatforms;
@@ -102,7 +101,7 @@ function preparePlatforms (platformList, projectRoot, options) {
                 // Please note that plugins' changes, such as installed js files, assets and
                 // config changes is not being reinstalled on each prepare.
                 var platformApi = platforms.getPlatformApi(platform);
-                return platformApi.prepare(project, _.clone(options))
+                return platformApi.prepare(project, Object.assign({}, options))
                     .then(function () {
                         // Handle edit-config in config.xml
                         var platformRoot = path.join(projectRoot, 'platforms', platform);

--- a/src/cordova/run.js
+++ b/src/cordova/run.js
@@ -20,7 +20,6 @@
 var cordova_util = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
 var platform_lib = require('../platforms/platforms');
-var _ = require('underscore');
 
 // Returns a promise.
 module.exports = function run (options) {
@@ -29,7 +28,7 @@ module.exports = function run (options) {
         options = cordova_util.preProcessOptions(options);
 
         // This is needed as .build modifies opts
-        var optsClone = _.clone(options.options);
+        var optsClone = Object.assign({}, options.options);
         optsClone.nobuild = true;
 
         var hooksRunner = new HooksRunner(projectRoot);

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -19,7 +19,6 @@
 
 var fs = require('fs-extra');
 var url = require('url');
-var underscore = require('underscore');
 var semver = require('semver');
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var CordovaError = require('cordova-common').CordovaError;
@@ -200,7 +199,7 @@ function loadLocalPlugins (searchpath, pluginInfoProvider) {
     if (localPlugins) {
         // localPlugins already populated, nothing to do.
         // just in case, make sure it was loaded with the same search path
-        if (!underscore.isEqual(localPlugins.searchpath, searchpath)) {
+        if (localPlugins.searchpath.join(path.delimiter) !== searchpath.join(path.delimiter)) {
             var msg =
                 'loadLocalPlugins called twice with different search paths.' +
                 'Support for this is not implemented.  Using previously cached path.';

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -26,7 +26,6 @@ var PlatformJson = require('cordova-common').PlatformJson;
 var CordovaError = require('cordova-common').CordovaError;
 var platform_modules = require('../platforms/platforms');
 var os = require('os');
-var underscore = require('underscore');
 var events = require('cordova-common').events;
 var HooksRunner = require('../hooks/HooksRunner');
 var isWindows = (os.platform().substr(0, 3) === 'win');
@@ -90,7 +89,7 @@ function possiblyFetch (id, plugins_dir, options) {
         return Promise.resolve(plugin_src_dir);
     }
 
-    var opts = underscore.extend({}, options, {
+    var opts = Object.assign({}, options, {
         client: 'plugman'
     });
     // TODO: without runtime require below, we have a circular dependency.
@@ -544,7 +543,7 @@ function installDependency (dep, install, options) {
                     return Promise.reject(new CordovaError(msg));
                 });
         }
-        opts = underscore.extend({}, options, {
+        opts = Object.assign({}, options, {
             cli_variables: install.filtered_variables,
             is_top_level: false
         });
@@ -553,7 +552,7 @@ function installDependency (dep, install, options) {
     } else {
         events.emit('verbose', 'Plugin dependency "' + dep.id + '" not fetched, retrieving then installing.');
 
-        opts = underscore.extend({}, options, {
+        opts = Object.assign({}, options, {
             cli_variables: install.filtered_variables,
             is_top_level: false,
             subdir: dep.subdir,

--- a/src/plugman/uninstall.js
+++ b/src/plugman/uninstall.js
@@ -22,7 +22,6 @@ var fs = require('fs-extra');
 var ActionStack = require('cordova-common').ActionStack;
 var dependencies = require('./util/dependencies');
 var CordovaError = require('cordova-common').CordovaError;
-var underscore = require('underscore');
 var events = require('cordova-common').events;
 var platform_modules = require('../platforms/platforms');
 var promiseutil = require('../util/promise-util');
@@ -271,7 +270,7 @@ function runUninstallPlatform (actions, platform, project_dir, plugin_dir, plugi
         events.emit('log', 'Uninstalling ' + danglers.length + ' dependent plugins.');
         promise = promiseutil.Q_chainmap(danglers, function (dangler) {
             var dependent_path = path.join(plugins_dir, dangler);
-            var opts = underscore.extend({}, options, {
+            var opts = Object.assign({}, options, {
                 is_top_level: depsInfo.top_level_plugins.indexOf(dangler) > -1,
                 depsInfo: depsInfo
             });


### PR DESCRIPTION
Because we can. The only logical difference should be that `Object.assign` takes _own_ enumerable props, while `_.extend` enumerable.

Resolves #643 