### PR TITLE
unit test deprecated platforms

### DIFF
--- a/spec/cordova/platform/listDeprecated.spec.js
+++ b/spec/cordova/platform/listDeprecated.spec.js
@@ -57,7 +57,7 @@ describe('cordova/platform/list show deprecated platforms info', function () {
     it('shows available platforms with deprecated info', () => {
         return platform_list(hooks_mock, projectRoot, { save: true })
             .then((result) => {
-                expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/Installed platforms:[\s\S]*Available.*:\s\s\s\sandroid 1.2.3\s\s\swp7 4.5.6.*\(deprecated\)/));
+                expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/Installed platforms:[\s\S]*Available.*:[\s]*android 1.2.3[\s]*wp7 4.5.6 \(deprecated\)/));
             });
     });
 

--- a/spec/cordova/platform/listDeprecated.spec.js
+++ b/spec/cordova/platform/listDeprecated.spec.js
@@ -1,0 +1,68 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const rewire = require('rewire');
+
+const events = require('cordova-common').events;
+
+const platform_list = rewire('../../../src/cordova/platform/list');
+
+describe('cordova/platform/list show deprecated platforms info', function () {
+    var hooks_mock;
+    var projectRoot = '/some/path';
+
+    beforeEach(function () {
+        // use mock platforms info so that this test can working properly
+        // with or without any deprecated platforms
+        platform_list.__set__({
+            cordova_util: {
+                getInstalledPlatformsWithVersions: () => Promise.resolve({})
+            },
+            platforms: {
+                hostSupports: () => true,
+                info: {
+                    android: {
+                        version: '1.2.3',
+                        deprecated: false
+                    },
+                    wp7: {
+                        version: '4.5.6',
+                        deprecated: true
+                    }
+                },
+                list: ['android', 'wp7']
+            }
+        });
+
+        hooks_mock = jasmine.createSpyObj('hooksRunner mock', ['fire']);
+        hooks_mock.fire.and.returnValue(Promise.resolve());
+
+        spyOn(events, 'emit');
+    });
+
+    it('shows available platforms with deprecated info', () => {
+        return platform_list(hooks_mock, projectRoot, { save: true })
+            .then((result) => {
+                expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/Installed platforms:[\s\S]*Available.*:\s\s\s\sandroid 1.2.3\s\s\swp7 4.5.6.*\(deprecated\)/));
+            });
+    });
+
+    it('returns platform list with deprecated info', function () {
+        var platformList = ['android 1.2.3', 'wp7 4.5.6'];
+        expect(platform_list.addDeprecatedInformationToPlatforms(platformList)).toEqual(['android 1.2.3', 'wp7 4.5.6 (deprecated)']);
+    });
+});


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

all

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

From work on PRs #851 and #852, I think the code to show which platforms are deprecated is not so well covered by testing. The following possible code mutation does not seem to trigger any test failures:

```diff
--- a/src/cordova/platform/list.js
+++ b/src/cordova/platform/list.js
@@ -58,7 +58,7 @@ function addDeprecatedInformationToPlatforms (platformsList) {
         var platformKey = p.split(' ')[0]; // Remove Version Information
         // allow for 'unknown' platforms, which will not exist in platforms
         if ((platforms.info[platformKey] || {}).deprecated) {
-            p = p.concat(' ', '(deprecated)');
+            p = p.concat(' ', 'xxx');
         }
         return p;
     });
```

### Description
<!-- Describe your changes in detail -->

Add `spec/cordova/platform/listDeprecated.spec.js` to test the output in case of any deprecated platforms.

### Testing
<!-- Please describe in detail how you tested your changes. -->

The above mutation leads to failures in the new test cases.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- ~~I've updated the documentation if necessary~~
