### PR TITLE
fix: platform & plugin prerelease package support

### DIFF
--- a/spec/plugman/install.spec.js
+++ b/spec/plugman/install.spec.js
@@ -160,51 +160,51 @@ describe('plugman/install', () => {
                 execaSpy.and.returnValue(Promise.resolve({ stdout: '2.5.0' }));
                 return install('android', project, pluginDir('com.cordova.engine'))
                     .then(() => {
-                        expect(satisfies).toHaveBeenCalledWith('2.5.0', '>=1.0.0', true);
+                        expect(satisfies).toHaveBeenCalledWith('2.5.0', '>=1.0.0', { loose: true, includePrerelease: true });
                     });
             }, TIMEOUT);
             it('Test 008 : should check version and munge it a little if it has "rc" in it so it plays nice with semver (introduce a dash in it)', () => {
                 execaSpy.and.returnValue(Promise.resolve({ stdout: '3.0.0rc1' }));
                 return install('android', project, pluginDir('com.cordova.engine'))
                     .then(() => {
-                        expect(satisfies).toHaveBeenCalledWith('3.0.0-rc1', '>=1.0.0', true);
+                        expect(satisfies).toHaveBeenCalledWith('3.0.0-rc1', '>=1.0.0', { loose: true, includePrerelease: true });
                     });
             }, TIMEOUT);
             it('Test 009 : should check specific platform version over cordova version if specified', () => {
                 execaSpy.and.returnValue(Promise.resolve({ stdout: '3.1.0' }));
                 return install('android', project, pluginDir('com.cordova.engine-android'))
                     .then(() => {
-                        expect(satisfies).toHaveBeenCalledWith('3.1.0', '>=3.1.0', true);
+                        expect(satisfies).toHaveBeenCalledWith('3.1.0', '>=3.1.0', { loose: true, includePrerelease: true });
                     });
             }, TIMEOUT);
             it('Test 010 : should check platform sdk version if specified', () => {
-                const cordovaVersion = require('../../package.json').version.replace(/-dev|-nightly.*$/, '');
+                const cordovaVersion = require('../../package.json').version;
                 execaSpy.and.returnValue(Promise.resolve({ stdout: '18' }));
                 return install('android', project, pluginDir('com.cordova.engine-android'))
                     .then(() => {
                         expect(satisfies.calls.count()).toBe(3);
                         // <engine name="cordova" VERSION=">=3.0.0"/>
-                        expect(satisfies.calls.argsFor(0)).toEqual([cordovaVersion, '>=3.0.0', true]);
+                        expect(satisfies.calls.argsFor(0)).toEqual([cordovaVersion, '>=3.0.0', { loose: true, includePrerelease: true }]);
                         // <engine name="cordova-android" VERSION=">=3.1.0"/>
-                        expect(satisfies.calls.argsFor(1)).toEqual(['18.0.0', '>=3.1.0', true]);
+                        expect(satisfies.calls.argsFor(1)).toEqual(['18.0.0', '>=3.1.0', { loose: true, includePrerelease: true }]);
                         // <engine name="android-sdk" VERSION=">=18"/>
-                        expect(satisfies.calls.argsFor(2)).toEqual(['18.0.0', '>=18', true]);
+                        expect(satisfies.calls.argsFor(2)).toEqual(['18.0.0', '>=18', { loose: true, includePrerelease: true }]);
                     });
             }, TIMEOUT);
             it('Test 011 : should check engine versions', () => {
                 return install('android', project, pluginDir('com.cordova.engine'))
                     .then(() => {
-                        const plugmanVersion = require('../../package.json').version.replace(/-dev|-nightly.*$/, '');
-                        const cordovaVersion = require('../../package.json').version.replace(/-dev|-nightly.*$/, '');
+                        const plugmanVersion = require('../../package.json').version;
+                        const cordovaVersion = require('../../package.json').version;
                         expect(satisfies.calls.count()).toBe(4);
                         // <engine name="cordova" version=">=2.3.0"/>
-                        expect(satisfies.calls.argsFor(0)).toEqual([cordovaVersion, '>=2.3.0', true]);
+                        expect(satisfies.calls.argsFor(0)).toEqual([cordovaVersion, '>=2.3.0', { loose: true, includePrerelease: true }]);
                         // <engine name="cordova-plugman" version=">=0.10.0" />
-                        expect(satisfies.calls.argsFor(1)).toEqual([plugmanVersion, '>=0.10.0', true]);
+                        expect(satisfies.calls.argsFor(1)).toEqual([plugmanVersion, '>=0.10.0', { loose: true, includePrerelease: true }]);
                         // <engine name="mega-fun-plugin" version=">=1.0.0" scriptSrc="megaFunVersion" platform="*" />
-                        expect(satisfies.calls.argsFor(2)).toEqual([null, '>=1.0.0', true]);
+                        expect(satisfies.calls.argsFor(2)).toEqual([null, '>=1.0.0', { loose: true, includePrerelease: true }]);
                         // <engine name="mega-boring-plugin" version=">=3.0.0" scriptSrc="megaBoringVersion" platform="ios|android" />
-                        expect(satisfies.calls.argsFor(3)).toEqual([null, '>=3.0.0', true]);
+                        expect(satisfies.calls.argsFor(3)).toEqual([null, '>=3.0.0', { loose: true, includePrerelease: true }]);
                     });
             }, TIMEOUT);
             it('Test 012 : should not check custom engine version that is not supported for platform', () => {
@@ -212,7 +212,7 @@ describe('plugman/install', () => {
                     .then(() => {
                         // Version >=3.0.0 of `mega-boring-plugin` is specified with platform="ios|android"
                         expect(satisfies.calls.count()).toBe(3);
-                        expect(satisfies).not.toHaveBeenCalledWith(jasmine.anything(), '>=3.0.0', true);
+                        expect(satisfies).not.toHaveBeenCalledWith(jasmine.anything(), '>=3.0.0', { loose: true, includePrerelease: true });
                     });
             }, TIMEOUT);
         });

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -132,11 +132,9 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                         }
                     }
 
