### PR TITLE
Break dependency cycles

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -47,7 +47,8 @@ describe('cordova/platform/addHelper', function () {
         ]);
         fetch_mock = jasmine.createSpy('fetch mock').and.returnValue(Promise.resolve());
         prepare_mock = jasmine.createSpy('prepare mock').and.returnValue(Promise.resolve());
-        prepare_mock.preparePlatforms = jasmine.createSpy('preparePlatforms mock').and.returnValue(Promise.resolve());
+        const preparePlatforms = jasmine.createSpy('preparePlatforms mock').and.returnValue(Promise.resolve());
+        prepare_mock.preparePlatforms = preparePlatforms;
 
         // `cordova.prepare` is never saved to a variable, so we need to fake `require`
         platform_addHelper = rewire('../../../src/cordova/platform/addHelper');
@@ -61,7 +62,8 @@ describe('cordova/platform/addHelper', function () {
             ConfigParser: cfg_parser_mock,
             fetch: fetch_mock,
             require: requireFake,
-            getPlatformDetailsFromDir
+            getPlatformDetailsFromDir,
+            preparePlatforms
         });
 
         spyOn(fs, 'ensureDirSync');

--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -22,7 +22,6 @@ var rewire = require('rewire');
 var cordova_util = require('../../../src/cordova/util');
 var plugman = require('../../../src/plugman/plugman');
 var fetch_metadata = require('../../../src/plugman/util/metadata');
