### PR TITLE
refactor: use execa's cross-platform shebang support in HooksRunner

### DIFF
--- a/integration-tests/HooksRunner.spec.js
+++ b/integration-tests/HooksRunner.spec.js
@@ -435,18 +435,4 @@ describe('HooksRunner', function () {
             return hooksRunner.fire('CLEAN YOUR SHORTS GODDAMNIT LIKE A BIG BOY!', hookOptions);
         });
     });
-
-    describe('extractSheBangInterpreter', () => {
-        const rewire = require('rewire');
-        const HooksRunner = rewire('../src/hooks/HooksRunner');
-        const extractSheBangInterpreter = HooksRunner.__get__('extractSheBangInterpreter');
-
-        it('Test 025 : should not read uninitialized buffer contents', () => {
-            spyOn(require('fs'), 'readSync').and.callFake((fd, buf) => {
-                buf.write('#!/usr/bin/env XXX\n# foo');
-                return 0;
-            });
-            expect(extractSheBangInterpreter(__filename)).toBeFalsy();
-        });
-    });
 });

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "init-package-json": "^1.10.3",
     "md5-file": "^4.0.0",
     "pify": "^4.0.1",
-    "read-chunk": "^3.2.0",
-    "semver": "^6.3.0",
-    "shebang-command": "^2.0.0"
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "codecov": "^3.2.0",


### PR DESCRIPTION
Up until now, we have maintained code for shebang support in hook
scripts on Windows. Fortunately, execa comes with support for that out
of the box. So this commit drops our implementation and makes use of
execa's.
