### PR TITLE
fix: remove unused dependency on cordova-create

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "cordova-common": "^4.0.1",
-    "cordova-create": "^3.0.0",
     "cordova-fetch": "^3.0.0",
     "cordova-serve": "^3.0.0",
     "dep-graph": "^1.1.0",


### PR DESCRIPTION
This should have been part of #820