### PR TITLE
output the error message if no engine has been defined

### DIFF
--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -227,7 +227,7 @@ function getEngines (pluginInfo, platform, project_dir, plugin_dir) {
         // check for other engines
         } else {
             if (typeof engine.platform === 'undefined' || typeof engine.scriptSrc === 'undefined') {
-                throw new CordovaError('warn', 'engine.platform or engine.scriptSrc is not defined in custom engine "' +
+                throw new CordovaError('engine.platform or engine.scriptSrc is not defined in custom engine "' +
                     theName + '" from plugin "' + pluginInfo.id + '" for ' + platform);
             }
 


### PR DESCRIPTION
### Platforms affected
All


### Motivation and Context
When installing a plugin I got a non descript error message.
```sh
> cordova plugin add cordova-plugin-background-mode
Installing "cordova-plugin-background-mode" for android
warn
```
Running with `--verbose` cleared it up

### Description
The first parameter is the message.



### Testing
Test for example with `cordova-plugin-background-mode` for android


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
