### PR TITLE
fix(ios): Prevent mix build phases

### DIFF
--- a/spec/cordova/platform/addHelper.spec.js
+++ b/spec/cordova/platform/addHelper.spec.js
@@ -296,6 +296,9 @@ describe('cordova/platform/addHelper', function () {
 
         // Call installPluginsForNewPlatform with some preset test arguments
         function installPluginsForNewPlatformWithTestArgs () {
+            platform_addHelper.__set__({
+                readPackageJsonIfExists: () => ({ ...package_json_mock, cordova: { platforms: [], plugins: [] } })
+            });
             return platform_addHelper.installPluginsForNewPlatform('atari', projectRoot, {});
         }
 

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -290,9 +290,14 @@ function installPluginsForNewPlatform (platform, projectRoot, opts) {
 
     // Get a list of all currently installed plugins, ignoring those that have already been installed for this platform
     // during prepare (installed from config.xml).
+    // Apply plugins sort from package.json
     const platformJson = PlatformJson.load(plugins_dir, platform);
+    const pkgJson = readPackageJsonIfExists(projectRoot);
+    const pkgJsonCordovaPlugins = Object.keys(pkgJson.cordova.plugins);
     const plugins = cordova_util.findPlugins(plugins_dir).filter(function (plugin) {
         return !platformJson.isPluginInstalled(plugin);
+    }).sort(function (a, b) {
+        return pkgJsonCordovaPlugins.indexOf(a) - pkgJsonCordovaPlugins.indexOf(b)
     });
     if (plugins.length === 0) {
         return Promise.resolve();

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -290,17 +290,21 @@ function installPluginsForNewPlatform (platform, projectRoot, opts) {
 
     // Get a list of all currently installed plugins, ignoring those that have already been installed for this platform
     // during prepare (installed from config.xml).
-    // Apply plugins sort from package.json
     const platformJson = PlatformJson.load(plugins_dir, platform);
-    const pkgJson = readPackageJsonIfExists(projectRoot);
-    const pkgJsonCordovaPlugins = Object.keys(pkgJson.cordova.plugins);
-    const plugins = cordova_util.findPlugins(plugins_dir).filter(function (plugin) {
+    let plugins = cordova_util.findPlugins(plugins_dir).filter(function (plugin) {
         return !platformJson.isPluginInstalled(plugin);
-    }).sort(function (a, b) {
-        return pkgJsonCordovaPlugins.indexOf(a) - pkgJsonCordovaPlugins.indexOf(b);
     });
     if (plugins.length === 0) {
         return Promise.resolve();
+    }
+
+    // If package.json includes the plugins, we use that for proper sort order
+    const pkgJson = readPackageJsonIfExists(projectRoot);
+    if (pkgJson?.cordova?.plugins) {
+        const pkgPluginIDs = Object.keys(pkgJson.cordova.plugins);
+        plugins = plugins.sort(function (a, b) {
+            return pkgPluginIDs.indexOf(a) - pkgPluginIDs.indexOf(b);
+        });
     }
 
     const output = path.join(projectRoot, 'platforms', platform);

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -297,7 +297,7 @@ function installPluginsForNewPlatform (platform, projectRoot, opts) {
     const plugins = cordova_util.findPlugins(plugins_dir).filter(function (plugin) {
         return !platformJson.isPluginInstalled(plugin);
     }).sort(function (a, b) {
-        return pkgJsonCordovaPlugins.indexOf(a) - pkgJsonCordovaPlugins.indexOf(b)
+        return pkgJsonCordovaPlugins.indexOf(a) - pkgJsonCordovaPlugins.indexOf(b);
     });
     if (plugins.length === 0) {
         return Promise.resolve();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Any


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->


Different installation orders for currently installed plugins

iOS
https://github.com/MaximBelov/reproduce-cordova-apply-plugins-sort/blob/20ab95bca8aef992aa5b1982b38e5e6d750580a8/plugins/ios.json

Android
https://github.com/MaximBelov/reproduce-cordova-apply-plugins-sort/blob/20ab95bca8aef992aa5b1982b38e5e6d750580a8/plugins/android.json

Plugins installation order should be the same for any platform and have the source of faithful from package.json

Why is this important?
ios: Prevent mix build phases

The plugin `cordova-plugin-firebasex` runs a hook that adds a new Build Phase "Crashlytics", which should be the last one
https://github.com/dpa99c/cordova-plugin-firebasex/pull/897

<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
How to reproduce

https://github.com/MaximBelov/reproduce-cordova-apply-plugins-sort

### Testing
<!-- Please describe in detail how you tested your changes. -->
How to reproduce 
Repository: https://github.com/MaximBelov/reproduce-cordova-apply-plugins-sort

**Version without patch**

```sh
git checkout master
npm run build
git diff  --no-index plugins/ios.json plugins/android.json

```
Result:  
![image](https://github.com/user-attachments/assets/cc5befae-24bd-459d-a42c-083c6f6991d1)
__________

**Version with patch**

```sh

git checkout patch
npm run build
git diff  --no-index plugins/ios.json plugins/android.json

```
Result:
![image](https://github.com/user-attachments/assets/a0b1fcc6-34c6-4b56-b807-996631f94285)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
