### PR TITLE
feat: bump cordova-common@4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.0.1-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "cordova-common": "^4.0.2",
+        "cordova-common": "^4.1.0",
         "cordova-fetch": "^3.0.1",
         "cordova-serve": "^4.0.0",
         "dep-graph": "^1.1.0",
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/cordova-common": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.0.2.tgz",
-      "integrity": "sha512-od7aNShyuBajzPY83mUEO8tERwwWdFklXETHiXP5Ft87CWeo/tSuwNPFztyTy8XYc74yXdogXKPTJeUHuVzB8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.1.0.tgz",
+      "integrity": "sha512-sYfOSfpYGQOmUDlsARUbpT/EvVKT/E+GI3zwTXt+C6DjZ7xs6ZQVHs3umHKSidjf9yVM2LLmvGFpGrGX7aGxug==",
       "dependencies": {
         "@netflix/nerror": "^1.1.3",
         "ansi": "^0.3.1",
@@ -8843,9 +8843,9 @@
       }
     },
     "cordova-common": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.0.2.tgz",
-      "integrity": "sha512-od7aNShyuBajzPY83mUEO8tERwwWdFklXETHiXP5Ft87CWeo/tSuwNPFztyTy8XYc74yXdogXKPTJeUHuVzB8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.1.0.tgz",
+      "integrity": "sha512-sYfOSfpYGQOmUDlsARUbpT/EvVKT/E+GI3zwTXt+C6DjZ7xs6ZQVHs3umHKSidjf9yVM2LLmvGFpGrGX7aGxug==",
       "requires": {
         "@netflix/nerror": "^1.1.3",
         "ansi": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "cordova-common": "^4.0.2",
+    "cordova-common": "^4.1.0",
     "cordova-fetch": "^3.0.1",
     "cordova-serve": "^4.0.0",
     "dep-graph": "^1.1.0",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

Note, all changes are backwards compatible.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When adding XML attributes to the XML tags, we currently need to update around 6 repos (cordova-common, cordova-lib, cordova-cli, platform repos, docs).

cordova-common 4.1.0 (https://github.com/apache/cordova-common/pull/181) fixes this by passing through all XML attributes. 

In order for platforms to begin using cordova-common 4.1.0, the developer's cordova-cli must use cordova-common 4.1.0.

cordova-cli depends on cordova-lib and cordova-common.
cordova-lib depends on cordova-common.

In order to ensure cordova-cli is always using the correct version of cordova-common, it would be safest to update cordova-lib first.

### Description
<!-- Describe your changes in detail -->

This PR updates cordova-lib's cordova-common to 4.1.0.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I've added unit tests for XML passthrough in cordova-common.

I've ran npm test on cordova-common, cordova-lib, cordova-cli. lib and cli were updated with the cordova-common change.
I've ran these changes on my company's app.

An update in my company's attribute is requiring me to add a new attribute to the framework tag. I've tested adding a new attribute to cordova-ios with my company's app using these changes.


I found 1 test failing in cordova-lib master. Naturally, since it failed on master and was not related to my changes, it was also failing on my branch.

pkgJson platform end-to-end with --save Test#012 : platform with local path is added correctly with --save
 - Unhandled promise rejection: TypeError: message.split is not a function
   at <Jasmine>
 - Error: Timeout - Async function did not complete within 150000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
   at <Jasmine>
   at listOnTimeout (node:internal/timers:559:17)
   at processTimers (node:internal/timers:502:7)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
