### PR TITLE
Extend and improve plugin tests in preparation of supporting scoped plugins

### DIFF
--- a/integration-tests/plugman_fetch.spec.js
+++ b/integration-tests/plugman_fetch.spec.js
@@ -29,6 +29,7 @@ var test_pkgjson_plugin = path.join(plugins_dir, 'pkgjson-test-plugin');
 var test_plugin_searchpath = path.join(test_plugin, '..');
 var test_plugin_id = 'org.test.plugins.childbrowser';
 var test_plugin_version = '0.6.0';
+const { asymmetricMatchers: { pathNormalizingTo } } = require('../spec/helpers');
 
 describe('fetch', function () {
     describe('local plugins', function () {
@@ -65,7 +66,11 @@ describe('fetch', function () {
 
         it('Test 002 : should copy locally-available plugin to plugins directory when adding a plugin with searchpath argument', function () {
             return fetch(test_plugin_id, temp, { searchpath: test_plugin_searchpath }).then(function () {
-                expect(fs.copySync).toHaveBeenCalledWith(test_plugin, path.join(temp, test_plugin_id), jasmine.objectContaining({ dereference: true }));
+                expect(fs.copySync).toHaveBeenCalledWith(
+                    pathNormalizingTo(test_plugin),
+                    path.join(temp, test_plugin_id),
+                    jasmine.objectContaining({ dereference: true })
+                );
             });
         });
         it('Test 003 : should create a symlink if used with `link` param', function () {

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -381,7 +381,7 @@ describe('cordova/plugin/add', function () {
                     });
             });
             it('should retrieve installed plugins and installed platforms version and feed that information into determinePluginVersionToFetch', function () {
-                plugin_util.getInstalledPlugins.and.returnValue([{ 'id': 'cordova-plugin-camera', 'version': '2.0.0' }]);
+                plugin_util.getInstalledPlugins.and.returnValue([{ 'id': '@cordova/plugin-thinger', 'version': '2.0.0' }]);
                 cordova_util.getInstalledPlatformsWithVersions.and.returnValue(Promise.resolve({ 'android': '6.0.0' }));
                 pluginInfo.engines = {};
                 pluginInfo.engines.cordovaDependencies = { '^1.0.0': { 'cordova': '>7.0.0' } };
@@ -389,7 +389,7 @@ describe('cordova/plugin/add', function () {
                     .then(function () {
                         expect(plugin_util.getInstalledPlugins).toHaveBeenCalledWith(projectRoot);
                         expect(cordova_util.getInstalledPlatformsWithVersions).toHaveBeenCalledWith(projectRoot);
-                        expect(add.determinePluginVersionToFetch).toHaveBeenCalledWith(pluginInfo, { 'cordova-plugin-camera': '2.0.0' }, { 'android': '6.0.0' }, '7.0.0');
+                        expect(add.determinePluginVersionToFetch).toHaveBeenCalledWith(pluginInfo, { '@cordova/plugin-thinger': '2.0.0' }, { 'android': '6.0.0' }, '7.0.0');
                     });
             });
         });

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -108,42 +108,42 @@ describe('util module', function () {
         });
     });
     describe('findPlugins method', function () {
+        let pluginsDir, plugins;
+
+        function expectFindPluginsToReturn (expectedPlugins) {
+            expect(util.findPlugins(pluginsDir))
+                .toEqual(jasmine.arrayWithExactContents(expectedPlugins));
+        }
+
+        beforeEach(function () {
+            pluginsDir = path.join(temp, 'plugins');
+            plugins = ['foo', 'bar', 'baz'];
+
+            plugins.forEach(plugin => {
+                fs.ensureDirSync(path.join(pluginsDir, plugin));
+            });
+        });
+
         it('Test 011 : should only return plugin directories present in a cordova project dir', function () {
-            var plugins = path.join(temp, 'plugins');
-            var android = path.join(plugins, 'android');
-            var ios = path.join(plugins, 'ios');
-            var wp8_dir = path.join(plugins, 'wp8');
-            var atari = path.join(plugins, 'atari');
-            fs.ensureDirSync(android);
-            fs.ensureDirSync(ios);
-            fs.ensureDirSync(wp8_dir);
-            fs.ensureDirSync(atari);
-            var res = util.findPlugins(plugins);
-            expect(res.length).toEqual(4);
+            expectFindPluginsToReturn(plugins);
         });
+
         it('Test 012 : should not return ".svn" directories', function () {
-            var plugins = path.join(temp, 'plugins');
-            var android = path.join(plugins, 'android');
-            var ios = path.join(plugins, 'ios');
-            var svn = path.join(plugins, '.svn');
-            fs.ensureDirSync(android);
-            fs.ensureDirSync(ios);
-            fs.ensureDirSync(svn);
-            var res = util.findPlugins(plugins);
-            expect(res.length).toEqual(2);
-            expect(res.indexOf('.svn')).toEqual(-1);
+            fs.ensureDirSync(path.join(pluginsDir, '.svn'));
+            expectFindPluginsToReturn(plugins);
         });
+
         it('Test 013 : should not return "CVS" directories', function () {
-            var plugins = path.join(temp, 'plugins');
-            var android = path.join(plugins, 'android');
-            var ios = path.join(plugins, 'ios');
-            var cvs = path.join(plugins, 'CVS');
-            fs.ensureDirSync(android);
-            fs.ensureDirSync(ios);
-            fs.ensureDirSync(cvs);
-            var res = util.findPlugins(plugins);
-            expect(res.length).toEqual(2);
-            expect(res.indexOf('CVS')).toEqual(-1);
+            fs.ensureDirSync(path.join(pluginsDir, 'CVS'));
+            expectFindPluginsToReturn(plugins);
+        });
+
+        it('Test 031 : should return plugin symlinks', function () {
+            const linkedPluginPath = path.join(temp, 'linked-plugin');
+            const pluginLinkPath = path.join(pluginsDir, 'plugin-link');
+            fs.ensureDirSync(linkedPluginPath);
+            fs.ensureSymlinkSync(linkedPluginPath, pluginLinkPath);
+            expectFindPluginsToReturn(plugins.concat('plugin-link'));
         });
     });
 

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -189,6 +189,15 @@ module.exports.writeConfigContent = function (appPath, configContent) {
     fs.writeFileSync(configFile, configContent, 'utf-8');
 };
 
+module.exports.asymmetricMatchers = {
+    pathNormalizingTo (expectedPath) {
+        return {
+            asymmetricMatch: actualPath => path.normalize(actualPath) === expectedPath,
+            jasmineToString: _ => `<pathNormalizingTo(${expectedPath})>`
+        };
+    }
+};
+
 const customMatchers = {
     toExist: () => ({ compare (file) {
         const pass = fs.existsSync(file);

--- a/spec/plugman/util/metadata.spec.js
+++ b/spec/plugman/util/metadata.spec.js
@@ -1,0 +1,132 @@
+/*!
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const path = require('path');
+const rewire = require('rewire');
+
+const pluginsDir = path.normalize('/plugins_dir/');
+const fetchJsonPath = path.join(pluginsDir, 'fetch.json');
+
+let fetchJson = null;
+const fsMock = {
+    readFileSync: () => fetchJson,
+    existsSync: () => fetchJson !== null,
+    writeFileSync (_, data) { fetchJson = data; },
+    unlinkSync () { fetchJson = null; }
+};
+
+// expect fsMock to only operate on fetchJsonPath
+Object.entries(fsMock).map(([key, fn]) => {
+    fsMock[key] = (...args) => {
+        expect(args[0]).toBe(fetchJsonPath);
+        return fn(...args);
+    };
+});
+
+describe('plugman.metadata', () => {
+    const TEST_PLUGIN = 'cordova-plugin-thinger';
+    let metadata;
+
+    beforeEach(() => {
+        metadata = rewire('../../../src/plugman/util/metadata');
+        metadata.__set__('fs', fsMock);
+        fetchJson = JSON.stringify({
+            [TEST_PLUGIN]: { metadata: 'matches' }
+        });
+    });
+
+    describe('get_fetch_metadata', () => {
+        const get_fetch_metadata = pluginId =>
+            metadata.get_fetch_metadata(path.join(pluginsDir, pluginId));
+
+        it('should return an empty object if there is no record', () => {
+            fetchJson = null;
+            expect(get_fetch_metadata(TEST_PLUGIN)).toEqual({});
+        });
+
+        it('should return the fetch metadata in plugins_dir/fetch.json if it is there', () => {
+            expect(get_fetch_metadata(TEST_PLUGIN)).toEqual({ metadata: 'matches' });
+        });
+
+        describe('cache behaviour', () => {
+            beforeEach(() => {
+                spyOn(fsMock, 'readFileSync').and.callThrough();
+                spyOn(fsMock, 'existsSync').and.callThrough();
+            });
+
+            it('with no cache, it should read from the filesystem', () => {
+                expect(get_fetch_metadata(TEST_PLUGIN)).toEqual({ metadata: 'matches' });
+                expect(fsMock.existsSync).toHaveBeenCalled();
+                expect(fsMock.readFileSync).toHaveBeenCalled();
+            });
+
+            it('with a cache, it should read from the cache', () => {
+                metadata.__set__('cachedJson', {
+                    'cordova-plugin-thinger': { metadata: 'cached' }
+                });
+
+                expect(get_fetch_metadata(TEST_PLUGIN)).toEqual({ metadata: 'cached' });
+                expect(fsMock.existsSync).not.toHaveBeenCalled();
+                expect(fsMock.readFileSync).not.toHaveBeenCalled();
+            });
+
+        });
+    });
+
+    describe('save_fetch_metadata', () => {
+        const save_fetch_metadata = (...args) =>
+            metadata.save_fetch_metadata(pluginsDir, ...args);
+
+        it('should save plugin metadata to a new fetch.json', () => {
+            fetchJson = null;
+            const meta = { metadata: 'saved' };
+
+            save_fetch_metadata('@cordova/plugin-thinger', meta);
+
+            expect(JSON.parse(fetchJson)).toEqual({
+                '@cordova/plugin-thinger': meta
+            });
+        });
+
+        it('should save plugin metadata to an existing fetch.json', () => {
+            const meta = { metadata: 'saved' };
+            const oldFetchJson = {
+                'some-other-plugin': { metadata: 'not-touched' }
+            };
+            fetchJson = JSON.stringify(oldFetchJson);
+
+            save_fetch_metadata('@cordova/plugin-thinger', meta);
+
+            expect(JSON.parse(fetchJson)).toEqual({
+                '@cordova/plugin-thinger': meta,
+                ...oldFetchJson
+            });
+        });
+    });
+
+    describe('remove_fetch_metadata', () => {
+        const remove_fetch_metadata = (...args) =>
+            metadata.remove_fetch_metadata(pluginsDir, ...args);
+
+        it('should remove metadata', () => {
+            remove_fetch_metadata(TEST_PLUGIN);
+            expect(JSON.parse(fetchJson)).toEqual({});
+        });
+    });
+});


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is a revised version of all passing tests that were included in #602 or #680 respectively. I pulled them out of the original PR to reduce its volume and because they are valid without the other changes of the PR.


### Description
<!-- Describe your changes in detail -->
- Extend tests for addHelper.installPluginsForNewPlatform
- Simplify and extend unit tests for cordova/util.findPlugins
- Add passing unit tests for plugman/util/metadata
- Test plugin/add.getFetchVersion w/ scoped plugins
- Less strict path comparison in plugman_fetch.spec
