### PR TITLE
test: fix missing stack traces in jasmine output

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -35,6 +35,6 @@ jasmine.getEnv().addReporter(new SpecReporter({
     },
     summary: {
         displayDuration: true,
-        displayStacktrace: true
+        displayStacktrace: 'raw'
     }
 }));


### PR DESCRIPTION
`true` is not a valid value for the `displayStacktrace` option of `jasmine-spec-reporter`. At least not anymore.