### PR TITLE
chore(osx): update platform pinning to ^6.0.0

### DIFF
--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -8,7 +8,7 @@
     "osx": {
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-osx.git",
-        "version": "^5.0.0",
+        "version": "^6.0.0",
         "deprecated": false
     },
     "android": {


### PR DESCRIPTION
### Motivation and Context & Description

Update OSX platform pinning to latest release 6.0.0

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
