### PR TITLE
feat(osx): deprecate platform

### DIFF
--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -9,7 +9,7 @@
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-osx.git",
         "version": "^6.0.0",
-        "deprecated": false
+        "deprecated": true
     },
     "android": {
         "url": "https://github.com/apache/cordova-android.git",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Status

- [ ] pending formal vote

### Platforms affected

"osx" (macOS)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

[see this discussion in dev@cordova.apache.org](https://lists.apache.org/thread.html/r638f55c4ddeb4aa51bc9d568e72e0d03669b347f5b42051b6be624ad%40%3Cdev.cordova.apache.org%3E)

### Description
<!-- Describe your changes in detail -->

set `"deprecated": true` for "osx" in `src/platforms/platformsConfig.json`

### Testing
<!-- Please describe in detail how you tested your changes. -->

__updated:__

In a local checkout of `cordova-cli`:

```console
npm i github:apache/cordova-lib#brodybits-deprecate-osx
./bin/cordova create test2
cd test2
```

Output of `../bin/cordova platform ls` with no deprecated platforms:

```console
Warning: using prerelease version 10.0.1-dev (cordova-lib@10.0.1-dev)
Installed platforms:
  
Available platforms: 
  android ^9.0.0
  browser ^6.0.0
  electron ^1.0.0
  ios ^6.1.0
  osx ^6.0.0 (deprecated)
```

Output of `../bin/cordova platform ls` with "osx" platform added:

```console
Warning: using prerelease version 10.0.1-dev (cordova-lib@10.0.1-dev)
Installed platforms:
  osx 6.0.0 (deprecated)
Available platforms: 
  android ^9.0.0
  browser ^6.0.0
  electron ^1.0.0
  ios ^6.1.0
```

### Checklist

- [x] ~~I've run the tests to see~~ all new and existing tests pass - Travis CI ✅
- ~~I added automated test coverage as appropriate for this change~~
- [x] ~~Commit~~ **Title** is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
