### PR TITLE
nyc@14 update in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
     "jasmine-spec-reporter": "^4.2.1",
-    "nyc": "^13.3.0",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1",
     "shelljs": "^0.8.3"
   },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This update resolves the `npm audit` warning at this time.

### Description
<!-- Describe your changes in detail -->

see title: nyc@14 update in `devDependencies`

### Testing
<!-- Please describe in detail how you tested your changes. -->

- [x] `npm run cover` succeeds locally on Node.js versions 6, 8, and 10
- [x] verified that Travis CI succeeds
- [x] verified that AppVeyor CI succeeds _- on Node.js versions 6 & 8, TBD still queued on Node.js 10_

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~