### PR TITLE
Deprecate plugin save command

### DIFF
--- a/src/cordova/plugin/index.js
+++ b/src/cordova/plugin/index.js
@@ -20,6 +20,7 @@
 var cordova_util = require('../util');
 var CordovaError = require('cordova-common').CordovaError;
 var HooksRunner = require('../../hooks/HooksRunner');
+const { events } = require('cordova-common');
 
 module.exports = plugin;
 module.exports.add = require('./add');
@@ -85,6 +86,7 @@ function plugin (command, targets, opts) {
             return module.exports.remove(projectRoot, targets, hooksRunner, opts);
         case 'save':
             // save the versions/folders/git-urls of currently installed plugins into config.xml
+            events.emit('warn', 'This command has been deprecated and will be removed in the next major release of Cordova.');
             return module.exports.save(projectRoot, opts);
         default:
             return module.exports.list(projectRoot, hooksRunner);


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Deprecates `plugin save`.

### Description
Adds warning emit that `plugin save` is deprecated and will be removed in next major.

closes: #778

### Testing
- `npm t`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
