### PR TITLE
Remove unused exports from cordova/util

### DIFF
--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -81,19 +81,6 @@ describe('util module', function () {
             expect(util.isCordova(anotherdir)).toEqual(somedir);
         });
     });
-    describe('deleteSvnFolders method', function () {
-        it('Test 008 : should delete .svn folders in any subdirectory of specified dir', function () {
-            var one = path.join(temp, 'one');
-            var two = path.join(temp, 'two');
-            var one_svn = path.join(one, '.svn');
-            var two_svn = path.join(two, '.svn');
-            fs.ensureDirSync(one_svn);
-            fs.ensureDirSync(two_svn);
-            util.deleteSvnFolders(temp);
-            expect(fs.existsSync(one_svn)).toEqual(false);
-            expect(fs.existsSync(two_svn)).toEqual(false);
-        });
-    });
     describe('listPlatforms method', function () {
         it('Test 009 : should only return supported platform directories present in a cordova project dir', function () {
             var platforms = path.join(temp, 'platforms');

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -31,10 +31,8 @@ exports.binname = 'cordova';
 exports.isCordova = isCordova;
 exports.getProjectRoot = getProjectRoot;
 exports.cdProjectRoot = cdProjectRoot;
-exports.deleteSvnFolders = deleteSvnFolders;
 exports.listPlatforms = listPlatforms;
 exports.findPlugins = findPlugins;
-exports.appDir = appDir;
 exports.projectWww = projectWww;
 exports.projectConfig = projectConfig;
 exports.preProcessOptions = preProcessOptions;
@@ -187,19 +185,6 @@ function convertToRealPathSafe (path) {
     return path;
 }
 
-// Recursively deletes .svn folders from a target path
-function deleteSvnFolders (dir) {
-    var contents = fs.readdirSync(dir);
-    contents.forEach(function (entry) {
-        var fullpath = path.join(dir, entry);
-        if (isDirectory(fullpath)) {
-            if (entry === '.svn') {
-                fs.removeSync(fullpath);
-            } else module.exports.deleteSvnFolders(fullpath);
-        }
-    });
-}
-
 function listPlatforms (project_dir) {
     var platforms_dir = path.join(project_dir, 'platforms');
     if (!fs.existsSync(platforms_dir)) {
@@ -243,10 +228,6 @@ function findPlugins (pluginDir) {
     }
 
     return plugins;
-}
-
-function appDir (projectDir) {
-    return projectDir;
 }
 
 function projectWww (projectDir) {

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -24,30 +24,9 @@ var CordovaError = require('cordova-common').CordovaError;
 var url = require('url');
 var platforms = require('../platforms/platforms');
 
-// Global configuration paths
-var global_config_path = process.env['CORDOVA_HOME'];
-if (!global_config_path) {
-    var HOME = process.env[(process.platform.slice(0, 3) === 'win') ? 'USERPROFILE' : 'HOME'];
-    global_config_path = path.join(HOME, '.cordova');
-}
-
 var origCwd = null;
 
-var lib_path = path.join(global_config_path, 'lib');
-
 exports.binname = 'cordova';
-exports.globalConfig = global_config_path;
-
-// defer defining libDirectory on exports so we don't create it if
-// someone simply requires this module
-Object.defineProperty(exports, 'libDirectory', {
-    configurable: true,
-    get: function () {
-        fs.ensureDirSync(lib_path);
-        exports.libDirectory = lib_path;
-        return lib_path;
-    }
-});
 
 exports.isCordova = isCordova;
 exports.getProjectRoot = getProjectRoot;


### PR DESCRIPTION
Nothing removed here was used anywhere in `cordova-lib`. Neither is the `cordova/util` module part of our public interface. Thus, all of the affected functions can be safely removed in any kind of release.