### PR TITLE
feat(cordova/util): support requiring platform API from node_modules

### DIFF
--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -62,7 +62,7 @@ describe('platforms/platforms', () => {
             expect(platformApi).toBeDefined();
             expect(platformApi.platform).toEqual('windows');
             expect(events.emit.calls.count()).toEqual(1);
-            expect(events.emit.calls.argsFor(0)[1]).toMatch('Platform API successfully found in:');
+            expect(events.emit.calls.argsFor(0)[1]).toMatch('Loaded API for windows project');
             expect(util.convertToRealPathSafe.calls.count()).toEqual(1);
             expect(util.isCordova.calls.count()).toEqual(0);
             expect(util.requireNoCache.calls.count()).toEqual(1);

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -224,6 +224,11 @@ describe('util module', function () {
                 expect(events.emit.calls.count()).toBe(1);
                 expect(events.emit.calls.argsFor(0)[1]).toMatch('Platform API successfully found in:');
             });
+
+            it('successfully loads platform Api from node_modules', () => {
+                const Api = util.getPlatformApiFunction(null, 'android');
+                expect(Api).toBe(require('cordova-android'));
+            });
         });
     });
 });

--- a/spec/cordova/util.spec.js
+++ b/spec/cordova/util.spec.js
@@ -20,7 +20,6 @@
 var path = require('path');
 var fs = require('fs-extra');
 var util = require('../../src/cordova/util');
-var events = require('../../cordova-lib').events;
 var helpers = require('../helpers');
 
 var cwd = process.cwd();
@@ -217,12 +216,9 @@ describe('util module', function () {
             it('Test 030 : successfully find platform Api', function () {
                 const FIXTURE_PROJECT = path.join(__dirname, 'fixtures/projects/platformApi/');
                 const API_PATH = path.join(FIXTURE_PROJECT, 'platforms/windows/cordova/Api.js');
-                spyOn(events, 'emit');
 
-                util.getPlatformApiFunction(API_PATH, 'cordova-platform-fixture');
-
-                expect(events.emit.calls.count()).toBe(1);
-                expect(events.emit.calls.argsFor(0)[1]).toMatch('Platform API successfully found in:');
+                const Api = util.getPlatformApiFunction(API_PATH, 'windows');
+                expect(Api.createPlatform().platform).toBe('windows');
             });
 
             it('successfully loads platform Api from node_modules', () => {

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -304,6 +304,8 @@ function isDirectory (dir) {
 function getPlatformApiFunction (dir, platform) {
     let PlatformApi;
     try {
+        // First try to load the platform API from the platform project
+        // This is necessary to support older platform API versions
         PlatformApi = exports.requireNoCache(dir);
     } catch (err) {
         try {
@@ -312,6 +314,7 @@ function getPlatformApiFunction (dir, platform) {
                 cdvPlatform = `cordova-${platform}`;
             }
 
+            // Load the platform API directly from node_modules
             PlatformApi = exports.requireNoCache(cdvPlatform);
         } catch (err) {
             // Module not found or threw error during loading

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -307,15 +307,19 @@ function getPlatformApiFunction (dir, platform) {
         // First try to load the platform API from the platform project
         // This is necessary to support older platform API versions
         PlatformApi = exports.requireNoCache(dir);
-    } catch (err) {
+    } catch (loadFromDirError) {
+        events.emit('verbose', `Unable to load Platform API from ${dir}:`);
+        events.emit('verbose', CordovaError.fullStack(loadFromDirError));
+
+        const cdvPlatform = platform.replace(/^(?:cordova-)?/, 'cordova-');
         try {
             // Load the platform API directly from node_modules
-            const cdvPlatform = platform.replace(/^(?:cordova-)?/, 'cordova-');
             PlatformApi = require(cdvPlatform);
-        } catch (err) {
-            // Module not found or threw error during loading
-            err.message = `Unable to load Platform API from ${dir}:\n${err.message}`;
-            throw err;
+        } catch (loadByNameError) {
+            events.emit('verbose', `Unable to load module ${cdvPlatform} by name:`);
+            events.emit('verbose', CordovaError.fullStack(loadByNameError));
+
+            throw new CordovaError(`Could not load API for ${platform} project ${dir}`);
         }
     }
 

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -301,14 +301,23 @@ function isDirectory (dir) {
 
 // Returns the API of the platform contained in `dir`.
 // Potential errors : module isn't found, can't load or doesn't implement the expected interface.
-function getPlatformApiFunction (dir) {
+function getPlatformApiFunction (dir, platform) {
     let PlatformApi;
     try {
         PlatformApi = exports.requireNoCache(dir);
     } catch (err) {
-        // Module not found or threw error during loading
-        err.message = `Unable to load Platform API from ${dir}:\n${err.message}`;
-        throw err;
+        try {
+            let cdvPlatform = platform;
+            if (!platform.startsWith('cordova-')) {
+                cdvPlatform = `cordova-${platform}`;
+            }
+
+            PlatformApi = exports.requireNoCache(cdvPlatform);
+        } catch (err) {
+            // Module not found or threw error during loading
+            err.message = `Unable to load Platform API from ${dir}:\n${err.message}`;
+            throw err;
+        }
     }
 
     // Module doesn't implement the expected interface

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -309,12 +309,8 @@ function getPlatformApiFunction (dir, platform) {
         PlatformApi = exports.requireNoCache(dir);
     } catch (err) {
         try {
-            let cdvPlatform = platform;
-            if (!platform.startsWith('cordova-')) {
-                cdvPlatform = `cordova-${platform}`;
-            }
-
             // Load the platform API directly from node_modules
+            const cdvPlatform = platform.replace(/^(?:cordova-)?/, 'cordova-');
             PlatformApi = require(cdvPlatform);
         } catch (err) {
             // Module not found or threw error during loading

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -328,6 +328,6 @@ function getPlatformApiFunction (dir, platform) {
         throw new Error(`The package at "${dir}" does not appear to implement the Cordova Platform API.`);
     }
 
-    events.emit('verbose', 'Platform API successfully found in: ' + dir);
+    events.emit('verbose', `Loaded API for ${platform} project ${dir}`);
     return PlatformApi;
 }

--- a/src/cordova/util.js
+++ b/src/cordova/util.js
@@ -315,7 +315,7 @@ function getPlatformApiFunction (dir, platform) {
             }
 
             // Load the platform API directly from node_modules
-            PlatformApi = exports.requireNoCache(cdvPlatform);
+            PlatformApi = require(cdvPlatform);
         } catch (err) {
             // Module not found or threw error during loading
             err.message = `Unable to load Platform API from ${dir}:\n${err.message}`;


### PR DESCRIPTION
### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We are looking at the possibility of having most of the platform tooling code run out of `node_modules` instead of being copied into the `platforms` folder. This allows loading the Platform API from either `platforms` or `node_modules`.


### Description
<!-- Describe your changes in detail -->
Try loading the Platform API from the `platforms` folder, but failing that, require the main file from the platform package.json in `node_modules`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
- Added unit test
- Passes existing tests

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change