### PR TITLE
feat!: remove osx & windows platform

### DIFF
--- a/spec/cordova/platforms/platforms.spec.js
+++ b/spec/cordova/platforms/platforms.spec.js
@@ -38,7 +38,7 @@ describe('platforms/platforms', () => {
 
     it('should have all and only the supported platforms', function () {
         expect(Object.keys(platforms)).toEqual(jasmine.arrayWithExactContents([
-            'android', 'browser', 'ios', 'osx', 'windows', 'electron'
+            'android', 'browser', 'ios', 'electron'
         ]));
     });
 

--- a/src/platforms/platformsConfig.json
+++ b/src/platforms/platformsConfig.json
@@ -5,22 +5,10 @@
         "version": "^6.2.0",
         "deprecated": false
     },
-    "osx": {
-        "hostos": ["darwin"],
-        "url": "https://github.com/apache/cordova-osx.git",
-        "version": "^6.0.0",
-        "deprecated": true
-    },
     "android": {
         "url": "https://github.com/apache/cordova-android.git",
         "version": "^10.1.1",
         "deprecated": false
-    },
-    "windows": {
-        "hostos": ["win32"],
-        "url": "https://github.com/apache/cordova-windows.git",
-        "version": "^7.0.0",
-        "deprecated": true
     },
     "browser": {
         "parser_file": "../cordova/metadata/browser_parser",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

osx, windows

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove OSX and Windows platform.

### Description
<!-- Describe your changes in detail -->

Since it was deprecated, this prepares the removal.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
  - was already deprecated.
