### PR TITLE
chore: replace superspawn with execa

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dep-graph": "^1.1.0",
     "detect-indent": "^6.0.0",
     "elementtree": "^0.1.7",
-    "execa": "^2.0.4",
+    "execa": "^3.2.0",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "indent-string": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dep-graph": "^1.1.0",
     "detect-indent": "^6.0.0",
     "elementtree": "^0.1.7",
+    "execa": "^2.0.4",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "indent-string": "^4.0.0",

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -17,15 +17,16 @@
     under the License.
 */
 
-const rewire = require('rewire');
 const fs = require('fs-extra');
 const path = require('path');
 const semver = require('semver');
+const rewire = require('rewire');
+
 const { events, PlatformJson } = require('cordova-common');
 const { spy: emitSpyHelper } = require('../common');
 const knownPlatforms = require('../../src/platforms/platforms');
-const { tmpDir, getFixture } = require('../helpers');
 
+const { tmpDir, getFixture } = require('../helpers');
 const temp_dir = tmpDir('plugman-install-test');
 const project = path.join(temp_dir, 'android_install');
 const plugins_dir = path.join(__dirname, 'plugins');

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -85,10 +85,6 @@ describe('plugman/install', () => {
                         .then(_ => returnValues.next());
                 });
 
-                // execaSpy = jasmine.createSpy('execa');
-                // execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
-                // install.__set__('execa', execaSpy);
-
                 return install('android', project, pluginDir('org.test.plugins.dummyplugin'));
             })
             .then(result => {

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -119,8 +119,6 @@ describe('plugman/install', () => {
         execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
         install.__set__('execa', execaSpy);
 
-        execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
-
         spyOn(fs, 'ensureDirSync');
         spyOn(fs, 'writeFileSync');
         spyOn(fs, 'copySync');

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -17,16 +17,15 @@
     under the License.
 */
 
+const rewire = require('rewire');
 const fs = require('fs-extra');
 const path = require('path');
 const semver = require('semver');
-const rewire = require('rewire');
-
-const { events, PlatformJson, superspawn } = require('cordova-common');
+const { events, PlatformJson } = require('cordova-common');
 const { spy: emitSpyHelper } = require('../common');
 const knownPlatforms = require('../../src/platforms/platforms');
-
 const { tmpDir, getFixture } = require('../helpers');
+
 const temp_dir = tmpDir('plugman-install-test');
 const project = path.join(temp_dir, 'android_install');
 const plugins_dir = path.join(__dirname, 'plugins');
@@ -67,6 +66,7 @@ const fake = {
 describe('plugman/install', () => {
     let install = require('../../src/plugman/install');
     let fetchSpy;
+    let execaSpy;
 
     beforeAll(() => {
         let api;
@@ -84,6 +84,10 @@ describe('plugman/install', () => {
                     return addPluginOrig.apply(api, arguments)
                         .then(_ => returnValues.next());
                 });
+
+                // execaSpy = jasmine.createSpy('execa');
+                // execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
+                // install.__set__('execa', execaSpy);
 
                 return install('android', project, pluginDir('org.test.plugins.dummyplugin'));
             })
@@ -115,7 +119,12 @@ describe('plugman/install', () => {
         fetchSpy = jasmine.createSpy('plugmanFetch').and.returnValue(Promise.resolve(pluginDir('com.cordova.engine')));
         install.__set__({ plugmanFetch: fetchSpy });
 
-        spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve(''));
+        execaSpy = jasmine.createSpy('execa');
+        execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
+        install.__set__('execa', execaSpy);
+
+        execaSpy.and.returnValue(Promise.resolve({ stdout: '' }));
+
         spyOn(fs, 'ensureDirSync');
         spyOn(fs, 'writeFileSync');
         spyOn(fs, 'copySync');
@@ -153,21 +162,21 @@ describe('plugman/install', () => {
             });
 
             it('Test 007 : should check version if plugin has engine tag', () => {
-                superspawn.spawn.and.returnValue(Promise.resolve('2.5.0'));
+                execaSpy.and.returnValue(Promise.resolve({ stdout: '2.5.0' }));
                 return install('android', project, pluginDir('com.cordova.engine'))
                     .then(() => {
                         expect(satisfies).toHaveBeenCalledWith('2.5.0', '>=1.0.0', true);
                     });
             }, TIMEOUT);
             it('Test 008 : should check version and munge it a little if it has "rc" in it so it plays nice with semver (introduce a dash in it)', () => {
-                superspawn.spawn.and.returnValue(Promise.resolve('3.0.0rc1'));
+                execaSpy.and.returnValue(Promise.resolve({ stdout: '3.0.0rc1' }));
                 return install('android', project, pluginDir('com.cordova.engine'))
                     .then(() => {
                         expect(satisfies).toHaveBeenCalledWith('3.0.0-rc1', '>=1.0.0', true);
                     });
             }, TIMEOUT);
             it('Test 009 : should check specific platform version over cordova version if specified', () => {
-                superspawn.spawn.and.returnValue(Promise.resolve('3.1.0'));
+                execaSpy.and.returnValue(Promise.resolve({ stdout: '3.1.0' }));
                 return install('android', project, pluginDir('com.cordova.engine-android'))
                     .then(() => {
                         expect(satisfies).toHaveBeenCalledWith('3.1.0', '>=3.1.0', true);
@@ -175,7 +184,7 @@ describe('plugman/install', () => {
             }, TIMEOUT);
             it('Test 010 : should check platform sdk version if specified', () => {
                 const cordovaVersion = require('../../package.json').version.replace(/-dev|-nightly.*$/, '');
-                superspawn.spawn.and.returnValue(Promise.resolve('18'));
+                execaSpy.and.returnValue(Promise.resolve({ stdout: '18' }));
                 return install('android', project, pluginDir('com.cordova.engine-android'))
                     .then(() => {
                         expect(satisfies.calls.count()).toBe(3);
@@ -220,7 +229,7 @@ describe('plugman/install', () => {
                 spyOn(fs, 'existsSync').and.callFake(fake['existsSync']['noPlugins']);
                 fetchSpy.and.callFake(fake['fetch']['dependencies']);
                 emit = spyOn(events, 'emit');
-                superspawn.spawn.and.returnValue(Promise.resolve('9.0.0'));
+                execaSpy.and.returnValue(Promise.resolve({ stdout: '9.0.0' }));
 
                 class PlatformApiMock {
                     static addPlugin () { return Promise.resolve(); }
@@ -339,7 +348,7 @@ describe('plugman/install', () => {
 
         it('Test 025 :should not fail when trying to install plugin less than minimum version. Skip instead  ', () => {
             spyOn(semver, 'satisfies').and.returnValue(false);
-            superspawn.spawn.and.returnValue(Promise.resolve('0.0.1'));
+            execaSpy.and.returnValue(Promise.resolve({ stdout: '0.0.1' }));
 
             return install('android', project, pluginDir('com.cordova.engine'))
                 .then(result => {

--- a/src/cordova/info.js
+++ b/src/cordova/info.js
@@ -72,7 +72,7 @@ function environmentInformation () {
     return Promise.all([
         'OS: ' + process.platform,
         'Node: ' + process.version,
-        failSafeSpawn('npm', ['-v']).then(data => 'npm: ' + data.stdout)
+        failSafeSpawn('npm', ['-v']).then(out => 'npm: ' + out)
     ])
         .then(env => env.join('\n'))
         .then(env => 'Environment: \n' + indent(env));
@@ -97,16 +97,16 @@ function getPlatformInfo (platform) {
     switch (platform) {
     case 'ios':
         return failSafeSpawn('xcodebuild', ['-version'])
-            .then(data => 'iOS platform:\n' + indent(data.stdout));
+            .then(out => 'iOS platform:\n' + indent(out));
     case 'android':
         return failSafeSpawn('android', ['list', 'target'])
-            .then(data => 'Android platform:\n' + indent(data.stdout));
+            .then(out => 'Android platform:\n' + indent(out));
     }
 }
 
 function failSafeSpawn (command, args) {
     return execa(command, args)
-        .catch(err => `ERROR: ${err.message}`);
+        .then(({ stdout }) => stdout, err => `ERROR: ${err.message}`);
 }
 
 function displayFileContents (filePath) {

--- a/src/cordova/info.js
+++ b/src/cordova/info.js
@@ -106,7 +106,7 @@ function getPlatformInfo (platform) {
 
 function failSafeSpawn (command, args) {
     return execa(command, args)
-        .catch(error => `ERROR: ${error.stderr}`);
+        .catch(err => `ERROR: ${err.message}`);
 }
 
 function displayFileContents (filePath) {

--- a/src/cordova/info.js
+++ b/src/cordova/info.js
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 */
 
+const execa = require('execa');
 var cordova_util = require('./util');
-var superspawn = require('cordova-common').superspawn;
 var pkg = require('../../package');
 var path = require('path');
 var fs = require('fs-extra');
@@ -72,7 +72,7 @@ function environmentInformation () {
     return Promise.all([
         'OS: ' + process.platform,
         'Node: ' + process.version,
-        failSafeSpawn('npm', ['-v']).then(out => 'npm: ' + out)
+        failSafeSpawn('npm', ['-v']).then(data => 'npm: ' + data.stdout)
     ])
         .then(env => env.join('\n'))
         .then(env => 'Environment: \n' + indent(env));
@@ -97,16 +97,16 @@ function getPlatformInfo (platform) {
     switch (platform) {
     case 'ios':
         return failSafeSpawn('xcodebuild', ['-version'])
-            .then(out => 'iOS platform:\n' + indent(out));
+            .then(data => 'iOS platform:\n' + indent(data.stdout));
     case 'android':
         return failSafeSpawn('android', ['list', 'target'])
-            .then(out => 'Android platform:\n' + indent(out));
+            .then(data => 'Android platform:\n' + indent(data.stdout));
     }
 }
 
 function failSafeSpawn (command, args) {
-    return superspawn.spawn(command, args)
-        .catch(err => `ERROR: ${err.message}`);
+    return execa(command, args)
+        .catch(error => `ERROR: ${error.stderr}`);
 }
 
 function displayFileContents (filePath) {

--- a/src/cordova/plugin/util.js
+++ b/src/cordova/plugin/util.js
@@ -17,13 +17,13 @@
     under the License.
 */
 
+const execa = require('execa');
 var path = require('path');
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var fs = require('fs-extra');
 var events = require('cordova-common').events;
 var CordovaError = require('cordova-common').CordovaError;
 var fetch = require('cordova-fetch');
-var superspawn = require('cordova-common').superspawn;
 
 module.exports.getInstalledPlugins = getInstalledPlugins;
 module.exports.mergeVariables = mergeVariables;
@@ -80,9 +80,9 @@ function info (plugin) {
     // check if npm is installed
     return fetch.isNpmInstalled()
         .then(function () {
-            return superspawn.spawn('npm', viewArgs)
-                .then(function (info) {
-                    var pluginInfo = JSON.parse(info);
+            return execa('npm', viewArgs)
+                .then(function (data) {
+                    var pluginInfo = JSON.parse(data.stdout);
                     return pluginInfo;
                 });
         });

--- a/src/cordova/plugin/util.js
+++ b/src/cordova/plugin/util.js
@@ -81,8 +81,8 @@ function info (plugin) {
     return fetch.isNpmInstalled()
         .then(function () {
             return execa('npm', viewArgs)
-                .then(function (data) {
-                    var pluginInfo = JSON.parse(data.stdout);
+                .then(({ stdout: info }) => {
+                    var pluginInfo = JSON.parse(info);
                     return pluginInfo;
                 });
         });

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -27,7 +27,7 @@ function handleError (error) {
         events.emit('warn', 'Platform does not support ' + this.script);
     } else {
         events.emit('warn', 'An unexpected error has occured while running ' + this.script +
-            ' with code ' + error.errno + ': ' + error.message);
+            ':\n' + error.message);
     }
 }
 

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -17,17 +17,17 @@
     under the License.
 */
 
+const execa = require('execa');
 var cordova_util = require('./util');
-var superspawn = require('cordova-common').superspawn;
 var path = require('path');
 var events = require('cordova-common').events;
 
 function handleError (error) {
-    if (error.code === 'ENOENT') {
+    if (error.errno === 'ENOENT') {
         events.emit('warn', 'Platform does not support ' + this.script);
     } else {
         events.emit('warn', 'An unexpected error has occured while running ' + this.script +
-            ' with code ' + error.code + ': ' + error);
+            ' with code ' + error.errno + ': ' + error.message);
     }
 }
 
@@ -35,14 +35,14 @@ function displayDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-devices' };
     events.emit('log', 'Available ' + platform + ' devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-devices');
-    return superspawn.spawn(cmd, options.argv, { stdio: 'inherit', chmod: true }).catch(handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout).catch(handleError.bind(caller));
 }
 
 function displayVirtualDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-emulator-images' };
     events.emit('log', 'Available ' + platform + ' virtual devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-emulator-images');
-    return superspawn.spawn(cmd, options.argv, { stdio: 'inherit', chmod: true }).catch(handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout).catch(handleError.bind(caller));
 }
 
 module.exports = function targets (options) {

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -23,7 +23,7 @@ var path = require('path');
 var events = require('cordova-common').events;
 
 function handleError (error) {
-    if (error.errno === 'ENOENT') {
+    if (error.code === 'ENOENT') {
         events.emit('warn', 'Platform does not support ' + this.script);
     } else {
         events.emit('warn', 'An unexpected error has occured while running ' + this.script +

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -35,7 +35,7 @@ function displayDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-devices' };
     events.emit('log', 'Available ' + platform + ' devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-devices');
-    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout).catch(handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout, handleError.bind(caller));
 }
 
 function displayVirtualDevices (projectRoot, platform, options) {

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -42,7 +42,7 @@ function displayVirtualDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-emulator-images' };
     events.emit('log', 'Available ' + platform + ' virtual devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-emulator-images');
-    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout).catch(handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout, handleError.bind(caller));
 }
 
 module.exports = function targets (options) {

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -35,14 +35,14 @@ function displayDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-devices' };
     events.emit('log', 'Available ' + platform + ' devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-devices');
-    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout, handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit' }).then(data => data.stdout, handleError.bind(caller));
 }
 
 function displayVirtualDevices (projectRoot, platform, options) {
     var caller = { 'script': 'list-emulator-images' };
     events.emit('log', 'Available ' + platform + ' virtual devices:');
     var cmd = path.join(projectRoot, 'platforms', platform, 'cordova', 'lib', 'list-emulator-images');
-    return execa(cmd, options.argv, { stdio: 'inherit', chmod: true }).then(data => data.stdout, handleError.bind(caller));
+    return execa(cmd, options.argv, { stdio: 'inherit' }).then(data => data.stdout, handleError.bind(caller));
 }
 
 module.exports = function targets (options) {

--- a/src/hooks/HooksRunner.js
+++ b/src/hooks/HooksRunner.js
@@ -15,16 +15,16 @@
  under the License.
  */
 
+const execa = require('execa');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 const readChunk = require('read-chunk');
 const shebangCommand = require('shebang-command');
-
 const cordovaUtil = require('../cordova/util');
 const scriptsFinder = require('./scriptsFinder');
 const Context = require('./Context');
-const { CordovaError, events, superspawn } = require('cordova-common');
+const { CordovaError, events } = require('cordova-common');
 
 const isWindows = os.platform().slice(0, 3) === 'win';
 
@@ -195,9 +195,10 @@ function runScriptViaChildProcessSpawn (script, context) {
         }
     };
 
-    return superspawn.spawn(command, args, execOpts)
-        .catch(function (err) {
-            throw new Error('Hook failed with error code ' + err.code + ': ' + script.fullPath);
+    return execa(command, args, execOpts)
+        .then(data => data.stdout)
+        .catch(function (error) {
+            throw new Error('Hook failed with error code ' + error.errno + ': ' + script.fullPath);
         });
 }
 

--- a/src/hooks/HooksRunner.js
+++ b/src/hooks/HooksRunner.js
@@ -21,6 +21,7 @@ const os = require('os');
 const path = require('path');
 const readChunk = require('read-chunk');
 const shebangCommand = require('shebang-command');
+
 const cordovaUtil = require('../cordova/util');
 const scriptsFinder = require('./scriptsFinder');
 const Context = require('./Context');

--- a/src/hooks/HooksRunner.js
+++ b/src/hooks/HooksRunner.js
@@ -194,13 +194,10 @@ function runScriptViaChildProcessSpawn (script, context) {
         }
     };
 
-    events.emit('log', `Running command: ${command} ${args.join(' ')}`);
+    events.emit('log', `Running hook: ${command} ${args.join(' ')}`);
 
     return execa(command, args, execOpts)
-        .then(data => data.stdout)
-        .catch(function (error) {
-            throw new Error('Hook failed with error code ' + error.errno + ': ' + script.fullPath);
-        });
+        .then(data => data.stdout);
 }
 
 /**

--- a/src/hooks/HooksRunner.js
+++ b/src/hooks/HooksRunner.js
@@ -184,7 +184,6 @@ function runScriptViaChildProcessSpawn (script, context) {
 
     const execOpts = {
         cwd: opts.projectRoot,
-        printCommand: true,
         stdio: 'inherit',
         env: {
             CORDOVA_VERSION: require('../../package').version,
@@ -194,6 +193,8 @@ function runScriptViaChildProcessSpawn (script, context) {
             CORDOVA_CMDLINE: process.argv.join(' ')
         }
     };
+
+    events.emit('log', `Running command: ${command} ${args.join(' ')}`);
 
     return execa(command, args, execOpts)
         .then(data => data.stdout)

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -171,8 +171,8 @@ function callEngineScripts (engines, project_dir) {
                     fs.chmodSync(engine.scriptSrc, '755');
                 }
                 return execa(scriptPath)
-                    .then(data => {
-                        engine.currentVersion = cleanVersionOutput(data.stdout, engine.name);
+                    .then(({ stdout }) => {
+                        engine.currentVersion = cleanVersionOutput(stdout, engine.name);
                         if (engine.currentVersion === '') {
                             events.emit('warn', engine.name + ' version check returned nothing (' + scriptPath + '), continuing anyways.');
                             engine.currentVersion = null;
@@ -434,16 +434,16 @@ function tryFetchDependency (dep, install, options) {
             dep.url = fetchdata.source.path;
 
             return execa.command('git rev-parse --show-toplevel', { cwd: dep.url })
-                .catch(error => {
-                    if (error.exitCode === 128) {
+                .catch(err => {
+                    if (err.exitCode === 128) {
                         throw new Error('Plugin ' + dep.id + ' is not in git repository. All plugins must be in a git repository.');
                     } else {
                         throw new Error('Failed to locate git repository for ' + dep.id + ' plugin.');
                     }
                 })
-                .then(function (data) {
+                .then(({ stdout: git_repo }) => {
                     // Clear out the subdir since the url now contains it
-                    var url = path.join(data.stdout, dep.subdir);
+                    var url = path.join(git_repo, dep.subdir);
                     dep.subdir = '';
                     return Promise.resolve(url);
                 }).catch(function () {

--- a/src/plugman/uninstall.js
+++ b/src/plugman/uninstall.js
@@ -17,7 +17,6 @@
     under the License.
 */
 
-const execa = require('execa');
 var path = require('path');
 var fs = require('fs-extra');
 var ActionStack = require('cordova-common').ActionStack;

--- a/src/plugman/uninstall.js
+++ b/src/plugman/uninstall.js
@@ -17,6 +17,7 @@
     under the License.
 */
 
+const execa = require('execa');
 var path = require('path');
 var fs = require('fs-extra');
 var ActionStack = require('cordova-common').ActionStack;


### PR DESCRIPTION
### Motivation and Context

https://github.com/apache/cordova/issues/16

### Description

Replace `superspawn` usage with `execa` 

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
