### PR TITLE
chore(ios): update platform pinning to ^6.1.0

### DIFF
--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -2,7 +2,7 @@
     "ios": {
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-ios.git",
-        "version": "^6.0.0",
+        "version": "^6.1.0",
         "deprecated": false
     },
     "osx": {


### PR DESCRIPTION
### Motivation, Context & Description

Update iOS platform pinning to latest release 6.1.0

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
