### PR TITLE
test: use expectAsync for rejections

### DIFF
--- a/integration-tests/HooksRunner.spec.js
+++ b/integration-tests/HooksRunner.spec.js
@@ -164,11 +164,9 @@ describe('HooksRunner', function () {
                 `;
                 addHooksToConfig(FAIL_HOOK);
 
-                return hooksRunner.fire('fail').then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                });
+                return expectAsync(
+                    hooksRunner.fire('fail')
+                ).toBeRejectedWithError();
             });
 
             it('Test 024 : should not error if the hook is unrecognized', function () {

--- a/integration-tests/plugman_fetch.spec.js
+++ b/integration-tests/plugman_fetch.spec.js
@@ -115,13 +115,9 @@ describe('fetch', function () {
         });
         it('Test 028 : should fail when locally-available plugin is missing pacakge.json', function () {
             test_plugin = path.join(plugins_dir, 'org.test.androidonly');
-            return fetch(test_plugin, temp)
-                .then(function () {
-                    fail();
-                }, function (err) {
-                    expect(err).toBeDefined();
-                    expect(err.message).toContain('needs a valid package.json');
-                });
+            return expectAsync(
+                fetch(test_plugin, temp)
+            ).toBeRejectedWithError(/needs a valid package\.json/);
         });
     });
 

--- a/integration-tests/plugman_uninstall.spec.js
+++ b/integration-tests/plugman_uninstall.spec.js
@@ -154,21 +154,17 @@ describe('plugman/uninstall', () => {
 
         describe('failure ', function () {
             it('Test 004 : should throw if platform is unrecognized', function () {
-                return uninstall.uninstallPlatform('atari', project, 'SomePlugin')
-                    .then(function (result) {
-                        fail('Expected promise to be rejected');
-                    }, function err (errMsg) {
-                        expect(errMsg.toString()).toContain('Platform "atari" not supported.');
-                    });
+                return expectAsync(
+                    uninstall.uninstallPlatform('atari', project, 'SomePlugin')
+                ).toBeRejectedWithError('Platform "atari" not supported.');
             });
 
             it('Test 005 : should throw if plugin is missing', function () {
-                return uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
-                    .then(function (result) {
-                        fail('Expected promise to be rejected');
-                    }, function err (errMsg) {
-                        expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-                    });
+                return expectAsync(
+                    uninstall.uninstallPlatform('android', project, 'SomePluginThatDoesntExist')
+                ).toBeRejectedWithError(
+                    'Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?'
+                );
             });
         });
     });
@@ -192,12 +188,11 @@ describe('plugman/uninstall', () => {
             it('Test 007 : should fail if plugin is a required dependency', function () {
                 setupProject('uninstall.test');
 
-                return uninstall.uninstallPlugin('C', plugins_install_dir)
-                    .then(function (result) {
-                        fail('Expected promise to be rejected');
-                    }, function err (errMsg) {
-                        expect(errMsg.toString()).toEqual('Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)');
-                    });
+                return expectAsync(
+                    uninstall.uninstallPlugin('C', plugins_install_dir)
+                ).toBeRejectedWithError(
+                    'Plugin "C" is required by (A) and cannot be removed (hint: use -f or --force)'
+                );
             });
 
             it('Test 008 : allow forcefully removing a plugin', function () {
@@ -245,21 +240,17 @@ describe('plugman/uninstall', () => {
 
         describe('failure', function () {
             it('Test 011 : should throw if platform is unrecognized', function () {
-                return uninstall('atari', project, 'SomePlugin')
-                    .then(function (result) {
-                        fail('Expected promise to be rejected');
-                    }, function err (errMsg) {
-                        expect(errMsg.toString()).toContain('Platform "atari" not supported.');
-                    });
+                return expectAsync(
+                    uninstall('atari', project, 'SomePlugin')
+                ).toBeRejectedWithError('Platform "atari" not supported.');
             });
 
             it('Test 012 : should throw if plugin is missing', function () {
-                return uninstall('android', project, 'SomePluginThatDoesntExist')
-                    .then(function (result) {
-                        fail('Expected promise to be rejected');
-                    }, function err (errMsg) {
-                        expect(errMsg.toString()).toContain('Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?');
-                    });
+                return expectAsync(
+                    uninstall('android', project, 'SomePluginThatDoesntExist')
+                ).toBeRejectedWithError(
+                    'Plugin "SomePluginThatDoesntExist" not found. Already uninstalled?'
+                );
             });
         });
     });

--- a/spec/cordova/build.spec.js
+++ b/spec/cordova/build.spec.js
@@ -39,29 +39,21 @@ describe('build command', function () {
     describe('failure', function () {
         it('Test 001 : should not run inside a project with no platforms', function () {
             util.listPlatforms.and.returnValue([]);
-            return cordovaBuild()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toEqual(
-                        'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                    );
-                });
+            return expectAsync(
+                cordovaBuild()
+            ).toBeRejectedWithError(
+                'No platforms added to this project. Please use `cordova platform add <platform>`.'
+            );
         });
 
         it('Test 002 : should not run outside of a Cordova-based project', function () {
             util.isCordova.and.returnValue(false);
 
-            return cordovaBuild()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toEqual(
-                        'Current working directory is not a Cordova-based project.'
-                    );
-                });
+            return expectAsync(
+                cordovaBuild()
+            ).toBeRejectedWithError(
+                'Current working directory is not a Cordova-based project.'
+            );
         });
     });
 
@@ -101,14 +93,12 @@ describe('build command', function () {
         describe('with no platforms added', function () {
             it('Test 008 : should not fire the hooker', function () {
                 util.listPlatforms.and.returnValue([]);
-                return Promise.resolve().then(cordovaBuild).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toEqual(
-                        'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                    );
-                });
+
+                return expectAsync(
+                    cordovaBuild()
+                ).toBeRejectedWithError(
+                    'No platforms added to this project. Please use `cordova platform add <platform>`.'
+                );
             });
         });
     });

--- a/spec/cordova/compile.spec.js
+++ b/spec/cordova/compile.spec.js
@@ -42,22 +42,17 @@ describe('compile command', function () {
     describe('failure', function () {
         it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function () {
             list_platforms.and.returnValue([]);
-            return cordova.compile()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.');
-                });
+            return expectAsync(
+                cordova.compile()
+            ).toBeRejectedWithError(
+                'No platforms added to this project. Please use `cordova platform add <platform>`.'
+            );
         });
         it('Test 002 : should not run outside of a Cordova-based project', function () {
             is_cordova.and.returnValue(false);
-            return cordova.compile()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                });
+            return expectAsync(
+                cordova.compile()
+            ).toBeRejectedWithError();
         });
     });
 
@@ -97,18 +92,16 @@ describe('compile command', function () {
         });
 
         describe('with no platforms added', function () {
-            it('Test 008 : should not fire the hooker', function () {
+            it('Test 008 : should not fire the hooker', async function () {
                 list_platforms.and.returnValue([]);
-                return Promise.resolve().then(cordova.compile)
-                    .then(function () {
-                        fail('Expected promise to be rejected');
-                    }, function (err) {
-                        expect(err).toEqual(jasmine.any(Error));
-                        expect(fire).not.toHaveBeenCalled();
-                        expect(err.message).toContain(
-                            'No platforms added to this project. Please use `cordova platform add <platform>`.'
-                        );
-                    });
+
+                await expectAsync(
+                    cordova.compile()
+                ).toBeRejectedWithError(
+                    'No platforms added to this project. Please use `cordova platform add <platform>`.'
+                );
+
+                expect(fire).not.toHaveBeenCalled();
             });
         });
     });

--- a/spec/cordova/emulate.spec.js
+++ b/spec/cordova/emulate.spec.js
@@ -46,22 +46,17 @@ describe('emulate command', function () {
     describe('failure', function () {
         it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function () {
             util.listPlatforms.and.returnValue([]);
-            return cordovaEmulate()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.');
-                });
+            return expectAsync(
+                cordovaEmulate()
+            ).toBeRejectedWithError(
+                'No platforms added to this project. Please use `cordova platform add <platform>`.'
+            );
         });
         it('Test 002 : should not run outside of a Cordova-based project', function () {
             util.isCordova.and.returnValue(false);
-            return cordovaEmulate()
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                });
+            return expectAsync(
+                cordovaEmulate()
+            ).toBeRejectedWithError();
         });
     });
 
@@ -144,15 +139,16 @@ describe('emulate command', function () {
         });
 
         describe('with no platforms added', function () {
-            it('Test 011 : should not fire the hooker', function () {
+            it('Test 011 : should not fire the hooker', async function () {
                 util.listPlatforms.and.returnValue([]);
-                return Promise.resolve().then(cordovaEmulate).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toContain('No platforms added to this project. Please use `cordova platform add <platform>`.');
-                    expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
-                });
+
+                await expectAsync(
+                    cordovaEmulate()
+                ).toBeRejectedWithError(
+                    'No platforms added to this project. Please use `cordova platform add <platform>`.'
+                );
+
+                expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
             });
         });
     });

--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -110,19 +110,17 @@ describe('cordova/platform/addHelper', function () {
 
         it('should throw if platform was already added before adding', function () {
             fs.existsSync.and.returnValue('/some/path/platforms/ios');
-            return platform_addHelper('add', hooks_mock, projectRoot, ['ios']).then(function () {
-                fail('addHelper success handler unexpectedly invoked');
-            }, function (e) {
-                expect(e.message).toContain('already added.');
-            });
+            return expectAsync(
+                platform_addHelper('add', hooks_mock, projectRoot, ['ios'])
+            ).toBeRejectedWithError(/already added\./);
         });
 
         it('should throw if platform was not added before updating', function () {
-            return platform_addHelper('update', hooks_mock, projectRoot, ['atari']).then(function () {
-                fail('addHelper success handler unexpectedly invoked');
-            }, function (e) {
-                expect(e.message).toContain('Platform "atari" is not yet added. See `cordova platform list`.');
-            });
+            return expectAsync(
+                platform_addHelper('update', hooks_mock, projectRoot, ['atari'])
+            ).toBeRejectedWithError(
+                'Platform "atari" is not yet added. See `cordova platform list`.'
+            );
         });
     });
     describe('happy path (success conditions)', function () {
@@ -272,11 +270,11 @@ describe('cordova/platform/addHelper', function () {
         describe('errors', function () {
             it('should reject the promise should fetch fail', function () {
                 fetch_mock.and.returnValue(Promise.reject(new Error('fetch has failed, rejecting promise')));
-                return platform_addHelper.downloadPlatform(projectRoot, 'android', '67').then(function () {
-                    fail('success handler unexpectedly invoked');
-                }, function (e) {
-                    expect(e.message).toContain('fetch has failed, rejecting promise');
-                });
+                return expectAsync(
+                    platform_addHelper.downloadPlatform(projectRoot, 'android', '67')
+                ).toBeRejectedWithError(
+                    /fetch has failed, rejecting promise/
+                );
             });
         });
         describe('happy path', function () {

--- a/spec/cordova/platform/getPlatformDetailsFromDir.spec.js
+++ b/spec/cordova/platform/getPlatformDetailsFromDir.spec.js
@@ -35,22 +35,20 @@ describe('cordova/platform/getPlatformDetailsFromDir', function () {
     });
 
     it('should throw if no config.xml or pkgJson', function () {
-        return platform_getPlatformDetails('dir', ['ios'])
-            .then(function () {
-                fail('Expected promise to be rejected');
-            }, function (reason) {
-                expect(reason).toMatch(/does not seem to contain a valid package.json or a valid Cordova platform/);
-            });
+        return expectAsync(
+            platform_getPlatformDetails('dir', ['ios'])
+        ).toBeRejectedWithError(
+            /does not seem to contain a valid package.json or a valid Cordova platform/
+        );
     });
 
     it('should throw if no platform is provided', function () {
         cordova_util.requireNoCache.and.returnValue({});
-        return platform_getPlatformDetails('dir')
-            .then(function () {
-                fail('Expected promise to be rejected');
-            }, function (reason) {
-                expect(reason).toMatch(/does not seem to contain a Cordova platform:/);
-            });
+        return expectAsync(
+            platform_getPlatformDetails('dir')
+        ).toBeRejectedWithError(
+            /does not seem to contain a Cordova platform:/
+        );
     });
 
     it('should return a promise with platform and version', function () {

--- a/spec/cordova/platform/index.spec.js
+++ b/spec/cordova/platform/index.spec.js
@@ -32,23 +32,20 @@ describe('cordova/platform', function () {
     describe('main module function', function () {
         describe('error/warning conditions', function () {
             // TODO: what about other commands? update? save?
-            it('should require at least one platform for add and remove commands', function () {
+            it('should require at least one platform for add and remove commands', async function () {
                 // targets = empty array
-                return platform('add', [])
-                    .then(function () {
-                        fail('should not succeed without targets');
-                    }, function (err) {
-                        expect(err).toMatch(/You need to qualify.* with one or more platforms/gi);
-                    })
-                    .then(function () {
-                        // targets = null
-                        return platform('remove', null);
-                    })
-                    .then(function () {
-                        fail('should not succeed without targets');
-                    }, function (err) {
-                        expect(err).toMatch(/You need to qualify.* with one or more platforms/gi);
-                    });
+                await expectAsync(
+                    platform('add', [])
+                ).toBeRejectedWithError(
+                    /You need to qualify.* with one or more platforms/i
+                );
+
+                // targets = null
+                await expectAsync(
+                    platform('remove', null)
+                ).toBeRejectedWithError(
+                    /You need to qualify.* with one or more platforms/i
+                );
             });
         });
         describe('handling of targets parameter', function () {

--- a/spec/cordova/platform/remove.spec.js
+++ b/spec/cordova/platform/remove.spec.js
@@ -55,11 +55,9 @@ describe('cordova/platform/remove', function () {
 
     describe('error/warning conditions', function () {
         it('should require specifying at least one platform', function () {
-            return platform_remove('remove', hooks_mock).then(function () {
-                fail('remove success handler unexpectedly invoked');
-            }, function (e) {
-                expect(e.message).toContain('No platform(s) specified.');
-            });
+            return expectAsync(
+                platform_remove('remove', hooks_mock)
+            ).toBeRejectedWithError(/No platform\(s\) specified\./);
         });
     });
     describe('happy path (success conditions)', function () {

--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -81,22 +81,16 @@ describe('cordova/plugin/add', function () {
         });
         describe('error/warning conditions', function () {
             it('should error out if at least one plugin is not specified', function () {
-                return add(projectRoot, hook_mock, { plugins: [] }).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toContain('No plugin specified');
-                });
+                return expectAsync(
+                    add(projectRoot, hook_mock, { plugins: [] })
+                ).toBeRejectedWithError(/No plugin specified/);
             });
             it('should error out if any mandatory plugin variables are not provided', function () {
                 plugin_info.getPreferences.and.returnValue({ some: undefined });
 
-                return add(projectRoot, hook_mock, { plugins: ['cordova-plugin-device'] }).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toContain('Variable(s) missing (use: --variable');
-                });
+                return expectAsync(
+                    add(projectRoot, hook_mock, { plugins: ['cordova-plugin-device'] })
+                ).toBeRejectedWithError(/Variable\(s\) missing \(use: --variable/);
             });
         });
         describe('happy path', function () {

--- a/spec/cordova/plugin/index.spec.js
+++ b/spec/cordova/plugin/index.spec.js
@@ -32,12 +32,9 @@ describe('cordova/plugin', function () {
 
     describe('error conditions', function () {
         it('should require at least one target for add and rm commands', function () {
-            return plugin('add', null).then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('one or more plugins');
-            });
+            return expectAsync(
+                plugin('add', null)
+            ).toBeRejectedWithError(/one or more plugins/);
         });
     });
 

--- a/spec/cordova/plugin/remove.spec.js
+++ b/spec/cordova/plugin/remove.spec.js
@@ -62,22 +62,16 @@ describe('cordova/plugin/remove', function () {
 
     describe('error/warning conditions', function () {
         it('should require that a plugin be provided', function () {
-            return remove(projectRoot, null).then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('No plugin specified');
-            });
+            return expectAsync(
+                remove(projectRoot, null)
+            ).toBeRejectedWithError(/No plugin specified/);
         });
 
         it('should require that a provided plugin be installed in the current project', function () {
             var opts = { plugins: [undefined] };
-            return remove(projectRoot, 'plugin', hook_mock, opts).then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('is not present in the project');
-            });
+            return expectAsync(
+                remove(projectRoot, 'plugin', hook_mock, opts)
+            ).toBeRejectedWithError(/is not present in the project/);
         });
     });
     describe('happy path', function () {

--- a/spec/cordova/prepare.spec.js
+++ b/spec/cordova/prepare.spec.js
@@ -65,30 +65,27 @@ describe('cordova/prepare', function () {
             spyOn(prepare, 'preparePlatforms').and.returnValue(Promise.resolve());
         });
         describe('failure', function () {
-            it('should invoke util.preProcessOptions as preflight task checker, which, if fails, should trigger promise rejection and only fire the before_prepare hook', function () {
+            it('should invoke util.preProcessOptions as preflight task checker, which, if fails, should trigger promise rejection and only fire the before_prepare hook', async function () {
                 util.preProcessOptions.and.callFake(function () {
                     throw new Error('preProcessOption error');
                 });
-                return prepare({}).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toBe('preProcessOption error');
-                    expect(HooksRunner.prototype.fire).toHaveBeenCalledWith('before_prepare', jasmine.any(Object));
-                });
+
+                await expectAsync(
+                    prepare({})
+                ).toBeRejectedWithError('preProcessOption error');
+
+                expect(HooksRunner.prototype.fire).toHaveBeenCalledWith('before_prepare', jasmine.any(Object));
             });
-            it('should invoke util.cdProjectRoot as a preflight task checker, which, if fails, should trigger a promise rejection and fire no hooks', function () {
+            it('should invoke util.cdProjectRoot as a preflight task checker, which, if fails, should trigger a promise rejection and fire no hooks', async function () {
                 util.cdProjectRoot.and.callFake(function () {
                     throw new Error('cdProjectRoot error');
                 });
 
-                return prepare({}).then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toBe('cdProjectRoot error');
-                    expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
-                });
+                await expectAsync(
+                    prepare({})
+                ).toBeRejectedWithError('cdProjectRoot error');
+
+                expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
             });
         });
 

--- a/spec/cordova/run.spec.js
+++ b/spec/cordova/run.spec.js
@@ -46,25 +46,19 @@ describe('run command', function () {
     describe('failure', function () {
         it('Test 001 : should not run inside a Cordova-based project with no added platforms by calling util.listPlatforms', function () {
             util.listPlatforms.and.returnValue([]);
-            return Promise.resolve().then(cordovaRun)
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toEqual('No platforms added to this project. Please use `cordova platform add <platform>`.');
-                });
+            return expectAsync(
+                cordovaRun()
+            ).toBeRejectedWithError(
+                'No platforms added to this project. Please use `cordova platform add <platform>`.'
+            );
         });
         it('Test 002 : should not run outside of a Cordova-based project', function () {
             var msg = 'Dummy message about not being in a cordova dir.';
             util.cdProjectRoot.and.throwError(new Error(msg));
             util.isCordova.and.returnValue(false);
-            return Promise.resolve().then(cordovaRun)
-                .then(function () {
-                    fail('Expected promise to be rejected');
-                }, function (err) {
-                    expect(err).toEqual(jasmine.any(Error));
-                    expect(err.message).toEqual(msg);
-                });
+            return expectAsync(
+                cordovaRun()
+            ).toBeRejectedWithError(msg);
         });
     });
 
@@ -142,16 +136,16 @@ describe('run command', function () {
         });
 
         describe('with no platforms added', function () {
-            it('Test 012 : should not fire the hooker', function () {
+            it('Test 012 : should not fire the hooker', async function () {
                 util.listPlatforms.and.returnValue([]);
-                return Promise.resolve().then(cordovaRun)
-                    .then(function () {
-                        fail('Expected promise to be rejected');
-                    }, function (err) {
-                        expect(err).toEqual(jasmine.any(Error));
-                        expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
-                        expect(err.message).toEqual('No platforms added to this project. Please use `cordova platform add <platform>`.');
-                    });
+
+                await expectAsync(
+                    cordovaRun()
+                ).toBeRejectedWithError(
+                    'No platforms added to this project. Please use `cordova platform add <platform>`.'
+                );
+
+                expect(HooksRunner.prototype.fire).not.toHaveBeenCalled();
             });
         });
     });

--- a/spec/cordova/serve.spec.js
+++ b/spec/cordova/serve.spec.js
@@ -77,27 +77,24 @@ describe('cordova/serve', () => {
             });
         });
 
-        it('should fail if run outside of a Cordova project', () => {
+        it('should fail if run outside of a Cordova project', async () => {
             const fakeMessage = 'CAN I HAZ CORDOVA PLZ?';
             cordovaUtil.cdProjectRoot.and.throwError(fakeMessage);
 
-            return serve(1234567, {}).then(() => {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toBe(fakeMessage);
-                expect(cordovaUtil.cdProjectRoot).toHaveBeenCalled();
-            });
+            await expectAsync(
+                serve(1234567, {})
+            ).toBeRejectedWithError(fakeMessage);
+
+            expect(cordovaUtil.cdProjectRoot).toHaveBeenCalled();
         });
 
         it('should fail if serve fails', () => {
-            const fakeError = new Error();
+            const fakeError = new Error('FAKE');
             serve.__get__('serve').and.returnValue(Promise.reject(fakeError));
 
-            return serve(1234567, {}).then(
-                _ => fail('Expected promise to be rejected'),
-                err => expect(err).toBe(fakeError)
-            );
+            return expectAsync(
+                serve(1234567, {})
+            ).toBeRejectedWith(fakeError);
         }, 100);
     });
 
@@ -141,24 +138,22 @@ describe('cordova/serve', () => {
         });
 
         it('should fail if prepare fails', () => {
-            const fakeError = new Error();
+            const fakeError = new Error('FAKE');
             const prepareSpy = serve.__get__('cordovaPrepare');
             prepareSpy.and.returnValue(Promise.reject(fakeError));
 
-            return privateServe(1234567, {}).then(
-                _ => fail('Expected promise to be rejected'),
-                err => expect(err).toBe(fakeError)
-            );
+            return expectAsync(
+                privateServe(1234567, {})
+            ).toBeRejectedWith(fakeError);
         }, 100);
 
         it('should fail if launching the server fails', () => {
-            const fakeError = new Error();
+            const fakeError = new Error('FAKE');
             serverSpy.launchServer.and.returnValue(Promise.reject(fakeError));
 
-            return privateServe(1234567, {}).then(
-                _ => fail('Expected promise to be rejected'),
-                err => expect(err).toBe(fakeError)
-            );
+            return expectAsync(
+                privateServe(1234567, {})
+            ).toBeRejectedWith(fakeError);
         }, 100);
     });
 

--- a/spec/plugman/add_platform.spec.js
+++ b/spec/plugman/add_platform.spec.js
@@ -25,12 +25,11 @@ describe('plugman/platform', () => {
             spyOn(fs, 'existsSync').and.returnValue(false);
         });
         it('Test 002 : should error on non existing plugin.xml', function () {
-            return platform.add().then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('can\'t find a plugin.xml.  Are you in the plugin?');
-            });
+            return expectAsync(
+                platform.add()
+            ).toBeRejectedWithError(
+                'can\'t find a plugin.xml.  Are you in the plugin?'
+            );
         }, 6000);
     });
 
@@ -39,12 +38,11 @@ describe('plugman/platform', () => {
             spyOn(fs, 'existsSync').and.returnValue(false);
         });
         it('Test 003 : should error on non existing plugin.xml', function () {
-            return platform.remove().then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('can\'t find a plugin.xml.  Are you in the plugin?');
-            });
+            return expectAsync(
+                platform.remove()
+            ).toBeRejectedWithError(
+                'can\'t find a plugin.xml.  Are you in the plugin?'
+            );
         }, 6000);
     });
 });

--- a/spec/plugman/create.spec.js
+++ b/spec/plugman/create.spec.js
@@ -34,12 +34,10 @@ describe('plugman/create', () => {
     it('Test 003 : should fail due to an existing plugin.xml', function () {
         spyOn(fs, 'existsSync').and.returnValue(true);
 
-        return create()
-            .then(function () {
-                fail('Expected promise to be rejected');
-            }, function (err) {
-                expect(err).toEqual(jasmine.any(Error));
-                expect(err.message).toContain('plugin.xml already exists. Are you already in a plugin?');
-            });
+        return expectAsync(
+            create()
+        ).toBeRejectedWithError(
+            'plugin.xml already exists. Are you already in a plugin?'
+        );
     }, 6000);
 });

--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -285,12 +285,11 @@ describe('plugman/install', () => {
             }, TIMEOUT);
 
             it('Test 019 : should throw if there is a cyclic dependency', () => {
-                return install('android', project, pluginDir('G'))
-                    .then(() => {
-                        fail('Expected promise to be rejected');
-                    }, err => {
-                        expect(err.toString()).toContain('Cyclic dependency from G to H');
-                    });
+                return expectAsync(
+                    install('android', project, pluginDir('G'))
+                ).toBeRejectedWithError(
+                    'Cyclic dependency from G to H'
+                );
             }, TIMEOUT);
 
             it('Test 020 : install subdir relative to top level plugin if no fetch meta', () => {
@@ -333,12 +332,11 @@ describe('plugman/install', () => {
     describe('failure', () => {
         it('Test 023 : should throw if variables are missing', () => {
             spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
-            return install('android', project, pluginDir('com.adobe.vars'))
-                .then(() => {
-                    fail('Expected promise to be rejected');
-                }, err => {
-                    expect(err.toString()).toContain('Variable(s) missing: API_KEY');
-                });
+            return expectAsync(
+                install('android', project, pluginDir('com.adobe.vars'))
+            ).toBeRejectedWithError(
+                'Variable(s) missing: API_KEY'
+            );
         }, TIMEOUT);
 
         it('Test 025 :should not fail when trying to install plugin less than minimum version. Skip instead  ', () => {
@@ -353,32 +351,21 @@ describe('plugman/install', () => {
 
         it('Test 026 : should throw if the engine scriptSrc escapes out of the plugin dir.', () => {
             spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
-            return install('android', project, pluginDir('org.test.invalid.engine.script'))
-                .then(() => {
-                    fail('Expected promise to be rejected');
-                }, err => {
-                    // <engine name="path-escaping-plugin" version=">=1.0.0" scriptSrc="../../../malicious/script" platform="*" />
-                    expect(err).toBeDefined();
-                    expect(err.message.indexOf('Security violation:')).toBe(0);
-                });
+            return expectAsync(
+                install('android', project, pluginDir('org.test.invalid.engine.script'))
+            ).toBeRejectedWithError(/^Security violation:/);
         }, TIMEOUT);
         it('Test 027 : should throw if a non-default cordova engine platform attribute is not defined.', () => {
             spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
-            return install('android', project, pluginDir('org.test.invalid.engine.no.platform'))
-                .then(() => {
-                    fail('Expected promise to be rejected');
-                }, err => {
-                    expect(err).toEqual(jasmine.any(Error));
-                });
+            return expectAsync(
+                install('android', project, pluginDir('org.test.invalid.engine.no.platform'))
+            ).toBeRejectedWithError();
         }, TIMEOUT);
         it('Test 028 : should throw if a non-default cordova engine scriptSrc attribute is not defined.', () => {
             spyOn(PlatformJson.prototype, 'isPluginInstalled').and.returnValue(false);
-            return install('android', project, pluginDir('org.test.invalid.engine.no.scriptSrc'))
-                .then(() => {
-                    fail('Expected promise to be rejected');
-                }, err => {
-                    expect(err).toEqual(jasmine.any(Error));
-                });
+            return expectAsync(
+                install('android', project, pluginDir('org.test.invalid.engine.no.scriptSrc'))
+            ).toBeRejectedWithError();
         }, TIMEOUT);
     });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Make use of `expectAsync` (available since Jasmine 3.5) to check for expected rejections. This makes for shorter and clearer expectations

This also fixes a test that would otherwise break with https://github.com/apache/cordova-common/pull/121

### Description
<!-- Describe your changes in detail -->
Uses `expectAsync(...).toBeRejectedWithError(...)` and `expectAsync(...).toBeRejectedWith(...)` to replace rejection checking that was done with `fail()` before. Where it greatly improved readability I switched the tests to `async/await`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm t`
