### PR TITLE
feat!: remove platform pinning

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -169,7 +169,7 @@ describe('cordova/platform/addHelper', function () {
 
             it('should fall back to using pinned version if both package.json and config.xml do not specify it', function () {
                 return platform_addHelper('add', hooks_mock, projectRoot, ['ios'], { restoring: true }).then(function () {
-                    expect(events.emit).toHaveBeenCalledWith('verbose', 'Grabbing pinned version.');
+                    expect(events.emit).toHaveBeenCalledWith('verbose', 'Grabbing the latest released version from the npmjs registry.');
                 });
             });
 

--- a/spec/cordova/platform/listDeprecated.spec.js
+++ b/spec/cordova/platform/listDeprecated.spec.js
@@ -57,7 +57,7 @@ describe('cordova/platform/list show deprecated platforms info', function () {
     it('shows available platforms with deprecated info', () => {
         return platform_list(hooks_mock, projectRoot, { save: true })
             .then((result) => {
-                expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/Installed platforms:[\s\S]*Available.*:[\s]*android 1.2.3[\s]*wp7 4.5.6 \(deprecated\)/));
+                expect(events.emit).toHaveBeenCalledWith('results', jasmine.stringMatching(/Available platforms:\n\s\sandroid\n\s\swp7 \(deprecated\)/));
             });
     });
 

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -98,7 +98,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                         spec = module.exports.getVersionFromConfigFile(platform, cfg);
                     }
 
-                    // If spec still doesn't exist, try to use pinned version
+                    // If spec still doesn't exist, grab latest released version from the npmjs registry
                     if (!spec) {
                         events.emit('verbose', 'Grabbing the latest released version from the npmjs registry.');
                         spec = 'latest';

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -99,9 +99,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                     }
 
                     // If spec still doesn't exist, try to use pinned version
-                    if (!spec && platforms.info[platform]) {
-                        events.emit('verbose', 'Grabbing pinned version.');
-                        spec = platforms.info[platform].version;
+                    if (!spec) {
+                        events.emit('verbose', 'Grabbing the latest released version from the npmjs registry.');
+                        spec = 'latest';
                     }
 
                     // Handle local paths

--- a/src/cordova/platform/list.js
+++ b/src/cordova/platform/list.js
@@ -27,27 +27,20 @@ function list (hooksRunner, projectRoot, opts) {
         .then(function () {
             return cordova_util.getInstalledPlatformsWithVersions(projectRoot);
         }).then(function (platformMap) {
-            let platformsText = [];
-            for (const plat in platformMap) {
-                platformsText.push(platformMap[plat] ? plat + ' ' + platformMap[plat] : plat);
-            }
+            // Exrtacted the installed platforms
+            const installed = Object.keys(platformMap)
+                .map(p => platformMap[p] ? p + ' ' + platformMap[p] : p)
+                .sort();
+            const installedResult = addDeprecatedInformationToPlatforms(installed).join('\n  ');
+            events.emit('results', `Installed platforms:\n  ${installedResult}`);
 
-            platformsText = addDeprecatedInformationToPlatforms(platformsText);
-            let results = 'Installed platforms:\n  ' + platformsText.sort().join('\n  ') + '\n';
-            let available = platforms.list.filter(platforms.hostSupports);
-
-            available = available.filter(function (p) {
-                return !platformMap[p]; // Only those not already installed.
-            });
-
-            available = available.map(function (p) {
-                return p.concat(' ', platforms.info[p].version);
-            });
-
-            available = addDeprecatedInformationToPlatforms(available);
-            results += 'Available platforms: \n  ' + available.sort().join('\n  ');
-
-            events.emit('results', results);
+            // Get the avaliable platforms excluding the installed ones
+            const available = platforms.list
+                .filter(platforms.hostSupports)
+                .filter(p => !platformMap[p])
+                .sort();
+            const availableResult = addDeprecatedInformationToPlatforms(available).join('\n  ');
+            events.emit('results', `Available platforms:\n  ${availableResult}`);
         }).then(function () {
             return hooksRunner.fire('after_platform_ls', opts);
         });

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -2,24 +2,20 @@
     "ios": {
         "hostos": ["darwin"],
         "url": "https://github.com/apache/cordova-ios.git",
-        "version": "^6.2.0",
         "deprecated": false
     },
     "android": {
         "url": "https://github.com/apache/cordova-android.git",
-        "version": "^10.1.1",
         "deprecated": false
     },
     "browser": {
         "parser_file": "../cordova/metadata/browser_parser",
         "handler_file": "../plugman/platforms/browser",
         "url": "https://github.com/apache/cordova-browser.git",
-        "version": "^6.0.0",
         "deprecated": false
     },
     "electron": {
         "url": "https://github.com/apache/cordova-electron.git",
-        "version": "^3.0.0",
         "deprecated": false
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

none

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Stop managing the platform pinning.
- Always allow the use of the latest release version without requiring an update of the lib or cli.

### Description
<!-- Describe your changes in detail -->

- Remove platform version pinning data.
- Remove logic for displaying the pinning version.
- Always fetch latest version when not supplied or already installed.
- Updated test specs to support code changes.

Previous concerns which shouldnt not be an issue anymore: Platforms relied on the common object which was passed to platform. Platforms should now be recreating the common object using its own installed common package.

E.g.
- [cordova-android](https://github.com/apache/cordova-android/blob/master/lib/Api.js#L118)
- [cordova-ios](https://github.com/apache/cordova-ios/blob/master/lib/Api.js#L213)
- [cordova-electron](https://github.com/apache/cordova-electron/blob/master/lib/Api.js#L96)

### Testing
<!-- Please describe in detail how you tested your changes. -->

In Progress

- [x] `npm t`
- [x] GH Actions

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
