### PR TITLE
chore: improve npm ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
-spec-cordova
-spec-plugman
+.*
+appveyor.yml
 spec
+integration-tests
 coverage
-src/plugman/defaults.json
 temp


### PR DESCRIPTION
### Motivation and Context

Decrease production package size

### Description

**BEFORE**
npm notice package size:  105.7 kB
npm notice unpacked size: 487.6 kB
npm notice total files:   86

**AFTER**
npm notice package size:  88.3 kB
npm notice unpacked size: 394.7 kB
npm notice total files:   66

### Testing

- `npm t`



### Checklist

- [x] I've run the tests to see all new and existing tests pass