### PR TITLE
Apply Timeout to Browser E2E Test for FileLock to Unlock

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -275,7 +275,7 @@ describe('pkgJson', function () {
                     expect(getPkgJson(`dependencies.${PLUGIN}`)).toBeDefined();
                 });
         });
-    });
+    }, TIMEOUT * 2);
 
     // This group of tests checks if platforms are added and removed as expected from package.json.
     describe('platform end-to-end with --save', function () {

--- a/spec/cordova/fixtures/basePkgJson/package.json
+++ b/spec/cordova/fixtures/basePkgJson/package.json
@@ -1,11 +1,15 @@
 {
   "name": "testbase",
   "version": "1.0.0",
-  "description": "",
+  "description": "Test Base Package for Cordova Lib Test Spec",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC"
+  "author": "Apache Software Foundation",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apache/cordova-lib"
+  }
 }


### PR DESCRIPTION
### Platforms affected
None

### Motivation and Context
fixes:https://github.com/apache/cordova-lib/issues/787

### Description
There is a process still running creating a file lock so it is unable to remove the file. Applying a timeout to allow the process to complete so there is no file lock.

Same issue occurred in the past for iOS and was fixed under this PR, but this test was missed. 
 https://github.com/apache/cordova-lib/pull/615

It also included an update to the `basePkgJson/package.json` to remove NPM WARN printouts.

### Testing
- https://ci.appveyor.com/project/erisu/cordova-lib/builds/25273509

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