-var prepare = require('../../../src/cordova/prepare');
 
 describe('cordova/platform/addHelper', function () {
     const projectRoot = '/some/path';
@@ -204,10 +203,10 @@ describe('cordova/platform/addHelper', function () {
         describe('after platform api invocation', function () {
 
             describe('when the restoring option is not provided', function () {
-                // test is commented out b/c preparePlatforms can't be spied on as it is dynamically required due to circular references.
-                xit('should invoke preparePlatforms twice (?!?), once before installPluginsForNewPlatforms and once after... ?!', function () {
+                it('should invoke preparePlatforms twice (?!?), once before installPluginsForNewPlatforms and once after... ?!', function () {
+                    const preparePlatforms = platform_addHelper.__get__('preparePlatforms');
                     return platform_addHelper('add', hooks_mock, projectRoot, ['atari'], { save: true }).then(function (result) {
-                        expect(prepare.preparePlatforms).toHaveBeenCalledWith([ 'atari' ], '/some/path', Object({ searchpath: undefined }));
+                        expect(preparePlatforms).toHaveBeenCalledWith([ 'atari' ], '/some/path', { searchpath: undefined });
                     });
                 });
             });

--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -20,6 +20,7 @@ var fs = require('fs-extra');
 var events = require('cordova-common').events;
 var rewire = require('rewire');
 var cordova_util = require('../../../src/cordova/util');
+var platforms = require('../../../src/platforms');
 var plugman = require('../../../src/plugman/plugman');
 var fetch_metadata = require('../../../src/plugman/util/metadata');
 
@@ -73,8 +74,8 @@ describe('cordova/platform/addHelper', function () {
         spyOn(cordova_util, 'isDirectory').and.returnValue(false);
         spyOn(cordova_util, 'fixRelativePath').and.callFake(function (input) { return input; });
         spyOn(cordova_util, 'isUrl').and.returnValue(false);
-        spyOn(cordova_util, 'hostSupports').and.returnValue(true);
         spyOn(cordova_util, 'removePlatformPluginsJson');
+        spyOn(platforms, 'hostSupports').and.returnValue(true);
         spyOn(events, 'emit');
         // Fake platform details we will use for our mocks, returned by either
         // getPlatfromDetailsFromDir (in the local-directory case), or
@@ -99,9 +100,9 @@ describe('cordova/platform/addHelper', function () {
         });
 
         it('should log if host OS does not support the specified platform', function () {
-            cordova_util.hostSupports.and.returnValue(false);
+            platforms.hostSupports.and.returnValue(false);
             return platform_addHelper('add', hooks_mock, projectRoot, ['atari']).then(function () {
-                expect(cordova_util.hostSupports).toHaveBeenCalled();
+                expect(platforms.hostSupports).toHaveBeenCalled();
                 expect(events.emit).toHaveBeenCalledWith('warning', jasmine.stringMatching(/WARNING: Applications/));
             });
         });

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -24,7 +24,6 @@ var metadata = require('../../../src/plugman/util/metadata');
 var events = require('cordova-common').events;
 var plugman = require('../../../src/plugman/plugman');
 var fs = require('fs-extra');
-var prepare = require('../../../src/cordova/prepare');
 var plugin_util = require('../../../src/cordova/plugin/util');
 
 describe('cordova/plugin/remove', function () {
@@ -47,7 +46,6 @@ describe('cordova/plugin/remove', function () {
         spyOn(plugman.uninstall, 'uninstallPlatform').and.returnValue(Promise.resolve());
         spyOn(plugman.uninstall, 'uninstallPlugin').and.returnValue(Promise.resolve());
         hook_mock = jasmine.createSpyObj('hooks runner mock', ['fire']);
-        spyOn(prepare, 'preparePlatforms').and.returnValue(true);
         hook_mock.fire.and.returnValue(Promise.resolve());
         cfg_parser_mock.prototype = jasmine.createSpyObj('config parser mock', ['write', 'getPlugin', 'removePlugin']);
         remove.__set__('ConfigParser', cfg_parser_mock);
@@ -56,7 +54,10 @@ describe('cordova/plugin/remove', function () {
             // id version dir getPreferences() engines engines.cordovaDependencies name versions
             return plugin_info;
         };
-        remove.__set__('PluginInfoProvider', plugin_info_provider_mock);
+        remove.__set__({
+            PluginInfoProvider: plugin_info_provider_mock,
+            preparePlatforms: jasmine.createSpy('preparePlatforms')
+        });
     });
 
     describe('error/warning conditions', function () {

--- a/spec/cordova/prepare.spec.js
+++ b/spec/cordova/prepare.spec.js
@@ -131,34 +131,4 @@ describe('cordova/prepare', function () {
             });
         });
     });
-
-    describe('preparePlatforms helper method', function () {
-        var cfg_parser_mock = function () {};
-        var platform_munger_mock = function () {};
-        var platform_munger_save_mock;
-        beforeEach(function () {
-            prepare.__set__('ConfigParser', cfg_parser_mock);
-            platform_munger_save_mock = jasmine.createSpy('platform munger save mock');
-            platform_munger_mock.prototype = jasmine.createSpyObj('platform munger prototype mock', ['add_config_changes']);
-            platform_munger_mock.prototype.add_config_changes.and.returnValue({
-                save_all: platform_munger_save_mock
-            });
-            prepare.__set__('PlatformMunger', platform_munger_mock);
-            spyOn(util, 'projectConfig').and.returnValue(project_dir);
-            spyOn(util, 'projectWww').and.returnValue(path.join(project_dir, 'www'));
-
-        });
-        it('should retrieve the platform API via getPlatformApi per platform provided, and invoke the prepare method from that API', function () {
-            return prepare.preparePlatforms(['android'], project_dir, {}).then(function () {
-                expect(platforms.getPlatformApi).toHaveBeenCalledWith('android');
-                expect(platform_api_prepare_mock).toHaveBeenCalled();
-            });
-        });
-        it('should handle config changes by invoking add_config_changes and save_all', function () {
-            return prepare.preparePlatforms(['android'], project_dir, {}).then(function () {
-                expect(platform_munger_mock.prototype.add_config_changes).toHaveBeenCalled();
-                expect(platform_munger_save_mock).toHaveBeenCalled();
-            });
-        });
-    });
 });

--- a/spec/cordova/prepare/platforms.spec.js
+++ b/spec/cordova/prepare/platforms.spec.js
@@ -1,0 +1,65 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const path = require('path');
+const rewire = require('rewire');
+const util = require('../../../src/cordova/util');
+const platforms = require('../../../src/platforms/platforms');
+const PlatformJson = require('cordova-common').PlatformJson;
+
+const project_dir = '/some/path';
+
+describe('cordova/prepare/platforms', () => {
+    let preparePlatforms, platform_munger_mock;
+
+    beforeEach(function () {
+        preparePlatforms = rewire('../../../src/cordova/prepare/platforms');
+
+        platform_munger_mock = class { add_config_changes () {} };
+        spyOn(platform_munger_mock.prototype, 'add_config_changes').and.returnValue({
+            save_all: jasmine.createSpy('platform munger save mock')
+        });
+        preparePlatforms.__set__({
+            ConfigParser: class {},
+            PlatformMunger: platform_munger_mock
+        });
+
+        spyOn(platforms, 'getPlatformApi').and.returnValue({
+            prepare: jasmine.createSpy('prepare').and.returnValue(Promise.resolve())
+        });
+        spyOn(PlatformJson, 'load');
+        spyOn(util, 'projectConfig').and.returnValue(project_dir);
+        spyOn(util, 'projectWww').and.returnValue(path.join(project_dir, 'www'));
+    });
+
+    it('should retrieve the platform API via getPlatformApi per platform provided, and invoke the prepare method from that API', () => {
+        return preparePlatforms(['android'], project_dir, {}).then(() => {
+            expect(platforms.getPlatformApi).toHaveBeenCalledWith('android');
+            expect(platforms.getPlatformApi().prepare).toHaveBeenCalled();
+        });
+    });
+
+    it('should handle config changes by invoking add_config_changes and save_all', () => {
+        const pmmp = platform_munger_mock.prototype;
+        return preparePlatforms(['android'], project_dir, {}).then(() => {
+            expect(pmmp.add_config_changes).toHaveBeenCalled();
+            expect(pmmp.add_config_changes().save_all).toHaveBeenCalled();
+        });
+    });
+});

--- a/spec/cordova/run.spec.js
+++ b/spec/cordova/run.spec.js
@@ -16,7 +16,7 @@
     specific language governing permissions and limitations
     under the License.
 */
-var cordova = require('../../src/cordova/cordova');
+const rewire = require('rewire');
 var platforms = require('../../src/platforms/platforms');
 var HooksRunner = require('../../src/hooks/HooksRunner');
 var util = require('../../src/cordova/util');
@@ -24,16 +24,19 @@ var util = require('../../src/cordova/util');
 var supported_platforms = Object.keys(platforms).filter(function (p) { return p !== 'www'; });
 
 describe('run command', function () {
-    var is_cordova, cd_project_root, list_platforms, fire, platformApi, getPlatformApi;
     var project_dir = '/some/path';
-    var prepare_spy;
+    let cordovaRun, cordovaPrepare, platformApi, getPlatformApi;
 
     beforeEach(function () {
-        is_cordova = spyOn(util, 'isCordova').and.returnValue(project_dir);
-        cd_project_root = spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
-        list_platforms = spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
-        fire = spyOn(HooksRunner.prototype, 'fire').and.returnValue(Promise.resolve());
-        prepare_spy = spyOn(cordova, 'prepare').and.returnValue(Promise.resolve());
+        spyOn(util, 'isCordova').and.returnValue(project_dir);
+        spyOn(util, 'cdProjectRoot').and.returnValue(project_dir);
+        spyOn(util, 'listPlatforms').and.returnValue(supported_platforms);
+        spyOn(HooksRunner.prototype, 'fire').and.returnValue(Promise.resolve());
+
+        cordovaRun = rewire('../../src/cordova/run');
+        cordovaPrepare = jasmine.createSpy('cordovaPrepare').and.returnValue(Promise.resolve());
+        cordovaRun.__set__({ cordovaPrepare });
+
         platformApi = {
             run: jasmine.createSpy('run').and.returnValue(Promise.resolve()),
             build: jasmine.createSpy('build').and.returnValue(Promise.resolve())
@@ -42,8 +45,8 @@ describe('run command', function () {
     });
     describe('failure', function () {
         it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function () {
-            list_platforms.and.returnValue([]);
-            return Promise.resolve().then(cordova.run)
+            util.listPlatforms.and.returnValue([]);
+            return Promise.resolve().then(cordovaRun)
                 .then(function () {
                     fail('Expected promise to be rejected');
                 }, function (err) {
@@ -53,9 +56,9 @@ describe('run command', function () {
         });
         it('Test 002 : should not run outside of a Cordova-based project', function () {
             var msg = 'Dummy message about not being in a cordova dir.';
-            cd_project_root.and.throwError(new Error(msg));
-            is_cordova.and.returnValue(false);
-            return Promise.resolve().then(cordova.run)
+            util.cdProjectRoot.and.throwError(new Error(msg));
+            util.isCordova.and.returnValue(false);
+            return Promise.resolve().then(cordovaRun)
                 .then(function () {
                     fail('Expected promise to be rejected');
                 }, function (err) {
@@ -67,12 +70,12 @@ describe('run command', function () {
 
     describe('success', function () {
         it('Test 003 : should call prepare before actually run platform ', function () {
-            return cordova.run(['android', 'ios']).then(function () {
-                expect(prepare_spy.calls.argsFor(0)).toEqual([ { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
+            return cordovaRun(['android', 'ios']).then(function () {
+                expect(cordovaPrepare.calls.argsFor(0)).toEqual([ { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
             });
         });
         it('Test 004 : should get PlatformApi instance for each platform and call its\' run method', function () {
-            return cordova.run(['android', 'ios']).then(function () {
+            return cordovaRun(['android', 'ios']).then(function () {
                 expect(getPlatformApi).toHaveBeenCalledWith('android');
                 expect(getPlatformApi).toHaveBeenCalledWith('ios');
                 expect(platformApi.build).toHaveBeenCalled();
@@ -80,46 +83,41 @@ describe('run command', function () {
             });
         });
         it('Test 005 : should pass down parameters', function () {
-            return cordova.run({ platforms: ['blackberry10'], options: { password: '1q1q' } }).then(function () {
-                expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q' }, verbose: false });
+            return cordovaRun({ platforms: ['blackberry10'], options: { password: '1q1q' } }).then(function () {
+                expect(cordovaPrepare).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q' }, verbose: false });
                 expect(platformApi.build).toHaveBeenCalledWith({ password: '1q1q' });
                 expect(platformApi.run).toHaveBeenCalledWith({ password: '1q1q', nobuild: true });
             });
         });
 
         it('Test 007 : should call platform\'s build method', function () {
-            return cordova.run({ platforms: ['blackberry10'] })
+            return cordovaRun({ platforms: ['blackberry10'] })
                 .then(function () {
-                    expect(prepare_spy).toHaveBeenCalled();
+                    expect(cordovaPrepare).toHaveBeenCalled();
                     expect(platformApi.build).toHaveBeenCalledWith({});
                     expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({ nobuild: true }));
                 });
         });
 
         it('Test 008 : should not call build if --nobuild option is passed', function () {
-            return cordova.run({ platforms: ['blackberry10'], options: { nobuild: true } })
+            return cordovaRun({ platforms: ['blackberry10'], options: { nobuild: true } })
                 .then(function () {
-                    expect(prepare_spy).toHaveBeenCalled();
+                    expect(cordovaPrepare).toHaveBeenCalled();
                     expect(platformApi.build).not.toHaveBeenCalled();
                     expect(platformApi.run).toHaveBeenCalledWith(jasmine.objectContaining({ nobuild: true }));
                 });
         });
 
         describe('run parameters should not be altered by intermediate build command', function () {
-            var originalBuildSpy;
             beforeEach(function () {
-                originalBuildSpy = platformApi.build;
-                platformApi.build = jasmine.createSpy('build').and.callFake(function (opts) {
+                platformApi.build.and.callFake(opts => {
                     opts.couldBeModified = 'insideBuild';
                     return Promise.resolve();
                 });
             });
-            afterEach(function () {
-                platformApi.build = originalBuildSpy;
-            });
             it('Test 009 : should leave parameters unchanged', function () {
-                return cordova.run({ platforms: ['blackberry10'], options: { password: '1q1q' } }).then(function () {
-                    expect(prepare_spy).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q', 'couldBeModified': 'insideBuild' }, verbose: false });
+                return cordovaRun({ platforms: ['blackberry10'], options: { password: '1q1q' } }).then(function () {
+                    expect(cordovaPrepare).toHaveBeenCalledWith({ platforms: [ 'blackberry10' ], options: { password: '1q1q', 'couldBeModified': 'insideBuild' }, verbose: false });
                     expect(platformApi.build).toHaveBeenCalledWith({ password: '1q1q', 'couldBeModified': 'insideBuild' });
                     expect(platformApi.run).toHaveBeenCalledWith({ password: '1q1q', nobuild: true });
                 });
@@ -130,26 +128,28 @@ describe('run command', function () {
     describe('hooks', function () {
         describe('when platforms are added', function () {
             it('Test 010 : should fire before hooks through the hooker module', function () {
-                return cordova.run(['android', 'ios']).then(function () {
-                    expect(fire.calls.argsFor(0)).toEqual([ 'before_run', { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
+                return cordovaRun(['android', 'ios']).then(function () {
+                    expect(HooksRunner.prototype.fire.calls.argsFor(0))
+                        .toEqual([ 'before_run', { platforms: [ 'android', 'ios' ], verbose: false, options: {} } ]);
                 });
             });
             it('Test 011 : should fire after hooks through the hooker module', function () {
-                return cordova.run('android').then(function () {
-                    expect(fire.calls.argsFor(2)).toEqual([ 'after_run', { platforms: [ 'android' ], verbose: false, options: {} } ]);
+                return cordovaRun('android').then(function () {
+                    expect(HooksRunner.prototype.fire.calls.argsFor(2))
+                        .toEqual([ 'after_run', { platforms: [ 'android' ], verbose: false, options: {} } ]);
                 });
             });
         });
 
         describe('with no platforms added', function () {
             it('Test 012 : should not fire the hooker', function () {
-                list_platforms.and.returnValue([]);
-                return Promise.resolve().then(cordova.run)
+                util.listPlatforms.and.returnValue([]);
+                return Promise.resolve().then(cordovaRun)
                     .then(function () {
                         fail('Expected promise to be rejected');
                     }, function (err) {
                         expect(err).toEqual(jasmine.any(Error));
-                        expect(fire).not.toHaveBeenCalled();
+                        expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
                         expect(err.message).toEqual('No platforms added to this project. Please use `cordova platform add <platform>`.');
                     });
             });

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -20,13 +20,12 @@
 const fs = require('fs-extra');
 const path = require('path');
 const semver = require('semver');
+const rewire = require('rewire');
 
 const { events, PlatformJson, superspawn } = require('cordova-common');
 const { spy: emitSpyHelper } = require('../common');
-const install = require('../../src/plugman/install');
 const knownPlatforms = require('../../src/platforms/platforms');
 const platforms = require('../../src/plugman/platforms/common');
-const plugman = require('../../src/plugman/plugman');
 
 const { tmpDir, getFixture } = require('../helpers');
 const temp_dir = tmpDir('plugman-install-test');
@@ -67,6 +66,7 @@ const fake = {
 };
 
 describe('plugman/install', () => {
+    let install = require('../../src/plugman/install');
     let fetchSpy;
 
     beforeAll(() => {
@@ -112,11 +112,14 @@ describe('plugman/install', () => {
     });
 
     beforeEach(() => {
+        install = rewire('../../src/plugman/install');
+        fetchSpy = jasmine.createSpy('plugmanFetch').and.returnValue(Promise.resolve(pluginDir('com.cordova.engine')));
+        install.__set__({ plugmanFetch: fetchSpy });
+
         spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(''));
         spyOn(fs, 'ensureDirSync');
         spyOn(platforms, 'copyFile').and.returnValue(true);
 
-        fetchSpy = spyOn(plugman, 'fetch').and.returnValue(Promise.resolve(pluginDir('com.cordova.engine')));
         spyOn(fs, 'writeFileSync');
         spyOn(fs, 'copySync');
         spyOn(fs, 'removeSync');

--- a/src/cordova/build.js
+++ b/src/cordova/build.js
@@ -19,6 +19,8 @@
 
 var cordovaUtil = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
+const cordovaPrepare = require('./prepare');
+const cordovaCompile = require('./compile');
 
 // Returns a promise.
 module.exports = function build (options) {
@@ -30,9 +32,9 @@ module.exports = function build (options) {
         var hooksRunner = new HooksRunner(projectRoot);
         return hooksRunner.fire('before_build', options)
             .then(function () {
-                return require('./cordova').prepare(options);
+                return cordovaPrepare(options);
             }).then(function () {
-                return require('./cordova').compile(options);
+                return cordovaCompile(options);
             }).then(function () {
                 return hooksRunner.fire('after_build', options);
             });

--- a/src/cordova/emulate.js
+++ b/src/cordova/emulate.js
@@ -20,6 +20,7 @@
 var cordova_util = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
 var platform_lib = require('../platforms/platforms');
+var cordovaPrepare = require('./prepare');
 
 // Returns a promise.
 module.exports = function emulate (options) {
@@ -38,7 +39,7 @@ module.exports = function emulate (options) {
             .then(function () {
                 if (!options.options.noprepare) {
                     // Run a prepare first!
-                    return require('./cordova').prepare(options);
+                    return cordovaPrepare(options);
                 }
             }).then(function () {
                 // Deploy in parallel (output gets intermixed though...)

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -25,7 +25,7 @@ var PlatformJson = require('cordova-common').PlatformJson;
 var events = require('cordova-common').events;
 var cordova_util = require('../util');
 var promiseutil = require('../../util/promise-util');
-var platforms = require('../../platforms/platforms');
+var platforms = require('../../platforms');
 var detectIndent = require('detect-indent');
 var getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
 var preparePlatforms = require('../prepare/platforms');
@@ -44,7 +44,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
     }
 
     for (var i = 0; i < targets.length; i++) {
-        if (!cordova_util.hostSupports(targets[i])) {
+        if (!platforms.hostSupports(targets[i])) {
             msg = 'WARNING: Applications for platform ' + targets[i] +
                   ' can not be built on this OS - ' + process.platform + '.';
             events.emit('warning', msg);
@@ -113,9 +113,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                     }
 
                     // If spec still doesn't exist, try to use pinned version
-                    if (!spec && platforms[platform]) {
+                    if (!spec && platforms.info[platform]) {
                         events.emit('verbose', 'Grabbing pinned version.');
-                        spec = platforms[platform].version;
+                        spec = platforms.info[platform].version;
                     }
 
                     // Handle local paths
@@ -270,7 +270,7 @@ function downloadPlatform (projectRoot, platform, version, opts) {
     var target = version ? (platform + '@' + version) : platform;
     return Promise.resolve().then(function () {
         // append cordova to platform
-        if (platform in platforms) {
+        if (platform in platforms.info) {
             target = 'cordova-' + target;
         }
 

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -27,6 +27,7 @@ var cordova_util = require('../util');
 var promiseutil = require('../../util/promise-util');
 var platforms = require('../../platforms/platforms');
 var detectIndent = require('detect-indent');
+var getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
 
 module.exports = addHelper;
 module.exports.getVersionFromConfigFile = getVersionFromConfigFile;
@@ -122,7 +123,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                         if (cordova_util.isDirectory(maybeDir)) {
                             return fetch(path.resolve(maybeDir), projectRoot, opts)
                                 .then(function (directory) {
-                                    return require('./index').getPlatformDetailsFromDir(directory, platform);
+                                    return getPlatformDetailsFromDir(directory, platform);
                                 });
                         }
                     }
@@ -285,7 +286,7 @@ function downloadPlatform (projectRoot, platform, version, opts) {
             '\n' + error;
         return Promise.reject(new CordovaError(message));
     }).then(function (libDir) {
-        return require('./index').getPlatformDetailsFromDir(libDir, platform);
+        return getPlatformDetailsFromDir(libDir, platform);
     });
 }
 

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -28,6 +28,7 @@ var promiseutil = require('../../util/promise-util');
 var platforms = require('../../platforms/platforms');
 var detectIndent = require('detect-indent');
 var getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
+var preparePlatforms = require('../prepare/platforms');
 
 module.exports = addHelper;
 module.exports.getVersionFromConfigFile = getVersionFromConfigFile;
@@ -177,7 +178,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                     return promise()
                         .then(function () {
                             if (!opts.restoring) {
-                                return require('../prepare').preparePlatforms([platform], projectRoot, { searchpath: opts.searchpath });
+                                return preparePlatforms([platform], projectRoot, { searchpath: opts.searchpath });
                             }
                         })
                         .then(function () {

--- a/src/cordova/platform/list.js
+++ b/src/cordova/platform/list.js
@@ -17,7 +17,7 @@
 
 var events = require('cordova-common').events;
 var cordova_util = require('../util');
-var platforms = require('../../platforms/platforms');
+var platforms = require('../../platforms');
 
 module.exports = list;
 module.exports.addDeprecatedInformationToPlatforms = addDeprecatedInformationToPlatforms;
@@ -34,14 +34,14 @@ function list (hooksRunner, projectRoot, opts) {
 
             platformsText = addDeprecatedInformationToPlatforms(platformsText);
             var results = 'Installed platforms:\n  ' + platformsText.sort().join('\n  ') + '\n';
-            var available = Object.keys(platforms).filter(cordova_util.hostSupports);
+            var available = platforms.list.filter(platforms.hostSupports);
 
             available = available.filter(function (p) {
                 return !platformMap[p]; // Only those not already installed.
             });
 
             available = available.map(function (p) {
-                return p.concat(' ', platforms[p].version);
+                return p.concat(' ', platforms.info[p].version);
             });
 
             available = addDeprecatedInformationToPlatforms(available);
@@ -57,7 +57,7 @@ function addDeprecatedInformationToPlatforms (platformsList) {
     platformsList = platformsList.map(function (p) {
         var platformKey = p.split(' ')[0]; // Remove Version Information
         // allow for 'unknown' platforms, which will not exist in platforms
-        if (platforms[platformKey] && platforms[platformKey].deprecated) {
+        if ((platforms.info[platformKey] || {}).deprecated) {
             p = p.concat(' ', '(deprecated)');
         }
         return p;

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -32,6 +32,7 @@ var fs = require('fs-extra');
 var semver = require('semver');
 var url = require('url');
 var detectIndent = require('detect-indent');
+var preparePlatforms = require('../prepare/platforms');
 
 module.exports = add;
 module.exports.determinePluginTarget = determinePluginTarget;
@@ -190,7 +191,7 @@ function add (projectRoot, hooksRunner, opts) {
             // Need to require right here instead of doing this at the beginning of file
             // otherwise tests are failing without any real reason.
             // TODO: possible circular dependency?
-            return require('../prepare').preparePlatforms(platformList, projectRoot, opts);
+            return preparePlatforms(platformList, projectRoot, opts);
         }).then(function () {
             opts.cordova = { plugins: cordova_util.findPlugins(pluginPath) };
             return hooksRunner.fire('after_plugin_add', opts);

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -29,6 +29,7 @@ var fs = require('fs-extra');
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var detectIndent = require('detect-indent');
 const { Q_chainmap } = require('../../util/promise-util');
+const preparePlatforms = require('../prepare/platforms');
 
 module.exports = remove;
 module.exports.validatePluginId = validatePluginId;
@@ -53,7 +54,7 @@ function remove (projectRoot, targets, hooksRunner, opts) {
             if (!shouldRunPrepare) {
                 return Promise.resolve();
             }
-            return require('../prepare').preparePlatforms(platformList, projectRoot, opts);
+            return preparePlatforms(platformList, projectRoot, opts);
         }).then(function () {
             opts.cordova = { plugins: cordova_util.findPlugins(pluginPath) };
             return hooksRunner.fire('after_plugin_rm', opts);

--- a/src/cordova/prepare/platforms.js
+++ b/src/cordova/prepare/platforms.js
@@ -1,0 +1,69 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var cordova_util = require('../util');
+var ConfigParser = require('cordova-common').ConfigParser;
+var PlatformJson = require('cordova-common').PlatformJson;
+var PlatformMunger = require('cordova-common').ConfigChanges.PlatformMunger;
+var platforms = require('../../platforms/platforms');
+var path = require('path');
+
+module.exports = preparePlatforms;
+
+/**
+ * Calls `platformApi.prepare` for each platform in project
+ *
+ * @param   {string[]}  platformList  List of platforms, added to current project
+ * @param   {string}    projectRoot   Project root directory
+ *
+ * @return  {Promise}
+ */
+function preparePlatforms (platformList, projectRoot, options) {
+    return Promise.all(platformList.map(function (platform) {
+        // TODO: this need to be replaced by real projectInfo
+        // instance for current project.
+        var project = {
+            root: projectRoot,
+            projectConfig: new ConfigParser(cordova_util.projectConfig(projectRoot)),
+            locations: {
+                plugins: path.join(projectRoot, 'plugins'),
+                www: cordova_util.projectWww(projectRoot),
+                rootConfigXml: cordova_util.projectConfig(projectRoot)
+            }
+        };
+        // platformApi prepare takes care of all functionality
+        // which previously had been executed by cordova.prepare:
+        //   - reset config.xml and then merge changes from project's one,
+        //   - update www directory from project's one and merge assets from platform_www,
+        //   - reapply config changes, made by plugins,
+        //   - update platform's project
+        // Please note that plugins' changes, such as installed js files, assets and
+        // config changes is not being reinstalled on each prepare.
+        var platformApi = platforms.getPlatformApi(platform);
+        return platformApi.prepare(project, Object.assign({}, options))
+            .then(function () {
+                // Handle edit-config in config.xml
+                var platformRoot = path.join(projectRoot, 'platforms', platform);
+                var platformJson = PlatformJson.load(platformRoot, platform);
+                var munger = new PlatformMunger(platform, platformRoot, platformJson);
+                // the boolean argument below is "should_increment"
+                munger.add_config_changes(project.projectConfig, true).save_all();
+            });
+    }));
+}

--- a/src/cordova/run.js
+++ b/src/cordova/run.js
@@ -20,6 +20,7 @@
 var cordova_util = require('./util');
 var HooksRunner = require('../hooks/HooksRunner');
 var platform_lib = require('../platforms/platforms');
+var cordovaPrepare = require('./prepare');
 
 // Returns a promise.
 module.exports = function run (options) {
@@ -36,7 +37,7 @@ module.exports = function run (options) {
             .then(function () {
                 if (!options.options.noprepare) {
                     // Run a prepare first, then shell out to run
-                    return require('./cordova').prepare(options);
+                    return cordovaPrepare(options);
                 }
             }).then(function () {
                 // Deploy in parallel (output gets intermixed though...)

--- a/src/cordova/serve.js
+++ b/src/cordova/serve.js
@@ -25,6 +25,7 @@ const { template, object: zipObject } = require('underscore');
 
 const { ConfigParser, events } = require('cordova-common');
 const cordovaServe = require('cordova-serve');
+const cordovaPrepare = require('./prepare');
 const cordovaUtil = require('./util');
 const platforms = require('../platforms/platforms');
 const HooksRunner = require('../hooks/HooksRunner');
@@ -146,7 +147,7 @@ function serve (port) {
         const server = cordovaServe();
 
         // Run a prepare first!
-        return require('./cordova').prepare([])
+        return cordovaPrepare([])
             .then(() => {
                 registerRoutes(server.app);
                 return server.launchServer({ port, events });

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -22,7 +22,6 @@ var path = require('path');
 var events = require('cordova-common').events;
 var CordovaError = require('cordova-common').CordovaError;
 var url = require('url');
-var platforms = require('../platforms/platforms');
 
 var origCwd = null;
 
@@ -45,24 +44,12 @@ exports.isUrl = isUrl;
 exports.getInstalledPlatformsWithVersions = getInstalledPlatformsWithVersions;
 exports.requireNoCache = requireNoCache;
 exports.getPlatformApiFunction = getPlatformApiFunction;
-exports.hostSupports = hostSupports;
 exports.removePlatformPluginsJson = removePlatformPluginsJson;
 
 // Remove <platform>.json file from plugins directory.
 function removePlatformPluginsJson (projectRoot, target) {
     var plugins_json = path.join(projectRoot, 'plugins', target + '.json');
     fs.removeSync(plugins_json);
-}
-
-// Used to prevent attempts of installing platforms that are not supported on
-// the host OS. E.g. ios on linux.
-function hostSupports (platform) {
-    var p = platforms[platform] || {};
-    var hostos = p.hostos || null;
-    if (!hostos) { return true; }
-    if (hostos.indexOf('*') >= 0) { return true; }
-    if (hostos.indexOf(process.platform) >= 0) { return true; }
-    return false;
 }
 
 function requireNoCache (pkgJsonPath) {

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -1,0 +1,74 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+var path = require('path');
+var fs = require('fs-extra');
+var util = require('../cordova/util');
+var platforms = require('./platformsConfig.json');
+var events = require('cordova-common').events;
+
+// Avoid loading the same platform projects more than once (identified by path)
+var cachedApis = {};
+
+// getPlatformApi() should be the only method of instantiating the
+// PlatformProject classes for now.
+function getPlatformApi (platform, platformRootDir) {
+    // if platformRootDir is not specified, try to detect it first
+    if (!platformRootDir) {
+        var projectRootDir = util.isCordova();
+        platformRootDir = projectRootDir && path.join(projectRootDir, 'platforms', platform);
+    }
+    if (!platformRootDir) {
+        // If platformRootDir is still undefined, then we're probably is not inside of cordova project
+        throw new Error('Current location is not a Cordova project');
+    }
+    // CB-11174 Resolve symlinks first before working with root directory
+    platformRootDir = util.convertToRealPathSafe(platformRootDir);
+
+    // Make sure the platforms/platform folder exists
+    if (!fs.existsSync(platformRootDir)) {
+        throw new Error('The platform "' + platform + '" does not appear to have been added to this project.');
+    }
+
+    var platformApi;
+    var cached = cachedApis[platformRootDir];
+    var libDir = path.join(platformRootDir, 'cordova', 'Api.js');
+    if (cached && cached.platform === platform) {
+        platformApi = cached;
+    } else {
+        var PlatformApi = util.getPlatformApiFunction(libDir, platform);
+        platformApi = new PlatformApi(platform, platformRootDir, events);
+        cachedApis[platformRootDir] = platformApi;
+    }
+    return platformApi;
+}
+
+// Used to prevent attempts of installing platforms that are not supported on
+// the host OS. E.g. ios on linux.
+function hostSupports (platform) {
+    const { hostos } = platforms[platform] || {};
+    return !hostos || hostos.includes(process.platform);
+}
+
+module.exports = {
+    getPlatformApi,
+    hostSupports,
+    info: platforms,
+    list: Object.keys(platforms)
+};

--- a/src/platforms/platforms.js
+++ b/src/platforms/platforms.js
@@ -17,52 +17,18 @@
     under the License.
 */
 
-var path = require('path');
-var fs = require('fs-extra');
-var util = require('../cordova/util');
-var platforms = require('./platformsConfig.json');
-var events = require('cordova-common').events;
+const { getPlatformApi, info } = require('.');
 
-// Avoid loading the same platform projects more than once (identified by path)
-var cachedApis = {};
-
-// getPlatformApi() should be the only method of instantiating the
-// PlatformProject classes for now.
-function getPlatformApi (platform, platformRootDir) {
-    // if platformRootDir is not specified, try to detect it first
-    if (!platformRootDir) {
-        var projectRootDir = util.isCordova();
-        platformRootDir = projectRootDir && path.join(projectRootDir, 'platforms', platform);
-    }
-    if (!platformRootDir) {
-        // If platformRootDir is still undefined, then we're probably is not inside of cordova project
-        throw new Error('Current location is not a Cordova project');
-    }
-    // CB-11174 Resolve symlinks first before working with root directory
-    platformRootDir = util.convertToRealPathSafe(platformRootDir);
-
-    // Make sure the platforms/platform folder exists
-    if (!fs.existsSync(platformRootDir)) {
-        throw new Error('The platform "' + platform + '" does not appear to have been added to this project.');
-    }
-
-    var platformApi;
-    var cached = cachedApis[platformRootDir];
-    var libDir = path.join(platformRootDir, 'cordova', 'Api.js');
-    if (cached && cached.platform === platform) {
-        platformApi = cached;
-    } else {
-        var PlatformApi = util.getPlatformApiFunction(libDir, platform);
-        platformApi = new PlatformApi(platform, platformRootDir, events);
-        cachedApis[platformRootDir] = platformApi;
-    }
-    return platformApi;
-}
-
-module.exports = platforms;
+// Shallow-copy so that we don't affect other instances below
+module.exports = Object.assign({}, info);
 
 // We don't want these methods to be enumerable on the platforms object, because we expect enumerable properties of the
 // platforms object to be platforms.
 Object.defineProperties(module.exports, {
-    'getPlatformApi': { value: getPlatformApi, configurable: true, writable: true }
+    getPlatformApi: {
+        value: getPlatformApi,
+        configurable: true,
+        enumerable: false,
+        writable: true
+    }
 });

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -36,6 +36,7 @@ var superspawn = require('cordova-common').superspawn;
 var PluginInfo = require('cordova-common').PluginInfo;
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var variableMerge = require('./variable-merge');
+var plugmanFetch = require('./fetch');
 
 /* INSTALL FLOW
    ------------
@@ -92,8 +93,7 @@ function possiblyFetch (id, plugins_dir, options) {
     var opts = Object.assign({}, options, {
         client: 'plugman'
     });
-    // TODO: without runtime require below, we have a circular dependency.
-    return require('./plugman').fetch(id, plugins_dir, opts);
+    return plugmanFetch(id, plugins_dir, opts);
 }
 
 function checkEngines (engines) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Dependency cycles make testing hard since at least one module in the cycle has to require another at run-time. Furthermore they make it hard to separate the software into components conceptually. Finally, the facade-require anti-pattern that was often in use lead to huge parts of lib being loaded even is just a small part is actually being used (see also https://github.com/apache/cordova-cli/issues/406#issuecomment-481912178).

### Description
<!-- Describe your changes in detail -->
Details are in the commit messages.

After merging this PR, only one dependency cycle remains:
```
cordova/{prepare > restore-util > platform/index > platform/addHelper}
```
That's definitely the nastiest one, since it is the only one where there's also an actual cycle in the static call graph, i.e. a dependency cycle on function level instead of module level. I'll have to do some more testing to see if I can get rid of that one too. 

### Testing
<!-- Please describe in detail how you tested your changes. -->
Automated tests.