### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ git:
   depth: 10
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ shallow_clone: true
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "cordova-lib.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "cordova-common": "^3.1.0",


### PR DESCRIPTION
Dropping node 6 and 8 support will allow us to not worry about dubious failures that only happen in these versions and to use new features like `async/await`.