-                    if (/-nightly|-dev$/.exec(platDetails.version)) {
-                        msg = 'Warning: using prerelease platform ' + platform +
-                              '@' + platDetails.version +
-                              '.\nUse \'cordova platform add ' +
-                              platform + '@latest\' to add the latest published version instead.';
+                    if (semver.prerelease(platDetails.version)) {
+                        msg = `Warning: using prerelease platform ${platform}@${platDetails.version}.`;
+                        msg += `\nUse 'cordova platform add ${platform}@latest to add the latest published version instead.`;
                         events.emit('warn', msg);
                     }
 

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -99,22 +99,12 @@ function possiblyFetch (id, plugins_dir, options) {
 
 function checkEngines (engines) {
     for (let i = 0; i < engines.length; i++) {
-        const engine = engines[i];
+        const { currentVersion, minVersion, name } = engines[i];
 
-        // This is a hack to allow plugins with <engine> tag to be installed with
-        // engine with '-dev' or '-nightly' suffixes. It is required due to new semver range logic,
-        // introduced in semver@3.x. For more details see https://github.com/npm/node-semver#prerelease-tags.
-        //
-        // This may lead to false-positive checks, when engine version with dropped
-        // suffix is equal to one of range bounds, for example: 5.1.0-dev >= 5.1.0.
-        // However this shouldn't be a problem, because this only should happen in dev workflow.
-        engine.currentVersion = engine.currentVersion && engine.currentVersion.replace(/-dev|-nightly.*$/, '');
-        if (semver.satisfies(engine.currentVersion, engine.minVersion, /* loose= */true) || engine.currentVersion === null) {
+        if (semver.satisfies(currentVersion, minVersion, { loose: true, includePrerelease: true }) || currentVersion === null) {
             continue; // engine ok!
         } else {
-            const msg = 'Plugin doesn\'t support this project\'s ' + engine.name + ' version. ' +
-                      engine.name + ': ' + engine.currentVersion +
-                      ', failed version requirement: ' + engine.minVersion;
+            const msg = `Plugin doesn't support this project's ${name} version. ${name}: ${currentVersion}, failed version requirement: ${minVersion}`;
             events.emit('warn', msg);
             return Promise.reject(Object.assign(new Error(), { skip: true }));
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Support installing plugins to all prerelease identifiers as long as it still satisfies with semver.
- Improve the warning of installing a prerelease platform for all prerelease identifiers.

### Description
<!-- Describe your changes in detail -->

- Use `semver` to detect if the platform is a prerelease instead of using regular expression against specific tags.
- Update `semver.satisfies` to include prerelease version. This allows plugins to install on prerelease platforms as long as the platform's version still satisfies with the minimum version.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `cordova platform add`
- `cordova plugin add`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
