### PR TITLE
feat!(run): call platform api to list targets

### DIFF
--- a/src/cordova/run.js
+++ b/src/cordova/run.js
@@ -54,13 +54,13 @@ module.exports = function run (options) {
     }
 
     return Promise.resolve().then(function () {
+        const projectRoot = cordova_util.cdProjectRoot();
         options = cordova_util.preProcessOptions(options);
 
         // This is needed as .build modifies opts
         const optsClone = Object.assign({}, options.options);
         optsClone.nobuild = true;
 
-        const projectRoot = cordova_util.cdProjectRoot();
         const hooksRunner = new HooksRunner(projectRoot);
         return hooksRunner.fire('before_run', options)
             .then(function () {

--- a/src/cordova/run.js
+++ b/src/cordova/run.js
@@ -27,10 +27,10 @@ const cordovaPrepare = require('./prepare');
 const targets = require('./targets');
 
 // Returns a promise.
-module.exports = function run (options) {
+module.exports = function run (options = {}) {
     const { options: cliArgs } = options;
 
-    if (cliArgs.list) {
+    if (cliArgs?.list) {
         const { platforms } = options;
 
         if (platforms.length <= 0) {

--- a/src/cordova/run.js
+++ b/src/cordova/run.js
@@ -41,15 +41,14 @@ module.exports = function run (options = {}) {
         return Promise.resolve(platforms.map(function (platform) {
             const platformApi = platform_lib.getPlatformApi(platform);
 
-            // @todo enable warning once all platforms known to implement platformApi.listTargets
-            // if (!platformApi.listTargets) {
-            //     events.emit('warn', 'Please upgrade to the latest platfrom release to ensure the emulator list functionality continues to function in the future.');
-            // }
-
-            // If the Platform API object contains the `listTarget` method, call it, else fallback to original.
-            return platformApi.listTargets
-                ? platformApi.listTargets(options)
-                : targets(options, true);
+            if (platformApi?.listTargets) {
+                // Use Platform's API to fetch target list when available
+                return platformApi.listTargets(options);
+            } else {
+                events.emit('warn', 'Please update to the latest platform release to ensure uninterrupted fetching of target lists.');
+                // fallback to original method.
+                return targets(options);
+            }
         }));
     }
 

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -45,12 +45,9 @@ function displayVirtualDevices (projectRoot, platform, options) {
     return execa(cmd, options.argv, { stdio: 'inherit' }).then(data => data.stdout, handleError.bind(caller));
 }
 
-module.exports = function targets (options, isOptionsProcessed = false) {
+module.exports = function targets (options) {
     const projectRoot = cordova_util.cdProjectRoot();
-
-    if (!isOptionsProcessed) {
-        options = cordova_util.preProcessOptions(options);
-    }
+    options = cordova_util.preProcessOptions(options);
 
     let result = Promise.resolve();
     options.platforms.forEach(function (platform) {

--- a/src/cordova/targets.js
+++ b/src/cordova/targets.js
@@ -45,9 +45,12 @@ function displayVirtualDevices (projectRoot, platform, options) {
     return execa(cmd, options.argv, { stdio: 'inherit' }).then(data => data.stdout, handleError.bind(caller));
 }
 
-module.exports = function targets (options) {
+module.exports = function targets (options, isOptionsProcessed = false) {
     const projectRoot = cordova_util.cdProjectRoot();
-    options = cordova_util.preProcessOptions(options);
+
+    if (!isOptionsProcessed) {
+        options = cordova_util.preProcessOptions(options);
+    }
 
     let result = Promise.resolve();
     options.platforms.forEach(function (platform) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Prepare for the removal of calling binaries in the platform packages. 
Use the platform API to handle listing out of targets.

### Description
<!-- Describe your changes in detail -->

This PR will call `platformApi.listTargets` when the platfrom api contains the method.
To also support platforms that has not been updated, it will fallback and call the old binrary.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
