### PR TITLE
Make src/plugman/init-defaults.js lintable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 coverage/
-src/plugman/init-defaults.js
 spec/cordova/fixtures/*
 spec/plugman/projects/*
 spec/plugman/plugins/*

--- a/src/plugman/init-defaults.js
+++ b/src/plugman/init-defaults.js
@@ -19,11 +19,14 @@
 
 /* global dirname */
 /* global config */
-/* global package */
 /* global basename */
 /* global yes */
 /* global prompt */
 // PromZard file that is used by createpackagejson and init-package-json module
+
+// The PromZard context is also provided via this. Make use of this to avoid
+// having to use the reserved word package. This way we can lint this file.
+const pkg = this.package;
 
 var fs = require('fs-extra');
 var path = require('path');
@@ -55,17 +58,17 @@ function readDeps (test) {
     };
 }
 
-var name = package.name || defaults.id || basename;
+var name = pkg.name || defaults.id || basename;
 exports.name = yes ? name : prompt('name', name);
 
-var version = package.version ||
+var version = pkg.version ||
               defaults.version ||
               config.get('init.version') ||
               config.get('init-version') ||
               '1.0.0';
 exports.version = yes ? version : prompt('version', version);
 
-if (!package.description) {
+if (!pkg.description) {
     if (defaults.description) {
         exports.description = defaults.description;
     } else {
@@ -73,7 +76,7 @@ if (!package.description) {
     }
 }
 
-if (!package.cordova) {
+if (!pkg.cordova) {
     exports.cordova = {};
     if (defaults.id) {
         exports.cordova.id = defaults.id;
@@ -83,15 +86,15 @@ if (!package.cordova) {
     }
 }
 
-if (!package.dependencies) {
+if (!pkg.dependencies) {
     exports.dependencies = readDeps(false);
 }
 
-if (!package.devDependencies) {
+if (!pkg.devDependencies) {
     exports.devDependencies = readDeps(true);
 }
 
-if (!package.repository) {
+if (!pkg.repository) {
     exports.repository = function (cb) {
         fs.readFile('.git/config', 'utf8', function (er, gconf) {
             if (er || !gconf) {
@@ -116,7 +119,7 @@ if (!package.repository) {
     };
 }
 
-if (!package.keywords) {
+if (!pkg.keywords) {
     if (defaults.keywords) {
         exports.keywords = defaults.keywords;
     } else {
@@ -129,13 +132,13 @@ if (!package.keywords) {
     }
 }
 
-if (!package.engines) {
+if (!pkg.engines) {
     if (defaults.engines && defaults.engines.length > 0) {
         exports.engines = defaults.engines;
     }
 }
 
-if (!package.author) {
+if (!pkg.author) {
     exports.author = (config.get('init.author.name') ||
                      config.get('init-author-name')) ?
         {
@@ -148,7 +151,7 @@ if (!package.author) {
         }
         : prompt('author');
 }
-var license = package.license ||
+var license = pkg.license ||
               defaults.license ||
               config.get('init.license') ||
               config.get('init-license') ||


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`src/plugman/init-defaults.js` was not lintable since it was using the reserved word `package`.


### Description
<!-- Describe your changes in detail -->
Use the fact that the PromZard context is also provided as `this` to assign the `package` variable to `pkg` instead.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing with Plugman CLI.
