### PR TITLE
feat: replace dep-graph dependency w/ custom class

### DIFF
--- a/licence_checker.yml
+++ b/licence_checker.yml
@@ -17,4 +17,3 @@
 
 ignored-packages:
   - spdx-exceptions@2.5.0
-  - underscore@1.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cordova-common": "^5.0.1",
         "cordova-fetch": "^4.0.0",
         "cordova-serve": "^4.0.1",
-        "dep-graph": "^1.1.0",
         "detect-indent": "^6.1.0",
         "detect-newline": "^3.1.0",
         "elementtree": "^0.1.7",
@@ -2666,18 +2665,6 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
-    },
-    "node_modules/dep-graph": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dep-graph/-/dep-graph-1.1.0.tgz",
-      "integrity": "sha512-/6yUWlSH0Uevjj6HWvO86rDeFzuYfzbaKDqifTEemwfwEPyBrODTb3ox/jFzqmc2+UmgJ3IDMS88BKEBh1Nm2Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "underscore": "1.2.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -9453,14 +9440,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz",
-      "integrity": "sha512-HRhh6FYh5I5/zTt7L9MnHRA/nlSFPiwymMCXEremmzT7tHR+8CNP0FXHPaUpafAPwvAlNrvZiH91kQwoo/CqUA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "cordova-common": "^5.0.1",
     "cordova-fetch": "^4.0.0",
     "cordova-serve": "^4.0.1",
-    "dep-graph": "^1.1.0",
     "detect-indent": "^6.1.0",
     "detect-newline": "^3.1.0",
     "elementtree": "^0.1.7",

--- a/src/plugman/install.js
+++ b/src/plugman/install.js
@@ -22,7 +22,6 @@ const os = require('node:os');
 const path = require('node:path');
 const execa = require('execa');
 const ActionStack = require('cordova-common').ActionStack;
-const DepGraph = require('dep-graph');
 const semver = require('semver');
 const PlatformJson = require('cordova-common').PlatformJson;
 const CordovaError = require('cordova-common').CordovaError;
@@ -36,6 +35,7 @@ const PluginInfo = require('cordova-common').PluginInfo;
 const PluginInfoProvider = require('cordova-common').PluginInfoProvider;
 const variableMerge = require('./variable-merge');
 const plugmanFetch = require('./fetch');
+const DepGraph = require('./util/dep-graph');
 
 const isWindows = (os.platform().substr(0, 3) === 'win');
 

--- a/src/plugman/util/dep-graph.js
+++ b/src/plugman/util/dep-graph.js
@@ -1,0 +1,62 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+module.exports = class DepGraph {
+    constructor () {
+        this.graph = new Map();
+    }
+
+    add (id, dep) {
+        if (!this.graph.has(id)) {
+            this.graph.set(id, new Set());
+        }
+        this.graph.get(id).add(dep);
+
+        if (!this.graph.has(dep)) {
+            this.graph.set(dep, new Set());
+        }
+    }
+
+    getChain (id) {
+        const visited = new Set();
+        const stack = new Set();
+        const result = [];
+
+        const traverse = (node, parent = null) => {
+            if (stack.has(node)) {
+                throw new Error(`Cyclic dependency from ${parent} to ${node}`);
+            }
+
+            if (!this.graph.has(node)) return;
+
+            stack.add(node);
+            for (const dep of this.graph.get(node)) {
+                if (!visited.has(dep)) {
+                    traverse(dep, node);
+                    result.push(dep);
+                    visited.add(dep);
+                }
+            }
+            stack.delete(node);
+        };
+
+        traverse(id);
+        return result;
+    }
+};

--- a/src/plugman/util/dependencies.js
+++ b/src/plugman/util/dependencies.js
@@ -19,8 +19,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const DepGraph = require('dep-graph');
 const events = require('cordova-common').events;
+const DepGraph = require('./dep-graph');
 let pkg;
 
 module.exports = pkg = {
@@ -66,7 +66,11 @@ module.exports = pkg = {
     // Returns a list of top-level plugins which are (transitively) dependent on the given plugin.
     dependents: function (plugin_id, plugins_dir, platformJson, pluginInfoProvider) {
         let depsInfo;
-        if (typeof plugins_dir === 'object') { depsInfo = plugins_dir; } else { depsInfo = pkg.generateDependencyInfo(platformJson, plugins_dir, pluginInfoProvider); }
+        if (typeof plugins_dir === 'object') {
+            depsInfo = plugins_dir;
+        } else {
+            depsInfo = pkg.generateDependencyInfo(platformJson, plugins_dir, pluginInfoProvider);
+        }
 
         const graph = depsInfo.graph;
         const tlps = depsInfo.top_level_plugins;
@@ -81,7 +85,11 @@ module.exports = pkg = {
     // In other words, if the given plugin were deleted, these dangling dependencies should be deleted too.
     danglers: function (plugin_id, plugins_dir, platformJson, pluginInfoProvider) {
         let depsInfo;
-        if (typeof plugins_dir === 'object') { depsInfo = plugins_dir; } else { depsInfo = pkg.generateDependencyInfo(platformJson, plugins_dir, pluginInfoProvider); }
+        if (typeof plugins_dir === 'object') {
+            depsInfo = plugins_dir;
+        } else {
+            depsInfo = pkg.generateDependencyInfo(platformJson, plugins_dir, pluginInfoProvider);
+        }
 
         const { graph, top_level_plugins } = depsInfo;
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove `dep-graph` dependency

### Description
<!-- Describe your changes in detail -->

- Remove [`dep-graph`](https://www.npmjs.com/dep-graph) dependency.
  - The last release was **2012**.
  - Its repository was archived in 2018.
  - It had a dependency on `underscore@1.2.1`.

In replacement of `dep-graph`, this PR would create our own custom class to behave identical.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
  - All tests are passing and the coverage of the new class is 100%

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
