### PR TITLE
test(pkgJson): make expectations work for npm 5 to 7

### DIFF
--- a/integration-tests/pkgJson.spec.js
+++ b/integration-tests/pkgJson.spec.js
@@ -284,14 +284,15 @@ describe('pkgJson', function () {
         });
 
         it('Test#026 : should successfully add a plugin with git/semver combo', async () => {
-            const URL = 'https://github.com/apache/cordova-plugin-device.git#semver:2.0.x';
+            const TAG = '#semver:2.0.x';
+            const URL = `https://github.com/apache/cordova-plugin-device.git${TAG}`;
 
             expect(getPkgJson('cordova.plugins')).toBeUndefined();
             expect(getPkgJson(`devDependencies.${pluginId}`)).toBeUndefined();
 
             await cordova.plugin('add', URL, { save: true });
             expect(getPkgJson('cordova.plugins')[pluginId]).toBeDefined();
-            expect(getPkgJson('devDependencies')[pluginId]).toMatch(URL);
+            expect(getPkgJson('devDependencies')[pluginId]).toContain(TAG);
         });
     });
 
@@ -389,7 +390,7 @@ describe('pkgJson', function () {
             }).then(function () {
                 // Expect platforms to be uninstalled & removed from config files
                 expect(getPkgJson('cordova.platforms')).toEqual([]);
-                expect(getPkgJson('devDependencies')).toEqual({});
+                expect(getPkgJson('devDependencies') || {}).toEqual({});
                 expect(getCfg().getEngines()).toEqual([]);
                 expect(installedPlatforms()).toEqual([]);
             });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In some cases, npm 7 causes the `package.json` to look slightly different than with npm 6. This PR changes our tests so that they work with both flavors.


### Description
<!-- Describe your changes in detail -->
This PR addresses the following differences:

Saved GitHub URL format in `package.json`:
- npm 6: `git+https://github.com/apache/cordova-android.git#4.1.x`
- npm 7: `github:apache/cordova-android#4.1.x`

Empty devDependencies format in `package.json`:
- npm 6: `{}`
- npm 7: `undefined`


### Testing
<!-- Please describe in detail how you tested your changes. -->
- Automated tests are passing with `npm@6`
- Automated tests are passing with `npm@^7.2` and https://github.com/apache/cordova-fetch/pull/91
  _Except for one test that fails due to a bug in npm 7: https://github.com/npm/cli/issues/2339_