### PR TITLE
[cordova-cli #578] plugin/remove.js: don't stomp opts.cli_variables in removePluginFromPlatform()

### DIFF
--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -92,7 +92,6 @@ function remove (projectRoot, targets, hooksRunner, opts) {
 
     function removePluginFromPlatform (target, platform) {
         let platformRoot;
-
         return Promise.resolve().then(function () {
             platformRoot = path.join(projectRoot, 'platforms', platform);
             const directory = path.join(pluginPath, target);
@@ -102,8 +101,11 @@ function remove (projectRoot, targets, hooksRunner, opts) {
 
             return plugin_util.mergeVariables(pluginInfo, cfg, opts);
         }).then(function (variables) {
-            opts.cli_variables = variables;
-            return plugman.uninstall.uninstallPlatform(platform, platformRoot, target, pluginPath, opts)
+            // leave opts.cli_variables untouched, so values discarded by mergeVariables()
+            // for this platform are still available for other platforms
+            const platformOpts = { ...opts, cli_variables: variables };
+
+            return plugman.uninstall.uninstallPlatform(platform, platformRoot, target, pluginPath, platformOpts)
                 .then(function (didPrepare) {
                     // If platform does not returned anything we'll need
                     // to trigger a prepare after all plugins installed

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -92,6 +92,7 @@ function remove (projectRoot, targets, hooksRunner, opts) {
 
     function removePluginFromPlatform (target, platform) {
         let platformRoot;
+
         return Promise.resolve().then(function () {
             platformRoot = path.join(projectRoot, 'platforms', platform);
             const directory = path.join(pluginPath, target);


### PR DESCRIPTION


### Platforms affected
CLI - adding and removing plugins with differing required variables per platform (e.g. [cordova-plugin-googleplus](https://github.com/TheAnkurPanchani/cordova-plugin-googleplus) )

### Motivation and Context
resolves apache/cordova-cli#578 :
`cordova plugin rm plugin-package --variable "IOS_ONLY_REQUIRED_VARIABLE=variable-value"` will fail if the project includes e.g. both android and ios platforms.

### Description
In `removePluginFromPlatform()`, at [cordova/plugin/remove.js:105](https://github.com/apache/cordova-lib/blob/7f8b2d011dc05749cf6075fe483b5e1bb08f1a07/src/cordova/plugin/remove.js#L105), `opts.cli_variables` is destructively reassigned to the result of `mergeVariables()`. As mergeVariables() selects only keys specified for a specific platform, this can result in CLI-specified values being lost before the platform that requires them is processed.

In the change, instead call `uninstallPlatform()` with a copy of `opts` that includes the platform-specific `mergeVariables()` result. 

### Testing
- Ran existing tests (`npm run test`)
- verified the change fixes my local use case by `npm link`ing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
  > I'm not familiar enough with how to create a reproduction case in the test library for this project.
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
  > No doc update should be required
