### PR TITLE
Keep final new line in package.json

### DIFF
--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -145,7 +145,7 @@ describe('cordova/plugin/add', function () {
 
                 spyOn(fs, 'readFileSync').and.returnValue('file');
                 return add(projectRoot, hook_mock, { plugins: ['cordova-plugin-device'], cli_variables: cli_plugin_variables, save: 'true' }).then(function () {
-                    expect(fs.writeFileSync).toHaveBeenCalledWith(jasmine.any(String), JSON.stringify({ cordova: { plugins: { 'cordova-plugin-device': cli_plugin_variables } }, dependencies: {}, devDependencies: {} }, null, 2), 'utf8');
+                    expect(fs.writeFileSync).toHaveBeenCalledWith(jasmine.any(String), JSON.stringify({ cordova: { plugins: { 'cordova-plugin-device': cli_plugin_variables } }, dependencies: {}, devDependencies: {} }, null, 2) + '\n', 'utf8');
                 });
             });
             it('should overwrite plugin information in config.xml after a successful installation', function () {

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -27,6 +27,9 @@ const cordova_util = require('../util');
 const promiseutil = require('../../util/promise-util');
 const platforms = require('../../platforms');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -226,7 +229,8 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                 if (modifiedPkgJson === true) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                    const newline = detectNewline(file);
+                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                 }
             });
         }).then(function () {

--- a/src/cordova/platform/addHelper.js
+++ b/src/cordova/platform/addHelper.js
@@ -29,7 +29,6 @@ const platforms = require('../../platforms');
 const detectIndent = require('detect-indent');
 const detectNewline = require('detect-newline');
 const stringifyPackage = require('stringify-package');
-const writeFileAtomicSync = require('write-file-atomic').sync;
 const getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -230,7 +229,7 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
                     const newline = detectNewline(file);
-                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
+                    fs.writeFileSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), 'utf8');
                 }
             });
         }).then(function () {

--- a/src/cordova/platform/remove.js
+++ b/src/cordova/platform/remove.js
@@ -27,7 +27,6 @@ const platforms = require('../../platforms/platforms');
 const detectIndent = require('detect-indent');
 const detectNewline = require('detect-newline');
 const stringifyPackage = require('stringify-package');
-const writeFileAtomicSync = require('write-file-atomic').sync;
 
 module.exports = remove;
 
@@ -75,7 +74,7 @@ function remove (hooksRunner, projectRoot, targets, opts) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
                     const newline = detectNewline(file);
-                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
+                    fs.writeFileSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), 'utf8');
                 }
             }
         }).then(function () {

--- a/src/cordova/platform/remove.js
+++ b/src/cordova/platform/remove.js
@@ -25,6 +25,9 @@ const cordova_util = require('../util');
 const promiseutil = require('../../util/promise-util');
 const platforms = require('../../platforms/platforms');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 
 module.exports = remove;
 
@@ -71,7 +74,8 @@ function remove (hooksRunner, projectRoot, targets, opts) {
                 if (modifiedPkgJson === true) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                    const newline = detectNewline(file);
+                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                 }
             }
         }).then(function () {

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -24,7 +24,6 @@ const url = require('url');
 const detectIndent = require('detect-indent');
 const detectNewline = require('detect-newline');
 const stringifyPackage = require('stringify-package');
-const writeFileAtomicSync = require('write-file-atomic').sync;
 const cordova_util = require('../util');
 const plugin_util = require('./util');
 const cordova_pkgJson = require('../../../package.json');
@@ -158,7 +157,7 @@ function add (projectRoot, hooksRunner, opts) {
                             const file = fs.readFileSync(pkgJsonPath, 'utf8');
                             const indent = detectIndent(file).indent || '  ';
                             const newline = detectNewline(file);
-                            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
+                            fs.writeFileSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), 'utf8');
                         }
 
                         const src = module.exports.parseSource(target, opts);

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -22,6 +22,9 @@ const path = require('node:path');
 const semver = require('semver');
 const url = require('url');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const cordova_util = require('../util');
 const plugin_util = require('./util');
 const cordova_pkgJson = require('../../../package.json');
@@ -154,7 +157,8 @@ function add (projectRoot, hooksRunner, opts) {
                             // Write to package.json
                             const file = fs.readFileSync(pkgJsonPath, 'utf8');
                             const indent = detectIndent(file).indent || '  ';
-                            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                            const newline = detectNewline(file);
+                            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                         }
 
                         const src = module.exports.parseSource(target, opts);

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -28,6 +28,9 @@ const plugman = require('../../plugman/plugman');
 const metadata = require('../../plugman/util/metadata');
 const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const { Q_chainmap } = require('../../util/promise-util');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -145,7 +148,8 @@ function remove (projectRoot, targets, hooksRunner, opts) {
             // Write out new package.json with plugin removed correctly.
             const file = fs.readFileSync(pkgJsonPath, 'utf8');
             const indent = detectIndent(file).indent || '  ';
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+            const newline = detectNewline(file);
+            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
         }
     }
 }

