### PR TITLE
fix(restore-util): consider long and short names when restoring platforms from package.json

### DIFF
--- a/spec/cordova/restore-util.spec.js
+++ b/spec/cordova/restore-util.spec.js
@@ -212,6 +212,22 @@ describe('cordova/restore-util', () => {
             });
         });
 
+        it('Test#007 : should find platform spec', () => {
+            setPkgJson('cordova.platforms', ['android']);
+            setPkgJson('devDependencies', {
+                'cordova-android': '1.0.0'
+            });
+
+            return restore.installPlatformsFromConfigXML(['android'], {}).then(() => {
+                expect(cordovaPlatform.add).toHaveBeenCalledWith(
+                    jasmine.anything(),
+                    jasmine.anything(),
+                    ['android@1.0.0'],
+                    jasmine.anything()
+                );
+            });
+        });
+
         it('Test#016 : should restore platforms & plugins and create a missing package.json', () => {
             getCfg()
                 .addEngine(testPlatform)

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -108,7 +108,7 @@ function installPlatformsFromConfigXML (platforms, opts) {
 
     const platformInfo = platformIDs.map(plID => ({
         name: plID,
-        spec: specs[plID]
+        spec: specs[`cordova-${plID}`]
     }));
 
     let platformName = '';

--- a/src/cordova/restore-util.js
+++ b/src/cordova/restore-util.js
@@ -108,7 +108,7 @@ function installPlatformsFromConfigXML (platforms, opts) {
 
     const platformInfo = platformIDs.map(plID => ({
         name: plID,
-        spec: specs[`cordova-${plID}`]
+        spec: specs[`cordova-${plID}`] || specs[plID]
     }));
 
     let platformName = '';


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #878 

### Description
<!-- Describe your changes in detail -->

Try platform name prefixed with `cordova-` for platform / spec mapping, before falling back to plain platform name.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Added a unit test to ensure that platforms are restored without config.xml engine entry, and from devDependency.
All existing unit tests passes.

Manually tested in a [repo project](https://github.com/lirichard/cordova-platform-devdependencies-reproduction).

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
