### PR TITLE
fix: add undeclared dependency `underscore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "detect-indent": "^6.0.0",
     "detect-newline": "^3.1.0",
     "elementtree": "^0.1.7",
+    "underscore": "^1.9.2",
     "execa": "^4.0.3",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",


### PR DESCRIPTION
### Platforms affected

All

### Motivation and Context

`cordova-lib` depends on `underscore` but doesn't declare it as a dependency
https://github.com/apache/cordova-lib/blob/5cc0a79b5897a62d25097233e9cbe89f41bb1264/src/cordova/serve.js#L24
https://github.com/apache/cordova-lib/blob/b9ad92a6693c2fe977309d17449fa95949c1f7c3/src/cordova/requirements.js#L20

It was declared correctly before but seems to have been removed in https://github.com/apache/cordova-lib/pull/772

Ref https://github.com/apache/cordova-ios/pull/1105

### Description

Added `underscore` as a dependency

### Testing

Ran `cordova prepare` under a strict dependency environment

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