--- a/src/cordova/plugin/remove.js
+++ b/src/cordova/plugin/remove.js
@@ -30,7 +30,6 @@ const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const detectIndent = require('detect-indent');
 const detectNewline = require('detect-newline');
 const stringifyPackage = require('stringify-package');
-const writeFileAtomicSync = require('write-file-atomic').sync;
 const { Q_chainmap } = require('../../util/promise-util');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -149,7 +148,7 @@ function remove (projectRoot, targets, hooksRunner, opts) {
             const file = fs.readFileSync(pkgJsonPath, 'utf8');
             const indent = detectIndent(file).indent || '  ';
             const newline = detectNewline(file);
-            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
+            fs.writeFileSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), 'utf8');
         }
     }
 }


### PR DESCRIPTION
### Platforms affected

### Motivation and Context

Cordova removes the final new line in a package.json when running cordova commands. This causes us a problem since we have a formatting rule for final new lines.

### Description

Apply the same writing rules every time the package.json is written to.

### Testing

We have had the following patch in production for the last 3 months.

<details>
<summary>Patch</summary>

```diff
diff --git a/node_modules/cordova-lib/src/cordova/platform/addHelper.js b/node_modules/cordova-lib/src/cordova/platform/addHelper.js
index 0856245..653f834 100644
--- a/node_modules/cordova-lib/src/cordova/platform/addHelper.js
+++ b/node_modules/cordova-lib/src/cordova/platform/addHelper.js
@@ -27,6 +27,9 @@ const cordova_util = require('../util');
 const promiseutil = require('../../util/promise-util');
 const platforms = require('../../platforms');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const getPlatformDetailsFromDir = require('./getPlatformDetailsFromDir');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -228,7 +231,8 @@ function addHelper (cmd, hooksRunner, projectRoot, targets, opts) {
                 if (modifiedPkgJson === true) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                    const newline = detectNewline(file);
+                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                 }
             });
         }).then(function () {
diff --git a/node_modules/cordova-lib/src/cordova/platform/remove.js b/node_modules/cordova-lib/src/cordova/platform/remove.js
index 5a91906..e8ade46 100644
--- a/node_modules/cordova-lib/src/cordova/platform/remove.js
+++ b/node_modules/cordova-lib/src/cordova/platform/remove.js
@@ -25,6 +25,9 @@ const cordova_util = require('../util');
 const promiseutil = require('../../util/promise-util');
 const platforms = require('../../platforms/platforms');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 
 module.exports = remove;
 
@@ -71,7 +74,8 @@ function remove (hooksRunner, projectRoot, targets, opts) {
                 if (modifiedPkgJson === true) {
                     const file = fs.readFileSync(pkgJsonPath, 'utf8');
                     const indent = detectIndent(file).indent || '  ';
-                    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                    const newline = detectNewline(file);
+                    writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                 }
             }
         }).then(function () {
diff --git a/node_modules/cordova-lib/src/cordova/plugin/add.js b/node_modules/cordova-lib/src/cordova/plugin/add.js
index 087bc29..95b1c10 100644
--- a/node_modules/cordova-lib/src/cordova/plugin/add.js
+++ b/node_modules/cordova-lib/src/cordova/plugin/add.js
@@ -32,6 +32,9 @@ const fs = require('fs-extra');
 const semver = require('semver');
 const url = require('url');
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const preparePlatforms = require('../prepare/platforms');
 
 module.exports = add;
@@ -154,7 +157,8 @@ function add (projectRoot, hooksRunner, opts) {
                             // Write to package.json
                             const file = fs.readFileSync(pkgJsonPath, 'utf8');
                             const indent = detectIndent(file).indent || '  ';
-                            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+                            const newline = detectNewline(file);
+                            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
                         }
 
                         const src = module.exports.parseSource(target, opts);
diff --git a/node_modules/cordova-lib/src/cordova/plugin/remove.js b/node_modules/cordova-lib/src/cordova/plugin/remove.js
index f6cdf89..a9cbfe6 100644
--- a/node_modules/cordova-lib/src/cordova/plugin/remove.js
+++ b/node_modules/cordova-lib/src/cordova/plugin/remove.js
@@ -28,6 +28,9 @@ const path = require('path');
 const fs = require('fs-extra');
 const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+const writeFileAtomicSync = require('write-file-atomic').sync;
 const { Q_chainmap } = require('../../util/promise-util');
 const preparePlatforms = require('../prepare/platforms');
 
@@ -142,7 +145,8 @@ function remove (projectRoot, targets, hooksRunner, opts) {
             // Write out new package.json with plugin removed correctly.
             const file = fs.readFileSync(pkgJsonPath, 'utf8');
             const indent = detectIndent(file).indent || '  ';
-            fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent), 'utf8');
+            const newline = detectNewline(file);
+            writeFileAtomicSync(pkgJsonPath, stringifyPackage(pkgJson, indent, newline), { encoding: 'utf8' });
         }
     }
 }
```
</details>

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
