### PR TITLE
Do not spawn child process to get platform version

### DIFF
--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -296,7 +296,7 @@ function runInstall (actions, platform, project_dir, plugin_dir, plugins_dir, op
         if (options.platformVersion) {
             return Promise.resolve(options.platformVersion);
         }
-        return Promise.resolve(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version'), [], { chmod: true }));
+        return Promise.resolve(cordovaUtil.getPlatformVersion(project_dir));
     }).then(function (platformVersion) {
         options.platformVersion = platformVersion;
         return callEngineScripts(theEngines, path.resolve(plugins_dir, '..'));

--- a/src/plugman/uninstall.js
+++ b/src/plugman/uninstall.js
@@ -29,7 +29,6 @@ var HooksRunner = require('../hooks/HooksRunner');
 var cordovaUtil = require('../cordova/util');
 var npmUninstall = require('cordova-fetch').uninstall;
 
-var superspawn = require('cordova-common').superspawn;
 var PlatformJson = require('cordova-common').PlatformJson;
 var PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 var variableMerge = require('../plugman/variable-merge');
@@ -83,7 +82,7 @@ module.exports.uninstallPlatform = function (platform, project_dir, id, plugins_
         if (options.platformVersion) {
             return Promise.resolve(options.platformVersion);
         }
-        return Promise.resolve(superspawn.maybeSpawn(path.join(project_dir, 'cordova', 'version'), [], { chmod: true }));
+        return Promise.resolve(cordovaUtil.getPlatformVersion(project_dir));
     }).then(function (platformVersion) {
         options.platformVersion = platformVersion;
         return runUninstallPlatform(current_stack, platform, project_dir, plugin_dir, plugins_dir, options);


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We should not have to spawn a child process to get a platform version. Since platform version scripts also export the version, we don't have to.

This would resolve the `maybeSpawn` issues in #812


### Description
<!-- Describe your changes in detail -->
Instead of running the version script, we require it (without caching).

