### PR TITLE
chore(android): update platform pinning to ^9.0.0

### DIFF
--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -13,7 +13,7 @@
     },
     "android": {
         "url": "https://github.com/apache/cordova-android.git",
-        "version": "^9.0.0-nightly.2020.5.11.e86b211c",
+        "version": "^9.0.0",
         "deprecated": false
     },
     "windows": {


### PR DESCRIPTION
### Motivation, Context & Description

Update Android platform pinning to latest release 9.0.0

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
