### PR TITLE
fix(cordova/util): version detection for legacy platforms

### DIFF
--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -107,6 +107,19 @@ describe('util module', function () {
                 .then(versions => expect(versions[PLATFORM]).toBe('9.0.0'));
         });
     });
+    describe('getPlatformVersion method', () => {
+        it('should get the version from a legacy platform', () => {
+            const PLATFORM_VERSION = '1.2.3-dev';
+
+            fs.outputFileSync(path.join(temp, 'cordova/version'), `
+                #!/usr/bin/env node
+                console.log('${PLATFORM_VERSION}');
+            `.trim());
+
+            const version = util.getPlatformVersion(temp);
+            expect(version).toBe(PLATFORM_VERSION);
+        });
+    });
     describe('findPlugins method', function () {
         let pluginsDir, plugins;
 

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -207,9 +207,10 @@ function getPlatformVersion (platformPath) {
         ).version();
     } catch (e) {
         // Platforms pre-Cordova 10
-        return requireNoCache(
-            path.join(platformPath, 'cordova/version')
-        ).version;
+        return require('execa').sync(
+            process.argv0, // node
+            [path.join(platformPath, 'cordova/version')]
+        ).stdout;
     }
 }
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The new mechanism introduced in #815 relied on all platforms exporting their version in their version script. This is not the case for the browser platform though. Thus we need to revert to spawning an external process for legacy platforms unfortunately.


### Description
<!-- Describe your changes in detail -->
For platforms that do not expose `Api.version`, synchronously call the version script instead.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I manually tested the new version with the current browser platform and `cordova info` output (which was broken for `browser` because of the bug fixed here)
