### PR TITLE
Have plugman.createPackageJson create file in plugin dir, not in cwd

### DIFF
--- a/src/plugman/createpackagejson.js
+++ b/src/plugman/createpackagejson.js
@@ -45,8 +45,7 @@ function createPackageJson (plugin_path) {
             events.emit('verbose', 'defaults.json created from plugin.xml');
 
             var initFile = require.resolve('./init-defaults');
-            var dir = process.cwd();
-            return initPkgJson(dir, initFile, {});
+            return initPkgJson(plugin_path, initFile, {});
         })
         .then(_ => {
             events.emit('verbose', 'Package.json successfully created');


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Right now `plugman createpackagejson <plugin dir>` reads values from `plugin.xml` in `<plugin dir>` but creates the `package.json` in `process.cwd()`. I could not find any documentation of this behavior, but I consider it a bug.


### Description
<!-- Describe your changes in detail -->
Always create the `package.json` in `<plugin dir>` next to `plugin.xml` instead.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing with plugman CLI and this version of lib.

