### PR TITLE
test(pkgJson): fix test after release of geolocation plugin v4.1.0

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -168,7 +168,7 @@ describe('pkgJson', function () {
                 }).then(function () {
                     // Expect that only the plugin that had --save was added.
                     expect(getPkgJson('cordova.plugins')).toEqual({
-                        [SAVED_PLUGIN]: {}
+                        [SAVED_PLUGIN]: jasmine.anything()
                     });
                 });
         });


### PR DESCRIPTION
When `cordova-plugin-geolocation` introduced a new variable in v4.1.0, a test that expected it to have no variables started failing. 

However, whether there were any variables or not was beside the point of the test in the first place. It should only check that the key for the plugin is present in `cordova.plugins`.

I updated the test accordingly.

Fixes #863