### PR TITLE
Revert "nyc@14 update in devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
     "jasmine-spec-reporter": "^4.2.1",
-    "nyc": "^14.1.1",
+    "nyc": "^13.3.0",
     "rewire": "^4.0.1",
     "shelljs": "^0.8.3"
   },


### PR DESCRIPTION
Reverts apache/cordova-lib#783 - I think we should revert PR #783 since it fails on AppVeyor on Node.js version 10.

I think it would be cleanest to revert the change, which is a single line in `devDependencies`, then investigate *why* we get the single test failure on AppVeyor on Node.js 10.

An alternative could be to disable the single e2e test on Windows until we get a chance to investigate the issue with the test case. I would probably not favor this alternative.