### PR TITLE
fix: Platforms restored from both dev and normal dependencies.

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -247,6 +247,21 @@ describe('cordova/platform/addHelper', function () {
                     });
                 });
 
+                it('should use pkgJson version devDependencies, if dependencies are nonempty but do not include the platform', function () {
+                    package_json_mock.dependencies.lorem = {}; // Add some item to dependencies so it's defined but nonempty
+                    package_json_mock.cordova = { platforms: ['ios'] };
+                    package_json_mock.devDependencies.ios = {};
+                    cordova_util.requireNoCache.and.returnValue(package_json_mock);
+                    fs.existsSync.and.callFake(function (filePath) {
+                        return path.basename(filePath) === 'package.json';
+                    });
+                    fs.readFileSync.and.returnValue('{}');
+                    return platform_addHelper('add', hooks_mock, projectRoot, ['ios'], { save: true, restoring: true }).then(function () {
+                        expect(platform_addHelper.getVersionFromConfigFile).not.toHaveBeenCalled();
+                        expect(fs.writeFileSync).toHaveBeenCalled();
+                    });
+                });
+
                 it('should only write the package.json file if it was modified', function () {
                     package_json_mock.cordova = { platforms: ['ios'] };
                     cordova_util.requireNoCache.and.returnValue(package_json_mock);

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -99,7 +99,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                         } else if (pkgJson.dependencies[platform]) {
                             spec = pkgJson.dependencies[platform];
                         }
-                    } else if (spec === undefined && pkgJson && pkgJson.devDependencies && cmd === 'add') {
+                    }
+
+                    if (spec === undefined && pkgJson && pkgJson.devDependencies && cmd === 'add') {
                         if (pkgJson.devDependencies['cordova-' + platform]) {
                             spec = pkgJson.devDependencies['cordova-' + platform];
                         } else if (pkgJson.devDependencies[platform]) {


### PR DESCRIPTION
Closes #866

"[Wrong platform version is detected when dependencies and devDependencies are both present](https://github.com/apache/cordova-lib/issues/866)"

Relates to:
"[Save platforms and plugins to devDependencies](https://github.com/apache/cordova-fetch/issues/64)"

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The issue was discovered using a project which has both dev and normal dependencies where platform dependency was specified under `devDependencies`.

Steps to recreate:
1. Have a project with both dev and normal dependencies in `package.json`.
2. `cordova platform add electron@2.0.0`
3. `rm -rf ./node_modules ./plugins ./platforms`
4. `cordova prepare electron`
5. Should be using 2.0.0 from `package.json` but will be using 1.0.0 opinned version. 


### Description
<!-- Describe your changes in detail -->

This is a small fix to address an issue where Cordova CLI restores platforms using its pinned version rather than version present in `package.json`. Such a case exists if `package.json` has normal and dev dependencies. With the logic currently at `master` it checks if `dependencies` key exists within `package.json` and attempts to find platform version there if not found  it never bothers to check `devDependencies`.

With the fix it will check normal dependencies and if not found will check dev dependencies.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Using the same steps as to reproduce and confirming that correct version is being used.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change (courtesy of @lirichard)
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
