### PR TITLE
[WIP] remove coverage from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-coverage
 .nyc_output/
 node_modules
 npm-debug.log


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`coverage` is no longer needed in `.gitignore` since `istanbul` was replaced by `nyc`

This helps to keep `.gitignore` as clean as possible and sets a better example for updating some other components such as `cordova-common`.

### Description
<!-- Describe your changes in detail -->

Remove the `coverage` entry from `.gitignore`

NOTE: This should have been done in PR #637 (6ccda674) where `istanbul` was replaced by `nyc`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm test` continues to succeed
- `git status` shows no additional "untracked files" due to `npm run cover`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~