### PR TITLE
fix: plugin installation from git url w/ semver

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -278,6 +278,17 @@ describe('pkgJson', function () {
                     expect(getPkgJson(`dependencies.${PLUGIN}`)).toBeDefined();
                 });
         });
+
+        it('Test#026 : should successfully add a plugin with git/semver combo', async () => {
+            const URL = 'https://github.com/apache/cordova-plugin-device.git#semver:2.0.x';
+
+            expect(getPkgJson('cordova.plugins')).toBeUndefined();
+            expect(getPkgJson(`dependencies.${pluginId}`)).toBeUndefined();
+
+            await cordova.plugin('add', URL, { save: true });
+            expect(getPkgJson('cordova.plugins')[pluginId]).toBeDefined();
+            expect(getPkgJson('dependencies')[pluginId]).toMatch(URL);
+        });
     });
 
     // This group of tests checks if platforms are added and removed as expected from package.json.

--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -61,11 +61,6 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
         if (result) {
             if (result[1]) { options.git_ref = result[1]; }
             if (result[2]) { options.subdir = result[2]; }
-
-            // throw error for subdirectories
-            if (options.subdir && options.subdir !== '.') {
-                return Promise.reject(new CordovaError('Cordova does not support subdirectories'));
-            }
         }
     }
     return Promise.resolve().then(function () {


### PR DESCRIPTION
AFAICT, the check that is removed here was part of our previous plugin fetching mechanism and was not removed when migrating to cordova-fetch.

Fixes #795