### PR TITLE
chore: remove nightly packages from testing scope

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -367,15 +367,15 @@ describe('pkgJson', function () {
             expect(installedPlatforms()).toEqual([]);
 
             // Add the testing platform with --save and add specific version to android platform.
-            return cordova.platform('add', ['android@9.0.0-nightly.2020.5.9.e86b211c', 'ios@6.0.0-nightly.2020.5.9.e65d685c'], { save: true }).then(function () {
+            return cordova.platform('add', ['android@9.0.0', 'ios@6.1.0'], { save: true }).then(function () {
                 expect(installedPlatforms()).toEqual(['android', 'ios']);
 
                 // Check the platform add was successful in platforms list and
                 // dependencies should have specific version from add.
                 expect(getPkgJson('cordova.platforms')).toEqual(['android', 'ios']);
                 expect(getPkgJson('devDependencies')).toEqual({
-                    'cordova-android': specWithMinSatisfyingVersion('9.0.0-nightly.2020.5.9.e86b211c'),
-                    'cordova-ios': specWithMinSatisfyingVersion('6.0.0-nightly.2020.5.9.e65d685c')
+                    'cordova-android': specWithMinSatisfyingVersion('9.0.0'),
+                    'cordova-ios': specWithMinSatisfyingVersion('6.1.0')
                 });
 
                 expect(getCfg().getEngines()).toEqual([]);
@@ -425,7 +425,7 @@ describe('pkgJson', function () {
             setPkgJson('cordova.platforms', [PLATFORM]);
             setPkgJson('devDependencies', {
                 [PLUGIN]: '^3.2.2',
-                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.12.e65d685c'
+                [`cordova-${PLATFORM}`]: '^6.1.0'
             });
 
             // config.xml has no platforms or plugins yet.
@@ -490,17 +490,17 @@ describe('pkgJson', function () {
 
             setPkgJson('cordova.platforms', [PLATFORM]);
             setPkgJson('devDependencies', {
-                [`cordova-${PLATFORM}`]: '^6.0.0-nightly.2020.5.1.e65d685c',
+                [`cordova-${PLATFORM}`]: '^6.1.0',
                 [PLUGIN]: '^3.2.2'
             });
             getCfg()
-                .addEngine(PLATFORM, '~6.0.0-nightly.2020.5.1.e65d685c')
+                .addEngine(PLATFORM, '~6.1.0')
                 .addPlugin({ name: PLUGIN, spec: '~3.2.1' })
                 .write();
 
             expect(installedPlatforms()).toEqual([]);
 
-            return cordova.platform('add', `${PLATFORM}@6.0.0-nightly.2020.5.9.e65d685c`, { save: true }).then(function () {
+            return cordova.platform('add', `${PLATFORM}@6.1.0`, { save: true }).then(function () {
                 // Pkg.json has ios.
                 expect(getPkgJson('cordova.platforms')).toEqual([PLATFORM]);
             }).then(function () {

--- a/integration-tests/platform.spec.js
+++ b/integration-tests/platform.spec.js
@@ -132,7 +132,7 @@ describe('cordova/platform end-to-end', () => {
             .then(() => {
                 expect(path.join(nodeModulesDir, 'cordova-ios')).toExist();
                 expect(path.join(platformsDir, 'ios')).toExist();
-                return cordova.platform('add', 'android@9.0.0-nightly.2020.5.9.e86b211c');
+                return cordova.platform('add', 'android@9.0.0');
             })
             .then(() => {
                 expect(path.join(nodeModulesDir, 'cordova-android')).toExist();
@@ -177,7 +177,7 @@ describe('cordova/platform end-to-end', () => {
         return Promise.resolve()
             .then(() => {
                 // add cordova-android instead of android
-                return cordova.platform('add', 'cordova-android@9.0.0-nightly.2020.5.9.e86b211c');
+                return cordova.platform('add', 'cordova-android@9.0.0');
             })
             .then(() => {
                 // 3rd party platform from npm

--- a/integration-tests/plugin.spec.js
+++ b/integration-tests/plugin.spec.js
@@ -213,7 +213,7 @@ describe('plugin end-to-end', function () {
         const targetVersion = '5.2.2';
         const apiFile = path.join(project, 'platforms/android/cordova/Api.js');
         const apiString = fs.readFileSync(apiFile, 'utf8')
-            .replace(/const VERSION = '9.0.0-nightly.2020.5.12.e86b211c';/, `const VERSION = '${targetVersion}';`);
+            .replace(/const VERSION = '9.0.0';/, `const VERSION = '${targetVersion}';`);
         fs.writeFileSync(apiFile, apiString, 'utf8');
 
         return addPlugin(npmInfoTestPlugin, npmInfoTestPlugin)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",
     "codecov": "^3.2.0",
-    "cordova-android": "9.0.0-nightly.2020.5.12.e86b211c",
+    "cordova-android": "9.0.0",
     "delay": "^4.1.0",
     "jasmine": "^3.5.0",
     "jasmine-spec-reporter": "^4.2.1",

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -104,7 +104,7 @@ describe('util module', function () {
 
             return helpers.getFixture('androidApp').copyTo(platformPath)
                 .then(_ => util.getInstalledPlatformsWithVersions(temp))
-                .then(versions => expect(versions[PLATFORM]).toBe('9.0.0-nightly.2020.5.12.e86b211c'));
+                .then(versions => expect(versions[PLATFORM]).toBe('9.0.0'));
         });
     });
     describe('findPlugins method', function () {


### PR DESCRIPTION
### Motivation, Context & Description

- Remove the nightly packages from testing that was used temporarily
- Use actual released packages

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
