### PR TITLE
fix: handle prerelease platform versions in engine requirement checks

### DIFF
--- a/spec/cordova/plugin/add.spec.js
+++ b/spec/cordova/plugin/add.spec.js
@@ -449,6 +449,12 @@ describe('cordova/plugin/add', function () {
             it('should return an array with failed platform requirements ', function () {
                 expect(add.getFailedRequirements({ 'cordova-android': '>=6.0.0' }, {}, { android: '5.5.0' }, '7.0.0')).toEqual([{ dependency: 'cordova-android', installed: '5.5.0', required: '>=6.0.0' }]);
             });
+            it('should treat prerelease platform versions as the matching release version', function () {
+                expect(add.getFailedRequirements({ 'cordova-ios': '>=7.0.0' }, {}, { ios: '8.0.2-dev.0' }, '12.0.0').length).toBe(0);
+            });
+            it('should return failed platform requirements for prerelease versions below minimum', function () {
+                expect(add.getFailedRequirements({ 'cordova-ios': '>=7.0.0' }, {}, { ios: '6.9.9-dev.0' }, '12.0.0')).toEqual([{ dependency: 'cordova-ios', installed: '6.9.9-dev.0', required: '>=7.0.0' }]);
+            });
         });
         describe('listUnmetRequirements helper method', function () {
             it('should emit warnings for failed requirements', function () {

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -518,8 +518,16 @@ function getFailedRequirements (reqs, pluginMap, platformMap, cordovaVersion) {
             } else if (trimmedReq.indexOf('cordova-') === 0) {
                 // Might be a platform constraint
                 const platform = trimmedReq.substring(8);
-                if (platformMap[platform] && !semver.satisfies(platformMap[platform], reqs[req])) {
-                    badInstalledVersion = platformMap[platform];
+                if (platformMap[platform]) {
+                    let platformVersion = platformMap[platform];
+                    if (semver.prerelease(platformVersion)) {
+                        // Keep prerelease behavior consistent with the "cordova" version check above.
+                        platformVersion = semver.inc(platformVersion, 'patch');
+                    }
+
+                    if (!semver.satisfies(platformVersion, reqs[req])) {
+                        badInstalledVersion = platformMap[platform];
+                    }
                 }
             }
 

--- a/src/cordova/plugin/add.js
+++ b/src/cordova/plugin/add.js
@@ -518,16 +518,8 @@ function getFailedRequirements (reqs, pluginMap, platformMap, cordovaVersion) {
             } else if (trimmedReq.indexOf('cordova-') === 0) {
                 // Might be a platform constraint
                 const platform = trimmedReq.substring(8);
-                if (platformMap[platform]) {
-                    let platformVersion = platformMap[platform];
-                    if (semver.prerelease(platformVersion)) {
-                        // Keep prerelease behavior consistent with the "cordova" version check above.
-                        platformVersion = semver.inc(platformVersion, 'patch');
-                    }
-
-                    if (!semver.satisfies(platformVersion, reqs[req])) {
-                        badInstalledVersion = platformMap[platform];
-                    }
+                if (platformMap[platform] && !semver.satisfies(platformMap[platform], reqs[req], { loose: true, includePrerelease: true })) {
+                    badInstalledVersion = platformMap[platform];
                 }
             }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- This PR fixes plugin engine requirement checks for prerelease platform versions such as 8.0.2-dev.0.
- Added tests
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->

When adding a plugin, Cordova validates engine constraints in plugin metadata. For platform constraints, prerelease versions are compared directly with semver.satisfies(). Since semver excludes prerelease versions from normal ranges by default, versions like 8.0.2-dev.0 may not satisfy >=7.0.0, even though they should be treated as the corresponding release line.

This can trigger warnings such as:

```bash
Unmet project requirements for latest version of cordova-plugin-google-maps-sdk:
    cordova-ios (8.0.2-dev.0 in project, >=7.0.0 required)
Current project does not satisfy the engine requirements specified by any version of cordova-plugin-google-maps-sdk. Fetching latest version of plugin anyway (may be incompatible)
```

### Root cause
The cordova requirement path already normalizes prerelease cordova versions before comparison, but platform versions were not normalized the same way.

### Fix
Normalize prerelease platform versions before semver engine checks, mirroring existing behavior for the cordova version check.

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
