### PR TITLE
breaking: upgrade cordova dependencies for next major

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -139,7 +139,7 @@ describe('pkgJson', function () {
                 .then(function () {
                     // Check that the plugin and spec add was successful to pkg.json.
                     expect(getPkgJson('cordova.plugins')[pluginId]).toBeDefined();
-                    expect(getPkgJson('dependencies')[pluginId]).tohaveMinSatisfyingVersion('1.1.2');
+                    expect(getPkgJson('devDependencies')[pluginId]).tohaveMinSatisfyingVersion('1.1.2');
 
                     expect(getCfg().getPluginIdList()).toEqual([]);
                 }).then(function () {
@@ -148,7 +148,7 @@ describe('pkgJson', function () {
                 }).then(function () {
                     // Expect plugin to be removed from pkg.json.
                     expect(getPkgJson('cordova.plugins')[pluginId]).toBeUndefined();
-                    expect(getPkgJson('dependencies')[pluginId]).toBeUndefined();
+                    expect(getPkgJson('devDependencies')[pluginId]).toBeUndefined();
                 });
         });
 
@@ -219,7 +219,7 @@ describe('pkgJson', function () {
                     expect(getPkgJson('cordova.plugins')).toEqual({
                         [pluginId]: {}, [OTHER_PLUGIN]: {}
                     });
-                    expect(getPkgJson('dependencies')).toEqual({
+                    expect(getPkgJson('devDependencies')).toEqual({
                         'cordova-android': jasmine.any(String),
                         [pluginId]: jasmine.any(String),
                         [OTHER_PLUGIN]: jasmine.any(String)
@@ -230,7 +230,7 @@ describe('pkgJson', function () {
                 }).then(function () {
                     // Checking that the plugin removed is in not in the platforms.
                     expect(getPkgJson('cordova.plugins')).toEqual({});
-                    expect(getPkgJson('dependencies')).toEqual({
+                    expect(getPkgJson('devDependencies')).toEqual({
                         'cordova-android': jasmine.any(String)
                     });
                 });
@@ -244,7 +244,7 @@ describe('pkgJson', function () {
 
             // Pkg.json has no platform or plugin or specs.
             expect(getPkgJson('cordova.platforms')).not.toContain(PLATFORM);
-            expect(getPkgJson(`dependencies.${PLUGIN}`)).toBeUndefined();
+            expect(getPkgJson(`devDependencies.${PLUGIN}`)).toBeUndefined();
 
             // Config.xml has no platform or plugin or specs.
             expect(getCfg().getEngines()).not.toContain(PLATFORM);
@@ -261,7 +261,7 @@ describe('pkgJson', function () {
 
                     // Check that installed version satisfies the dependency spec
                     const version = pluginVersion(PLUGIN);
-                    expect(version).toSatisfy(getPkgJson(`dependencies.${PLUGIN}`));
+                    expect(version).toSatisfy(getPkgJson(`devDependencies.${PLUGIN}`));
                 });
         });
 
@@ -275,7 +275,7 @@ describe('pkgJson', function () {
                 .then(() => {
                     // Pkg.json has test plugin.
                     expect(getPkgJson(`cordova.plugins.${PLUGIN}`)).toBeDefined();
-                    expect(getPkgJson(`dependencies.${PLUGIN}`)).toBeDefined();
+                    expect(getPkgJson(`devDependencies.${PLUGIN}`)).toBeDefined();
                 });
         });
 
@@ -283,11 +283,11 @@ describe('pkgJson', function () {
             const URL = 'https://github.com/apache/cordova-plugin-device.git#semver:2.0.x';
 
             expect(getPkgJson('cordova.plugins')).toBeUndefined();
-            expect(getPkgJson(`dependencies.${pluginId}`)).toBeUndefined();
+            expect(getPkgJson(`devDependencies.${pluginId}`)).toBeUndefined();
 
             await cordova.plugin('add', URL, { save: true });
             expect(getPkgJson('cordova.plugins')[pluginId]).toBeDefined();
-            expect(getPkgJson('dependencies')[pluginId]).toMatch(URL);
+            expect(getPkgJson('devDependencies')[pluginId]).toMatch(URL);
         });
     });
 
@@ -373,7 +373,7 @@ describe('pkgJson', function () {
                 // Check the platform add was successful in platforms list and
                 // dependencies should have specific version from add.
                 expect(getPkgJson('cordova.platforms')).toEqual(['android', 'browser']);
-                expect(getPkgJson('dependencies')).toEqual({
+                expect(getPkgJson('devDependencies')).toEqual({
                     'cordova-android': specWithMinSatisfyingVersion('7.0.0'),
                     'cordova-browser': specWithMinSatisfyingVersion('5.0.1')
                 });
@@ -385,7 +385,7 @@ describe('pkgJson', function () {
             }).then(function () {
                 // Expect platforms to be uninstalled & removed from config files
                 expect(getPkgJson('cordova.platforms')).toEqual([]);
-                expect(getPkgJson('dependencies')).toEqual({});
+                expect(getPkgJson('devDependencies')).toEqual({});
                 expect(getCfg().getEngines()).toEqual([]);
                 expect(installedPlatforms()).toEqual([]);
             });
@@ -405,7 +405,7 @@ describe('pkgJson', function () {
                 .then(() => {
                     expect(installedPlatforms()).toEqual([PLATFORM]);
                     expect(getPkgJson('cordova.platforms')).toEqual([PLATFORM]);
-                    expect(getPkgJson(`dependencies.cordova-${PLATFORM}`)).toBeDefined();
+                    expect(getPkgJson(`devDependencies.cordova-${PLATFORM}`)).toBeDefined();
                 });
         });
     });
@@ -422,7 +422,7 @@ describe('pkgJson', function () {
             const PLUGIN = 'cordova-plugin-splashscreen';
 
             setPkgJson('cordova.platforms', [PLATFORM]);
-            setPkgJson('dependencies', {
+            setPkgJson('devDependencies', {
                 [PLUGIN]: '^3.2.2',
                 [`cordova-${PLATFORM}`]: '^4.5.4'
             });
@@ -439,13 +439,13 @@ describe('pkgJson', function () {
                 // Config.xml and ios/cordova/version check.
                 const version = platformVersion(PLATFORM);
                 // Check that pkg.json and ios/cordova/version versions "satisfy" each other.
-                const pkgSpec = getPkgJson(`dependencies.cordova-${PLATFORM}`);
+                const pkgSpec = getPkgJson(`devDependencies.cordova-${PLATFORM}`);
                 expect(version).toSatisfy(pkgSpec);
             }).then(function () {
                 return cordova.plugin('add', PLUGIN, { save: true });
             }).then(function () {
                 // Check that installed version satisfies the dependency spec
-                expect(pluginVersion(PLUGIN)).toSatisfy(getPkgJson(`dependencies.${PLUGIN}`));
+                expect(pluginVersion(PLUGIN)).toSatisfy(getPkgJson(`devDependencies.${PLUGIN}`));
             });
         }, TIMEOUT * 2);
 
@@ -488,7 +488,7 @@ describe('pkgJson', function () {
             const PLUGIN = 'cordova-plugin-splashscreen';
 
             setPkgJson('cordova.platforms', [PLATFORM]);
-            setPkgJson('dependencies', {
+            setPkgJson('devDependencies', {
                 [`cordova-${PLATFORM}`]: '^4.2.1',
                 [PLUGIN]: '^3.2.2'
             });
@@ -508,7 +508,7 @@ describe('pkgJson', function () {
                 // Check that installed version satisfies the dependency spec
                 const version = pluginVersion(PLUGIN);
                 expect(version).toSatisfy(getCfg().getPlugin(PLUGIN).spec);
-                expect(version).toSatisfy(getPkgJson(`dependencies.${PLUGIN}`));
+                expect(version).toSatisfy(getPkgJson(`devDependencies.${PLUGIN}`));
             });
         });
     });

--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -61,9 +61,9 @@ describe('pkgJson', function () {
     }
 
     function platformVersion (platformName) {
-        const p = path.join(project, 'platforms', platformName, 'cordova/version');
+        const p = path.join(project, 'platforms', platformName, 'cordova/Api.js');
         expect(p).toExist();
-        return requireNoCache(p).version;
+        return requireNoCache(p).version();
     }
 
     function pluginVersion (pluginName) {
@@ -417,16 +417,15 @@ describe('pkgJson', function () {
         /** Test#020 will check that pkg.json, config.xml, platforms.json, and cordova platform ls
         *   are updated with the correct (platform and plugin) specs from pkg.json.
         */
-        // @todo test needs improvement. Platforms are now installed to devDependencies but must
-        // constinue to work in dependencies. Appears to ignore package.json too...
-        xit('Test#020 : During add, if pkg.json has a spec, use that one.', function () {
+        // @todo add a test to also support checking dependencies
+        it('Test#020 : During add, if pkg.json has a spec, use that one.', function () {
             const PLATFORM = 'ios';
             const PLUGIN = 'cordova-plugin-splashscreen';
 
             setPkgJson('cordova.platforms', [PLATFORM]);
             setPkgJson('devDependencies', {
                 [PLUGIN]: '^3.2.2',
-                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.9.e65d685c'
+                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.12.e65d685c'
             });
 
             // config.xml has no platforms or plugins yet.

--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -346,7 +346,7 @@ describe('pkgJson', function () {
         });
 
         it('Test#009 : should only add the platform to package.json with --save', function () {
-            const platformNotToAdd = 'browser';
+            const platformNotToAdd = 'ios';
             expect(pkgJsonPath).toExist();
 
             // Add a platform without --save.
@@ -367,21 +367,21 @@ describe('pkgJson', function () {
             expect(installedPlatforms()).toEqual([]);
 
             // Add the testing platform with --save and add specific version to android platform.
-            return cordova.platform('add', ['android@7.0.0', 'browser@5.0.1'], { save: true }).then(function () {
-                expect(installedPlatforms()).toEqual(['android', 'browser']);
+            return cordova.platform('add', ['android@9.0.0-nightly.2020.5.9.e86b211c', 'ios@6.0.0-nightly.2020.5.9.e65d685c'], { save: true }).then(function () {
+                expect(installedPlatforms()).toEqual(['android', 'ios']);
 
                 // Check the platform add was successful in platforms list and
                 // dependencies should have specific version from add.
-                expect(getPkgJson('cordova.platforms')).toEqual(['android', 'browser']);
+                expect(getPkgJson('cordova.platforms')).toEqual(['android', 'ios']);
                 expect(getPkgJson('devDependencies')).toEqual({
-                    'cordova-android': specWithMinSatisfyingVersion('7.0.0'),
-                    'cordova-browser': specWithMinSatisfyingVersion('5.0.1')
+                    'cordova-android': specWithMinSatisfyingVersion('9.0.0-nightly.2020.5.9.e86b211c'),
+                    'cordova-ios': specWithMinSatisfyingVersion('6.0.0-nightly.2020.5.9.e65d685c')
                 });
 
                 expect(getCfg().getEngines()).toEqual([]);
             }).then(function () {
                 // And now remove it with --save.
-                return cordova.platform('rm', ['android', 'browser'], { save: true });
+                return cordova.platform('rm', ['android', 'ios'], { save: true });
             }).then(function () {
                 // Expect platforms to be uninstalled & removed from config files
                 expect(getPkgJson('cordova.platforms')).toEqual([]);
@@ -417,14 +417,16 @@ describe('pkgJson', function () {
         /** Test#020 will check that pkg.json, config.xml, platforms.json, and cordova platform ls
         *   are updated with the correct (platform and plugin) specs from pkg.json.
         */
-        it('Test#020 : During add, if pkg.json has a spec, use that one.', function () {
+        // @todo test needs improvement. Platforms are now installed to devDependencies but must
+        // constinue to work in dependencies. Appears to ignore package.json too...
+        xit('Test#020 : During add, if pkg.json has a spec, use that one.', function () {
             const PLATFORM = 'ios';
             const PLUGIN = 'cordova-plugin-splashscreen';
 
             setPkgJson('cordova.platforms', [PLATFORM]);
             setPkgJson('devDependencies', {
                 [PLUGIN]: '^3.2.2',
-                [`cordova-${PLATFORM}`]: '^4.5.4'
+                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.9.e65d685c'
             });
 
             // config.xml has no platforms or plugins yet.
@@ -489,17 +491,17 @@ describe('pkgJson', function () {
 
             setPkgJson('cordova.platforms', [PLATFORM]);
             setPkgJson('devDependencies', {
-                [`cordova-${PLATFORM}`]: '^4.2.1',
+                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.1.e65d685c',
                 [PLUGIN]: '^3.2.2'
             });
             getCfg()
-                .addEngine(PLATFORM, '~4.2.1')
+                .addEngine(PLATFORM, '~6.0.0-nightly.2020.5.1.e65d685c')
                 .addPlugin({ name: PLUGIN, spec: '~3.2.1' })
                 .write();
 
             expect(installedPlatforms()).toEqual([]);
 
-            return cordova.platform('add', `${PLATFORM}@4.5.4`, { save: true }).then(function () {
+            return cordova.platform('add', `${PLATFORM}@6.0.0-nightly.2020.5.9.e65d685c`, { save: true }).then(function () {
                 // Pkg.json has ios.
                 expect(getPkgJson('cordova.platforms')).toEqual([PLATFORM]);
             }).then(function () {

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -127,22 +127,22 @@ describe('cordova/platform end-to-end', () => {
     it('Test 007 : should add and remove platform from node_modules directory', () => {
         return Promise.resolve()
             .then(() => {
-                return cordova.platform('add', 'browser', { save: true });
+                return cordova.platform('add', 'ios@nightly', { save: true });
             })
             .then(() => {
-                expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
-                expect(path.join(platformsDir, 'browser')).toExist();
-                return cordova.platform('add', 'android');
+                expect(path.join(nodeModulesDir, 'cordova-ios')).toExist();
+                expect(path.join(platformsDir, 'ios')).toExist();
+                return cordova.platform('add', 'android@9.0.0-nightly.2020.5.9.e86b211c');
             })
             .then(() => {
-                expect(path.join(nodeModulesDir, 'cordova-browser')).toExist();
+                expect(path.join(nodeModulesDir, 'cordova-android')).toExist();
                 expect(path.join(platformsDir, 'android')).toExist();
-                return cordova.platform('rm', 'browser');
+                return cordova.platform('rm', 'ios', { save: true });
             })
             .then(() => {
-                expect(path.join(nodeModulesDir, 'cordova-browser')).not.toExist();
-                expect(path.join(platformsDir, 'browser')).not.toExist();
-                return cordova.platform('rm', 'android');
+                expect(path.join(nodeModulesDir, 'cordova-ios')).not.toExist();
+                expect(path.join(platformsDir, 'ios')).not.toExist();
+                return cordova.platform('rm', 'android', { save: true });
             })
             .then(() => {
                 expect(path.join(nodeModulesDir, 'cordova-android')).not.toExist();
@@ -177,7 +177,7 @@ describe('cordova/platform end-to-end', () => {
         return Promise.resolve()
             .then(() => {
                 // add cordova-android instead of android
-                return cordova.platform('add', 'cordova-android');
+                return cordova.platform('add', 'cordova-android@9.0.0-nightly.2020.5.9.e86b211c');
             })
             .then(() => {
                 // 3rd party platform from npm

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -127,7 +127,7 @@ describe('cordova/platform end-to-end', () => {
     it('Test 007 : should add and remove platform from node_modules directory', () => {
         return Promise.resolve()
             .then(() => {
-                return cordova.platform('add', 'ios@nightly', { save: true });
+                return cordova.platform('add', 'ios', { save: true });
             })
             .then(() => {
                 expect(path.join(nodeModulesDir, 'cordova-ios')).toExist();

--- a/integration-tests/plugin.spec.js
+++ b/integration-tests/plugin.spec.js
@@ -210,12 +210,11 @@ describe('plugin end-to-end', function () {
 
         // Pretend to have cordova-android 5.2.2 installed to force the
         // expected version outcome for the plugin below
-        fs.writeFileSync(
-            path.join(project, 'platforms/android/cordova/version'),
-            `#!/usr/bin/env node
-            exports.version = '5.2.2';
-            if (!module.parent) console.log(exports.version);`
-        );
+        const targetVersion = '5.2.2';
+        const apiFile = path.join(project, 'platforms/android/cordova/Api.js');
+        const apiString = fs.readFileSync(apiFile, 'utf8')
+            .replace(/const VERSION = '9.0.0-dev';/, `const VERSION = '${targetVersion}';`);
+        fs.writeFileSync(apiFile, apiString, 'utf8');
 
         return addPlugin(npmInfoTestPlugin, npmInfoTestPlugin)
             .then(function () {

--- a/integration-tests/plugin.spec.js
+++ b/integration-tests/plugin.spec.js
@@ -213,7 +213,7 @@ describe('plugin end-to-end', function () {
         const targetVersion = '5.2.2';
         const apiFile = path.join(project, 'platforms/android/cordova/Api.js');
         const apiString = fs.readFileSync(apiFile, 'utf8')
-            .replace(/const VERSION = '9.0.0-dev';/, `const VERSION = '${targetVersion}';`);
+            .replace(/const VERSION = '9.0.0-nightly.2020.5.12.e86b211c';/, `const VERSION = '${targetVersion}';`);
         fs.writeFileSync(apiFile, apiString, 'utf8');
 
         return addPlugin(npmInfoTestPlugin, npmInfoTestPlugin)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "cordova-common": "^4.0.1-nightly.2020.5.8.82cded7d",
-    "cordova-create": "^3.0.0-nightly.2020.5.8.fcc799b1",
+    "cordova-common": "^4.0.1",
+    "cordova-create": "^3.0.0",
     "cordova-fetch": "^3.0.0",
     "cordova-serve": "^3.0.0",
     "dep-graph": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "cordova-common": "4.0.0-nightly.2019.11.8.40cb6cee",
-    "cordova-create": "^2.0.0",
-    "cordova-fetch": "^2.0.0",
+    "cordova-common": "^4.0.1-nightly.2020.5.8.82cded7d",
+    "cordova-create": "^3.0.0-nightly.2020.5.8.fcc799b1",
+    "cordova-fetch": "^3.0.0",
     "cordova-serve": "^3.0.0",
     "dep-graph": "^1.1.0",
     "detect-indent": "^6.0.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",
     "codecov": "^3.2.0",
-    "cordova-android": "^8.1.0",
+    "cordova-android": "^9.0.0-nightly.2020.5.8.e86b211c",
     "delay": "^4.1.0",
     "jasmine": "^3.5.0",
     "jasmine-spec-reporter": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",
     "codecov": "^3.2.0",
-    "cordova-android": "^9.0.0-nightly.2020.5.8.e86b211c",
+    "cordova-android": "9.0.0-nightly.2020.5.12.e86b211c",
     "delay": "^4.1.0",
     "jasmine": "^3.5.0",
     "jasmine-spec-reporter": "^4.2.1",

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -104,7 +104,7 @@ describe('util module', function () {
 
             return helpers.getFixture('androidApp').copyTo(platformPath)
                 .then(_ => util.getInstalledPlatformsWithVersions(temp))
-                .then(versions => expect(versions[PLATFORM]).toBe('9.0.0-dev'));
+                .then(versions => expect(versions[PLATFORM]).toBe('9.0.0-nightly.2020.5.12.e86b211c'));
         });
     });
     describe('findPlugins method', function () {

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -104,7 +104,7 @@ describe('util module', function () {
 
             return helpers.getFixture('androidApp').copyTo(platformPath)
                 .then(_ => util.getInstalledPlatformsWithVersions(temp))
-                .then(versions => expect(versions[PLATFORM]).toBe('8.1.0'));
+                .then(versions => expect(versions[PLATFORM]).toBe('9.0.0-dev'));
         });
     });
     describe('findPlugins method', function () {

--- a/spec/fixture-helper.js
+++ b/spec/fixture-helper.js
@@ -65,7 +65,9 @@ module.exports = function fixtureHelper (tmpDir) {
             process.chdir(projectPath);
 
             // Talk about a clunky interface :(
-            const platforms = ['android'];
+            // @todo remove @nightly once Android next major is released.
+            const platformFromPackageDependencies = path.resolve(path.dirname(require.resolve('cordova-android')), '../../../');
+            const platforms = [platformFromPackageDependencies];
             const opts = { platforms, save: true };
             const hooksRunner = new HooksRunner(projectPath);
             await platformAdd(hooksRunner, projectPath, platforms, opts);

--- a/spec/project-test-helpers.js
+++ b/spec/project-test-helpers.js
@@ -48,7 +48,7 @@ module.exports = function projectTestHelpers (getProjectPath) {
         expect(getCfg().getPlugins()).toEqual([]);
         expect(getCfg().getEngines()).toEqual([]);
         expect(getPkgJson('cordova')).toBeUndefined();
-        expect(getPkgJson('dependencies')).toBeUndefined();
+        expect(getPkgJson('devDependencies')).toBeUndefined();
     }
 
     function getCfg () {

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -200,8 +200,17 @@ function getInstalledPlatformsWithVersions (project_dir) {
 }
 
 function getPlatformVersion (platformPath) {
-    const versionPath = path.join(platformPath, 'cordova/version');
-    return requireNoCache(versionPath).version;
+    try {
+        // Major Platforms for Cordova 10+
+        return requireNoCache(
+            path.join(platformPath, 'cordova/Api')
+        ).version();
+    } catch (e) {
+        // Platforms pre-Cordova 10
+        return requireNoCache(
+            path.join(platformPath, 'cordova/version')
+        ).version;
+    }
 }
 
 function getPlatformVersionOrNull (platformPath) {

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -2,7 +2,7 @@
     "ios": {
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-ios.git",
-        "version": "^5.0.0",
+        "version": "^6.0.0-nightly.2020.5.11.e65d685c",
         "deprecated": false
     },
     "osx": {
@@ -13,7 +13,7 @@
     },
     "android": {
         "url": "https://github.com/apache/cordova-android.git",
-        "version": "^8.0.0",
+        "version": "^9.0.0-nightly.2020.5.11.e86b211c",
         "deprecated": false
     },
     "windows": {

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -2,7 +2,7 @@
     "ios": {
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-ios.git",
-        "version": "^6.0.0-nightly.2020.5.11.e65d685c",
+        "version": "^6.0.0",
         "deprecated": false
     },
     "osx": {


### PR DESCRIPTION
### Motivation, Context & Description

- Update Cordova dependencies to start using the next major releases.
- Use dependencies that fixed to the issues related to the combination of Node 12x+ and Rewire.
- Use the next major's patch nightlies (e.g: cordova-common) which contains bug fixes. This is to continue validating the fixes in the dependencies itself and identify if there are other issues to be resolved before pushing the next patch release for those dependencies.

### Tasks
- [x] Update Cordova related dependencies
- [x] Fixed Unit Tests
- [ ] Fixed End-to-End Tests

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I updated automated test coverage as appropriate for this change
