### PR TITLE
Persist relative paths on disk

### DIFF
--- a/src/plugman/fetch.js
+++ b/src/plugman/fetch.js
@@ -85,7 +85,7 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                             pinfo: pluginInfoProvider.get(directory),
                             fetchJsonSource: {
                                 type: 'local',
-                                path: directory
+                                path: path.relative(projectRoot, directory)
                             }
                         };
                     }).catch(function (error) {


### PR DESCRIPTION
### Platforms affected



### Motivation and Context

We have a monorepo that contains a cordova application and a Cordova plugin. When adding the plugin to the applicatoin the `fetch.json` contains an absolute directory which does not work on other computers.


### Description

Persist a relative directory on disk instead of an absolute directory.



### Testing

We have had the following patch in production for the last 2 months.

<details>
<summary>Patch</summary>

```diff
diff --git a/node_modules/cordova-lib/src/plugman/fetch.js b/node_modules/cordova-lib/src/plugman/fetch.js
index ec73836..2e4d1e2 100644
--- a/node_modules/cordova-lib/src/plugman/fetch.js
+++ b/node_modules/cordova-lib/src/plugman/fetch.js
@@ -84,7 +84,7 @@ function fetchPlugin (plugin_src, plugins_dir, options) {
                             pinfo: pluginInfoProvider.get(directory),
                             fetchJsonSource: {
                                 type: 'local',
-                                path: directory
+                                path: path.relative(projectRoot, directory)
                             }
                         };
                     }).catch(function (error) {
```
</details>


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
